### PR TITLE
Use __builtin_addressof on GCC7

### DIFF
--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -1,6 +1,6 @@
 // cmcstl2 - A concept-enabled C++ standard library
 //
-//  Copyright Casey Carter 2015
+//  Copyright Casey Carter 2015-2016
 //  Copyright Eric Niebler 2015
 //
 //  Use, modification and distribution is subject to the
@@ -17,6 +17,21 @@
 #include <utility>
 
 #include <meta/meta.hpp>
+
+#ifdef __clang__
+#define STL2_HAS_BUILTIN(X) __has_builtin(__builtin_ ## X)
+
+#else // __clang__
+
+#define STL2_HAS_BUILTIN(X) STL2_HAS_BUILTIN_ ## X
+
+#if defined(__GNUC__)
+#define STL2_HAS_BUILTIN_unreachable 1
+#if __GNUC__ >= 7
+#define STL2_HAS_BUILTIN_addressof 1
+#endif // __GNUC__ >= 7
+#endif // __GNUC__
+#endif // __clang__
 
 #define STL2_OPEN_NAMESPACE \
 	namespace std { namespace experimental { namespace ranges { inline namespace v1
@@ -177,4 +192,4 @@ STL2_OPEN_NAMESPACE {
 #define STL2_CONSTEXPR_EXT inline
 #endif
 
-#endif
+#endif // STL2_DETAIL_FWD_HPP

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -699,7 +699,7 @@ STL2_OPEN_NAMESPACE {
 			cursor::Readable<C>() && !cursor::Arrow<C>() &&
 			is_lvalue_reference<const_reference_t>::value
 		{
-			return __addressof::impl(**this);
+			return __stl2::addressof(**this);
 		}
 		// operator->: Otherwise, return a proxy
 		constexpr auto operator->() const

--- a/include/stl2/detail/memory/addressof.hpp
+++ b/include/stl2/detail/memory/addressof.hpp
@@ -1,0 +1,52 @@
+// cmcstl2 - A concept-enabled C++ standard library
+//
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/caseycarter/cmcstl2
+//
+#ifndef STL2_DETAIL_MEMORY_ADDRESSOF_HPP
+#define STL2_DETAIL_MEMORY_ADDRESSOF_HPP
+
+#include <stl2/detail/fwd.hpp>
+#include <memory>
+
+STL2_OPEN_NAMESPACE {
+#if STL2_HAS_BUILTIN(addressof)
+	template <class T>
+	constexpr T* addressof(T& t) noexcept {
+		return __builtin_addressof(t);
+	}
+
+#else // STL2_HAS_BUILTIN(addressof)
+
+	template <class>
+	constexpr bool __user_defined_addressof = false;
+	template <class T>
+	requires
+		requires(T& t) { t.operator&(); } ||
+		requires(T& t) { operator&(t); }
+	constexpr bool __user_defined_addressof<T> = true;
+
+	template <class T>
+	requires __user_defined_addressof<T>
+	T* __addressof(T& t) noexcept {
+		return std::addressof(t);
+	}
+
+	constexpr auto __addressof(auto& t) noexcept {
+		return &t;
+	}
+
+	template <class T>
+	constexpr T* addressof(T& t) noexcept {
+		return __stl2::__addressof(t);
+	}
+#endif // STL2_HAS_BUILTIN(addressof)
+} STL2_CLOSE_NAMESPACE
+
+#endif // STL2_DETAIL_MEMORY_ADDRESSOF_HPP

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -528,10 +528,10 @@ STL2_OPEN_NAMESPACE {
 				has_contiguous_iterator<R>
 			constexpr auto operator()(R& r) const
 			noexcept(noexcept(__stl2::begin(r) == __stl2::end(r)
-				? nullptr : __addressof::impl(*__stl2::begin(r))))
+				? nullptr : __stl2::addressof(*__stl2::begin(r))))
 			{
 				auto i = __stl2::begin(r);
-				return i == __stl2::end(r) ? nullptr : __addressof::impl(*i);
+				return i == __stl2::end(r) ? nullptr : __stl2::addressof(*i);
 			}
 
 			template <class R>

--- a/include/stl2/memory.hpp
+++ b/include/stl2/memory.hpp
@@ -1,6 +1,6 @@
 // cmcstl2 - A concept-enabled C++ standard library
 //
-//  Copyright Casey Carter 2015
+//  Copyright Casey Carter 2015-2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <stl2/detail/fwd.hpp>
+#include <stl2/detail/memory/addressof.hpp>
 
 STL2_OPEN_NAMESPACE {
 	// pointer traits
@@ -105,31 +106,6 @@ STL2_OPEN_NAMESPACE {
 	//using std::uses_allocator_v;
 	template <class T, class A>
 	constexpr bool uses_allocator_v = uses_allocator<T, A>::value;
-
-	// addressof
-	namespace __addressof {
-		template <class>
-		constexpr bool __user_defined_addressof = false;
-		template <class T>
-		requires
-			requires(T& t) { t.operator&(); } ||
-			requires(T& t) { operator&(t); }
-		constexpr bool __user_defined_addressof<T> = true;
-
-		template <class T>
-		requires __user_defined_addressof<T>
-		T* impl(T& t) noexcept {
-			return std::addressof(t);
-		}
-
-		constexpr auto impl(auto& t) noexcept {
-			return &t;
-		}
-	}
-	template <class T>
-	constexpr T* addressof(T& t) noexcept {
-		return __addressof::impl(t);
-	}
 } STL2_CLOSE_NAMESPACE
 
 #endif


### PR DESCRIPTION
`__stl2::addressof` is always `constexpr`, but does a better job of doing so with GCC7.