### PR TITLE
Implement PR for ericniebler/stl2#239:

### DIFF
--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 	// Not to spec: The function type must be decayed before being constrained.
 	template <class F, class...Is>
 	requires
-		models::IndirectCallable<remove_reference_t<F>, Is...>
+		models::IndirectCallable<decay_t<F>, Is...>
 	struct indirect_result_of<F(Is...)>
 	: result_of<F(reference_t<Is>...)> {};
 

--- a/test/concepts/iterator.cpp
+++ b/test/concepts/iterator.cpp
@@ -74,6 +74,8 @@ namespace ns {
 	using ranges::forward_iterator_tag;
 	using ranges::bidirectional_iterator_tag;
 	using ranges::random_access_iterator_tag;
+
+	using ranges::indirect_result_of_t;
 }
 
 #elif VALIDATE_STL2
@@ -260,6 +262,12 @@ namespace iterator_sentinel_test {
 
 namespace indirectly_callable_test {
 	CONCEPT_ASSERT(models::IndirectCallable<std::plus<int>, int*, int*>);
+}
+
+namespace indirect_result_of_test {
+	template <class R, class... Args>
+	using fn_t = R(Args...);
+	CONCEPT_ASSERT(models::Same<ns::indirect_result_of_t<fn_t<void, int>&(const int*)>, void>);
 }
 
 int main() {


### PR DESCRIPTION
In `indirect_result_of`, decay the type of the function before passing to `IndirectCallable`.