### PR TITLE
experimental support for move_iterator post-fix increment

### DIFF
--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 			)
 
 			// Experimental support for move_iterator post-increment
-			using __post_inc_t = decltype(current_++);
+			using __postinc_t = std::decay_t<decltype(current_++)>;
 			Readable{R}
 			struct __proxy {
 				using value_type = __stl2::value_type_t<R>;
@@ -107,16 +107,11 @@ STL2_OPEN_NAMESPACE {
 				)
 			};
 
-			STL2_CONSTEXPR_EXT cursor post_increment()
-			noexcept(noexcept(cursor{cursor{__stl2::exchange(current_, __stl2::next(current_))}}))
-			requires Same<__post_inc_t, I>() {
-				return cursor{__stl2::exchange(current_, __stl2::next(current_))};
-			}
-
+			template <class = void> // BUGBUG why is this necessary?
 			STL2_CONSTEXPR_EXT auto post_increment()
-			noexcept(noexcept(current_++) && std::is_nothrow_move_constructible<__post_inc_t>::value)
-			requires !Same<__post_inc_t, I>() && Readable<__post_inc_t>() {
-				return __proxy<__post_inc_t>{current_++};
+			noexcept(noexcept(__proxy<__postinc_t>{current_++}))
+			requires !ForwardIterator<I>() && Readable<__postinc_t>() {
+				return __proxy<__postinc_t>{current_++};
 			}
 
 			STL2_CONSTEXPR_EXT void prev()

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -18,7 +18,6 @@
 #include <stl2/detail/concepts/compare.hpp>
 #include <stl2/detail/concepts/object.hpp>
 #include <stl2/detail/iterator/basic_iterator.hpp>
-#include <stl2/detail/iterator/operations.hpp>
 #include <stl2/detail/iterator/concepts.hpp>
 
 STL2_OPEN_NAMESPACE {

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -95,12 +95,13 @@ STL2_OPEN_NAMESPACE {
 			using __post_inc_t = decltype(current_++);
 			Readable{R}
 			struct __proxy {
+				using value_type = __stl2::value_type_t<R>;
 				R __tmp;
-				decltype(auto) operator*()
+				STL2_CONSTEXPR_EXT decltype(auto) operator*()
 				STL2_NOEXCEPT_RETURN(
 					__stl2::iter_move(__tmp)
 				)
-				friend decltype(auto) iter_move(const __proxy& that)
+				friend STL2_CONSTEXPR_EXT decltype(auto) iter_move(const __proxy& that)
 				STL2_NOEXCEPT_RETURN(
 					__stl2::iter_move(that.__tmp)
 				)

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -91,6 +91,7 @@ STL2_OPEN_NAMESPACE {
 				static_cast<void>(++current_)
 			)
 
+			// Not to spec
 			// Experimental support for move_iterator post-increment
 			using __postinc_t = std::decay_t<decltype(current_++)>;
 			Readable{R}
@@ -107,7 +108,8 @@ STL2_OPEN_NAMESPACE {
 				)
 			};
 
-			template <class = void> // BUGBUG why is this necessary?
+			// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69096
+			template <class = void>
 			STL2_CONSTEXPR_EXT auto post_increment()
 			noexcept(noexcept(__proxy<__postinc_t>{current_++}))
 			requires !ForwardIterator<I>() && Readable<__postinc_t>() {

--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -10,10 +10,16 @@
 //
 // Project home: https://github.com/caseycarter/cmcstl2
 //
+#include <numeric>
 #include <stl2/iterator.hpp>
 #include <stl2/functional.hpp>
 #include <stl2/detail/algorithm/copy.hpp>
+#include <stl2/detail/algorithm/equal.hpp>
+#include <stl2/view/iota.hpp>
+#include <stl2/view/take_exactly.hpp>
+#include <stl2/view/repeat_n.hpp>
 #include <vector>
+#include <memory>
 #include "../simple_test.hpp"
 
 namespace ranges = __stl2;
@@ -21,14 +27,27 @@ namespace ranges = __stl2;
 struct A {
 	static std::size_t copy_count;
 	static std::size_t move_count;
+	int i{0};
 
 	static void clear() { copy_count = move_count = 0; }
 
 	A() = default;
-	A(const A&) { ++copy_count; }
-	A(A&&) noexcept { ++move_count; }
-	A& operator=(const A&) & { ++copy_count; return *this; }
-	A& operator=(A&&) & noexcept { ++move_count; return *this; }
+	A(int i) : i(i) {}
+	A(const A& that) : i(that.i) { ++copy_count; }
+	A(A&& that) noexcept : i(that.i) { ++move_count; that.i = -1; }
+	A& operator=(const A& that) & { ++copy_count; i = that.i; return *this; }
+	A& operator=(A&& that) & noexcept {
+		++move_count;
+		i = that.i;
+		that.i = -1;
+		return *this;
+	}
+	friend bool operator==(A a, A b) {
+		return a.i == b.i;
+	}
+	friend bool operator!=(A a, A b) {
+		return !(a == b);
+	}
 };
 
 std::size_t A::copy_count;
@@ -115,35 +134,48 @@ public:
 
 	proxy_iterator() = default;
 	explicit proxy_iterator(T* p) :
-		ptr_{p} {}
+		ptr_{std::make_shared<T*>(p)} {}
+
+	struct readable_proxy {
+		using value_type = T;
+		mutable T cache_;
+		T& operator*() const noexcept {
+			return cache_;
+		}
+		friend T&& iter_move(const readable_proxy& p) noexcept {
+			return std::move(p.cache_);
+		}
+	};
 
 	ranges::reference_wrapper<T> operator*() const {
-		return ranges::reference_wrapper<T>{*ptr_};
+		return ranges::reference_wrapper<T>{**ptr_};
 	}
 
 	bool operator==(const proxy_iterator& that) const {
-		return ptr_ == that.ptr_;
+		return *ptr_ == *that.ptr_;
 	}
 	bool operator!=(const proxy_iterator& that) const {
 		return !(*this == that);
 	}
 
 	proxy_iterator& operator++() & {
-		++ptr_;
+		// Input iterator is destructive!
+		(*ptr_)->i = -1;
+		++*ptr_;
 		return *this;
 	}
-	proxy_iterator operator++(int) & {
-		auto tmp = *this;
+	readable_proxy operator++(int) & {
+		readable_proxy tmp{__stl2::iter_move(*ptr_)};
 		++*this;
 		return tmp;
 	}
 
 	friend T&& iter_move(const proxy_iterator& p) {
-		return ranges::move(*p.ptr_);
+		return ranges::iter_move(*p.ptr_);
 	}
 
 private:
-	T* ptr_;
+	std::shared_ptr<T*> ptr_;
 };
 
 void test_proxy_iterator() {
@@ -175,6 +207,7 @@ void test_proxy_iterator() {
 			last = ranges::make_move_iterator(proxy_iterator<A>{ranges::data(vec) + ranges::size(vec)});
 		auto out = ranges::back_inserter(vec2);
 
+		std::iota(vec.begin(), vec.end(), 0);
 		vec2.clear();
 		A::clear();
 		std::copy(first, last, out);
@@ -182,6 +215,21 @@ void test_proxy_iterator() {
 		CHECK(ranges::size(vec2) == N);
 		CHECK(A::copy_count == std::size_t{0});
 		CHECK(A::move_count == N);
+		CHECK(ranges::equal(vec2, ranges::ext::take_exactly_view<ranges::ext::iota_view<int>>{0, N}, std::equal_to<>{}));
+		CHECK(ranges::equal(vec, ranges::ext::repeat_n_view<int>{-1, N}, std::equal_to<>{}));
+
+		first = ranges::make_move_iterator(proxy_iterator<A>{ranges::data(vec)});
+		std::iota(vec.begin(), vec.end(), 0);
+		vec2.clear();
+		A::clear();
+		while (first != last) // Test post-increment
+			*out++ = *first++;
+
+		CHECK(ranges::size(vec2) == N);
+		CHECK(A::copy_count == std::size_t{0});
+		CHECK(A::move_count == 2*N);
+		CHECK(ranges::equal(vec2, ranges::ext::take_exactly_view<ranges::ext::iota_view<int>>{0, N}, std::equal_to<>{}));
+		CHECK(ranges::equal(vec, ranges::ext::repeat_n_view<int>{-1, N}, std::equal_to<>{}));
 	}
 
 	{
@@ -201,6 +249,7 @@ void test_proxy_iterator() {
 				proxy_iterator<A>{ranges::data(vec)}, ranges::size(vec)));
 		auto out = ranges::back_inserter(vec2);
 
+		std::iota(vec.begin(), vec.end(), 0);
 		vec2.clear();
 		A::clear();
 		ranges::copy(first, ranges::move_sentinel<ranges::default_sentinel>{}, out);


### PR DESCRIPTION
Just experimenting to see how badly postfix increment is broken for generic iterator adaptors. (Motivated by my upcoming paper to kill Readability of op++ return type.) What do you think of this? Busted in some subtle way, or not?