### PR TITLE
bring sanity to input and output iterators' postfix increment operators

### DIFF
--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -140,8 +140,10 @@ STL2_OPEN_NAMESPACE {
 
 #if STL2_CONSTEXPR_EXTENSIONS
 #define STL2_CONSTEXPR_EXT constexpr
+#define STL2_CONSTEXPR_EXT_FWD constexpr
 #else
 #define STL2_CONSTEXPR_EXT inline
+#define STL2_CONSTEXPR_EXT_FWD
 #endif
 
 #ifndef STL2_ASSERT

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -585,10 +585,14 @@ STL2_OPEN_NAMESPACE {
 
 	///////////////////////////////////////////////////////////////////////////
 	// OutputIterator [iterators.output]
-	//
+	// Not to spec:
+	// adds requirement on *i++ from P0541.
 	template <class I, class T>
 	concept bool OutputIterator() {
-		return Iterator<I>() && Writable<I, T>();
+		return Iterator<I>() && Writable<I, T>() &&
+			requires(I i, T&& t) {
+				*i++ = std::forward<T>(t);
+			};
 	}
 
 	namespace models {

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -15,6 +15,7 @@
 #include <stl2/type_traits.hpp>
 #include <stl2/detail/ebo_box.hpp>
 #include <stl2/detail/fwd.hpp>
+#include <stl2/detail/compressed_pair.hpp>
 #include <stl2/detail/concepts/core.hpp>
 #include <stl2/detail/iterator/basic_iterator.hpp>
 #include <stl2/detail/iterator/concepts.hpp>
@@ -22,246 +23,221 @@
 #include <stl2/detail/iterator/operations.hpp>
 
 STL2_OPEN_NAMESPACE {
-	namespace __counted_iterator {
-		Iterator{I} class cursor;
+	Iterator{I}
+	class counted_iterator {
+		Iterator{O} friend class counted_iterator;
+		Iterator{O} friend STL2_CONSTEXPR_EXT_FWD
+		void advance(counted_iterator<O>& i, difference_type_t<O> n);
 
-		struct access {
-			template <_SpecializationOf<cursor> CC>
-			static constexpr decltype(auto) base(CC&& cc) noexcept {
-				return __stl2::forward<CC>(cc).get();
-			}
-			template <_SpecializationOf<cursor> CC>
-			static constexpr decltype(auto) count(CC&& cc) noexcept {
-				return (__stl2::forward<CC>(cc).count_);
-			}
-		};
+		ext::compressed_pair<I, difference_type_t<I>> data_{};
 
-		Iterator{I}
-		struct adaptor_box : protected detail::ebo_box<I, adaptor_box<I>> {
-			using base_t = detail::ebo_box<I, adaptor_box<I>>;
-			adaptor_box() = default;
-#if STL2_WORKAROUND_GCC_79143
-			template <class First, class... Rest>
-			requires
-				!models::Same<adaptor_box, std::decay_t<First>> &&
-				models::Constructible<I, First, Rest...>
-			constexpr adaptor_box(First&& f, Rest&&...r)
-			noexcept(std::is_nothrow_constructible<I, First, Rest...>::value)
-			: base_t(std::forward<First>(f), std::forward<Rest>(r)...) {}
-#else  // STL2_WORKAROUND_GCC_79143
-			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
-		};
-		InputIterator{I}
-		struct adaptor_box<I> : protected detail::ebo_box<I, adaptor_box<I>> {
-			using base_t = detail::ebo_box<I, adaptor_box<I>>;
-			using value_type = value_type_t<I>;
-			using single_pass = meta::bool_<!models::ForwardIterator<I>>;
-			using contiguous = meta::bool_<models::ContiguousIterator<I>>;
+		I& current() noexcept { return data_.first(); };
+		const I& current() const noexcept { return data_.first(); };
+		difference_type_t<I>& cnt() noexcept { return data_.second(); }
+		const difference_type_t<I>& cnt() const noexcept {
+			return data_.second();
+		}
+	public:
+		using iterator_type = I;
+		using difference_type = difference_type_t<I>;
 
-			adaptor_box() = default;
-#if STL2_WORKAROUND_GCC_79143
-			template <class First, class... Rest>
-			requires
-				!models::Same<adaptor_box, std::decay_t<First>> &&
-				models::Constructible<I, First, Rest...>
-			constexpr adaptor_box(First&& f, Rest&&...r)
-			noexcept(std::is_nothrow_constructible<I, First, Rest...>::value)
-			: base_t(std::forward<First>(f), std::forward<Rest>(r)...) {}
-#else  // STL2_WORKAROUND_GCC_79143
-			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
-		};
+		counted_iterator() = default;
+		counted_iterator(I x, difference_type_t<I> n)
+		: data_{__stl2::move(x), n} {
+			STL2_EXPECT(n >= 0);
+		}
+		template <ConvertibleTo<I> U>
+		counted_iterator(const counted_iterator<U>& i)
+		: data_{i.current(), i.count()} {}
+		template <ConvertibleTo<I> U>
+		counted_iterator& operator=(const counted_iterator<U>& i) {
+			current() = i.current();
+			cnt() = i.cnt();
+			return *this;
+		}
+		I base() const {
+			return current();
+		}
+		difference_type_t<I> count() const {
+			return cnt();
+		}
+		decltype(auto) operator*() noexcept(noexcept(*std::declval<I&>())) {
+			return *current();
+		}
+		decltype(auto) operator*() const
+			noexcept(noexcept(*std::declval<const I&>())) {
+			return *current();
+		}
+		counted_iterator& operator++() {
+			STL2_EXPECT(cnt() > 0);
+			++current();
+			--cnt();
+			return *this;
+		}
+		// Not to spec:
+		// https://github.com/ericniebler/stl2/issues/232
+		decltype(auto) operator++(int) {
+			STL2_EXPECT(cnt() > 0);
+			--cnt();
+			return current()++;
+		}
+		counted_iterator operator++(int) requires ForwardIterator<I>() {
+			STL2_EXPECT(cnt() > 0);
+			auto tmp(*this);
+			++*this;
+			return tmp;
+		}
+		counted_iterator& operator--() requires BidirectionalIterator<I>() {
+			--current();
+			++cnt();
+			return *this;
+		}
+		counted_iterator operator--(int) requires BidirectionalIterator<I>() {
+			auto tmp(*this);
+			--*this;
+			return tmp;
+		}
+		counted_iterator operator+(difference_type n) const
+			requires RandomAccessIterator<I>() {
+			STL2_EXPECT(n <= cnt());
+			return counted_iterator(current() + n, cnt() - n);
+		}
+		counted_iterator& operator+=(difference_type n)
+			requires RandomAccessIterator<I>() {
+			STL2_EXPECT(n <= cnt());
+			current() += n;
+			cnt() -= n;
+			return *this;
+		}
+		counted_iterator operator- (difference_type n) const
+			requires RandomAccessIterator<I>() {
+			STL2_EXPECT(-n <= cnt());
+			return counted_iterator(current() - n, cnt() + n);
+		}
+		counted_iterator& operator-=(difference_type n)
+			requires RandomAccessIterator<I>() {
+			STL2_EXPECT(-n <= cnt());
+			current() -= n;
+			cnt() += n;
+			return *this;
+		}
+		decltype(auto) operator[](difference_type n) const
+			requires RandomAccessIterator<I>() {
+			STL2_EXPECT(n <= cnt());
+			return current()[n];
+		}
 
-		Iterator{I}
-		class cursor : public adaptor_box<I> {
-			friend access;
-			using box_t = adaptor_box<I>;
-			using box_t::get;
-			difference_type_t<I> count_ = 0;
+		// Not to spec
+		// https://github.com/ericniebler/stl2/issues/245
+		friend constexpr rvalue_reference_t<I>
+		iter_move(const counted_iterator& i)
+			noexcept(noexcept(__stl2::iter_move(i.current())))
+			requires InputIterator<I>() {
+			return __stl2::iter_move(i.current());
+		}
+		template <IndirectlySwappable<I> I2>
+		friend void iter_swap(
+			const counted_iterator& x, const counted_iterator<I2>& y)
+			noexcept(noexcept(__stl2::iter_swap(x.current(), y.current()))) {
+			__stl2::iter_swap(x.current(), y.current());
+		}
+	};
 
-		public:
-			using difference_type = difference_type_t<I>;
+	template <Readable I>
+	struct value_type<counted_iterator<I>> {
+		using type = value_type_t<I>;
+	};
+	template <InputIterator I>
+	struct iterator_category<counted_iterator<I>> {
+		using type = iterator_category_t<I>;
+	};
 
-			class mixin : protected basic_mixin<cursor> {
-				using base_t = basic_mixin<cursor>;
-				using base_t::get;
-			public:
-				using iterator_type = I;
-				using difference_type = cursor::difference_type;
-
-				mixin() = default;
-				STL2_CONSTEXPR_EXT mixin(I&& i, difference_type n)
-				noexcept(std::is_nothrow_move_constructible<I>::value)
-				: base_t(cursor{std::move(i), n})
-				{}
-				STL2_CONSTEXPR_EXT mixin(const I& i, difference_type n)
-				noexcept(std::is_nothrow_copy_constructible<I>::value)
-				: base_t(cursor{i, n})
-				{}
-#if STL2_WORKAROUND_GCC_79143
-				constexpr explicit mixin(const cursor& c)
-				noexcept(std::is_nothrow_copy_constructible<cursor>::value)
-				: base_t{c}
-				{}
-				constexpr explicit mixin(cursor&& c)
-				noexcept(std::is_nothrow_move_constructible<cursor>::value)
-				: base_t{std::move(c)}
-				{}
-#else  // STL2_WORKAROUND_GCC_79143
-				using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
-
-				STL2_CONSTEXPR_EXT I base() const
-				noexcept(is_nothrow_copy_constructible<I>::value)
-				{
-					return get().get();
-				}
-				STL2_CONSTEXPR_EXT difference_type count() const noexcept {
-					return get().count_;
-				}
-			};
-
-			cursor() = default;
-			STL2_CONSTEXPR_EXT cursor(I&& i, difference_type n)
-			noexcept(is_nothrow_move_constructible<I>::value)
-			: box_t(__stl2::move(i)), count_{n}
-			{
-				STL2_EXPECT(0 <= n);
-			}
-			STL2_CONSTEXPR_EXT cursor(const I& i, difference_type n)
-			noexcept(is_nothrow_copy_constructible<I>::value)
-			: box_t(i), count_{n}
-			{
-				STL2_EXPECT(0 <= n);
-			}
-			template <ConvertibleTo<I> O>
-			STL2_CONSTEXPR_EXT cursor(cursor<O>&& that)
-			noexcept(is_nothrow_constructible<I, O&&>::value)
-			: box_t(access::base(__stl2::move(that))), count_{access::count(that)}
-			{}
-			template <ConvertibleTo<I> O>
-			STL2_CONSTEXPR_EXT cursor(const cursor<O>& that)
-			noexcept(is_nothrow_constructible<I, const O&>::value)
-			: box_t(access::base(that)), count_{access::count(that)}
-			{}
-
-#if STL2_WORKAROUND_GCC_69096
-			template <class II = I>
-			requires
-				InputIterator<II>() && Same<I, II>()
-			STL2_CONSTEXPR_EXT decltype(auto) read() const
-			noexcept(noexcept(*declval<const II&>()))
-			{
-				return *get();
-			}
-#else  // STL2_WORKAROUND_GCC_69096
-			STL2_CONSTEXPR_EXT decltype(auto) read() const
-			noexcept(noexcept(*declval<const I&>()))
-			requires InputIterator<I>()
-			{
-				return *get();
-			}
-#endif // STL2_WORKAROUND_GCC_69096
-
-			template <class T>
-			requires
-				!InputIterator<I>() &&
-				Writable<I, T&&>()
-			STL2_CONSTEXPR_EXT void write(T&& t)
-			noexcept(noexcept(*declval<I&>() = __stl2::forward<T>(t)))
-			{
-				*get() = __stl2::forward<T>(t);
-			}
-
-			STL2_CONSTEXPR_EXT bool equal(default_sentinel) const noexcept {
-				return count_ == 0;
-			}
-			STL2_CONSTEXPR_EXT bool equal(
-				const cursor<Common<I> >& that) const noexcept
-			{
-				return count_ == access::count(that);
-			}
-
-			STL2_CONSTEXPR_EXT void next()
-			noexcept(noexcept(++declval<I&>()))
-			{
-				STL2_EXPECT(0 < count_);
-				++get();
-				--count_;
-			}
-
-			STL2_CONSTEXPR_EXT void prev()
-			noexcept(noexcept(--declval<I&>()))
-			requires BidirectionalIterator<I>()
-			{
-				--get();
-				++count_;
-			}
-
-			STL2_CONSTEXPR_EXT void advance(difference_type n)
-			noexcept(noexcept(declval<I&>() += n))
-			requires RandomAccessIterator<I>()
-			{
-				STL2_EXPECT(n <= count_);
-				get() += n;
-				count_ -= n;
-			}
-
-			STL2_CONSTEXPR_EXT difference_type distance_to(
-				default_sentinel) const noexcept
-			{
-				return count_;
-			}
-			STL2_CONSTEXPR_EXT difference_type distance_to(
-				const cursor<Common<I> >& that) const noexcept
-			{
-				return count_ - access::count(that);
-			}
-
-			// FIXME: test
-			// Extension
-			STL2_CONSTEXPR_EXT decltype(auto) indirect_move() const
-			noexcept(noexcept(__stl2::iter_move(declval<const I&>())))
-			requires InputIterator<I>()
-			{
-				return __stl2::iter_move(get());
-			}
-
-			// FIXME: test
-			// Extension
-			STL2_CONSTEXPR_EXT void indirect_swap(
-				const cursor<IndirectlySwappable<I> >& that) const
-			STL2_NOEXCEPT_RETURN(
-				__stl2::iter_swap(get(), access::base(that))
-			)
-		};
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator==(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return x.count() == y.count();
+	}
+	bool operator==(
+		const counted_iterator<auto>& x, default_sentinel) {
+		return x.count() == 0;
+	}
+	bool operator==(
+		default_sentinel, const counted_iterator<auto>& x) {
+		return x.count() == 0;
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator!=(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return !(x == y);
+	}
+	bool operator!=(
+		const counted_iterator<auto>& x, default_sentinel y) {
+		return !(x == y);
+	}
+	bool operator!=(
+		default_sentinel x, const counted_iterator<auto>& y) {
+		return !(x == y);
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator<(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return y.count() < x.count();
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator<=(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return !(y < x);
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator>(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return y < x;
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	bool operator>=(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return !(x < y);
+	}
+	template <class I1, class I2>
+		requires Common<I1, I2>()
+	difference_type_t<I2> operator-(
+		const counted_iterator<I1>& x, const counted_iterator<I2>& y) {
+		return y.count() - x.count();
+	}
+	template <class I>
+	difference_type_t<I> operator-(
+		const counted_iterator<I>& x, default_sentinel) {
+		return -x.count();
+	}
+	template <class I>
+	difference_type_t<I> operator-(
+		default_sentinel, const counted_iterator<I>& y) {
+		return y.count();
+	}
+	template <RandomAccessIterator I>
+	counted_iterator<I>
+	operator+(difference_type_t<I> n, const counted_iterator<I>& x) {
+		STL2_EXPECT(n <= x.count());
+		return x + n;
 	}
 
-	// Not to spec:
-	// * hooks iter_move and iter_swap
-	//   See https://github.com/ericniebler/stl2/245
-	Iterator{I}
-	using counted_iterator = basic_iterator<__counted_iterator::cursor<I>>;
-
-	template <class I>
-	requires
-		models::Iterator<__f<I>>
-	STL2_CONSTEXPR_EXT auto make_counted_iterator(I&& i, difference_type_t<__f<I>> n)
+	template <Iterator I>
+	STL2_CONSTEXPR_EXT auto make_counted_iterator(I i, difference_type_t<I> n)
 	STL2_NOEXCEPT_RETURN(
-		counted_iterator<__f<I>>{__stl2::forward<I>(i), n}
+		counted_iterator<I>{__stl2::move(i), n}
 	)
 
 	Iterator{I}
-	STL2_CONSTEXPR_EXT void advance(counted_iterator<I>& i, difference_type_t<I> n)
-	noexcept(is_nothrow_copy_constructible<I>::value &&
-					 is_nothrow_move_assignable<I>::value &&
-					 noexcept(__stl2::next(declval<const I&>(), n)))
-	{
+	STL2_CONSTEXPR_EXT void advance(counted_iterator<I>& i, difference_type_t<I> n)	{
 		STL2_EXPECT(n <= i.count());
-		__counted_iterator::access::base(__stl2::get_cursor(i)) =
-			__stl2::next(__counted_iterator::access::base(__stl2::get_cursor(i)), n);
-		__counted_iterator::access::count(__stl2::get_cursor(i)) -= n;
+		__stl2::advance(i.current(), n);
+		i.cnt() -= n;
 	}
 
 	RandomAccessIterator{I}

--- a/include/stl2/detail/iterator/insert_iterators.hpp
+++ b/include/stl2/detail/iterator/insert_iterators.hpp
@@ -141,41 +141,53 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <class T, class C>
 		concept bool InsertableInto =
-			requires(T&& t, C& c, typename C::iterator i) {
-				{  c.insert(i, (T&&)t) } -> typename C::iterator;
+			requires(T&& t, C& c, iterator_t<C> i) {
+				{  c.insert(i, (T&&)t) } -> iterator_t<C>;
 			};
-
-		template <MemberValueType Container>
-			requires requires { typename Container::iterator; }
-		class insert_cursor : public insert_cursor_base<Container> {
-			using base_t = insert_cursor_base<Container>;
-			using I = typename Container::iterator;
-
-			using mixin = insert_cursor_mixin<insert_cursor, Container>;
-
-			constexpr insert_cursor() = default;
-			STL2_CONSTEXPR_EXT explicit insert_cursor(Container& x, I i)
-				noexcept(is_nothrow_move_constructible<I>::value) :
-				base_t{x}, iter_{__stl2::move(i)} {}
-
-			template <InsertableInto<Container> T>
-			void write(T&& t) {
-				iter_ = base_t::container_->insert(iter_, __stl2::forward<T>(t));
-				++iter_;
-			}
-
-		private:
-			I iter_{};
-		};
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 	// insert_iterator [insert.iterator]
 	//
-	template <detail::MemberValueType Container,
-		class I = typename Container::iterator>
-	using insert_iterator =
-		basic_iterator<detail::insert_cursor<Container>>;
+	template <detail::MemberValueType Container>
+	requires requires { typename iterator_t<Container>; }
+	class insert_iterator {
+	public:
+		using container_type = Container;
+		using difference_type = ptrdiff_t;
+
+		insert_iterator() = default;
+		insert_iterator(Container& x, iterator_t<Container> i)
+		: container(std::addressof(x)), iter(__stl2::move(i)) {}
+		insert_iterator& operator=(const value_type_t<Container>& value)
+		requires detail::InsertableInto<const value_type_t<Container>&, Container>
+		{
+			iter = container->insert(iter, value);
+			++iter;
+			return *this;
+		}
+		insert_iterator& operator=(value_type_t<Container>&& value)
+		requires detail::InsertableInto<value_type_t<Container>&&, Container>
+		{
+			iter = container->insert(iter, __stl2::move(value));
+			++iter;
+			return *this;
+		}
+		insert_iterator& operator*() {
+			return *this;
+		}
+		insert_iterator& operator++() {
+			return *this;
+		}
+		// Not to spec:
+		// https://github.com/ericniebler/stl2/issues/232
+		insert_iterator& operator++(int) {
+			return *this;
+		}
+	private:
+		detail::raw_ptr<Container> container{nullptr};
+		iterator_t<Container> iter{};
+	};
 
 	template <detail::MemberValueType Container>
 	STL2_CONSTEXPR_EXT auto inserter(Container& x, iterator_t<Container> i)

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -113,6 +113,8 @@ STL2_OPEN_NAMESPACE {
 
 			// Not to spec
 			// Experimental support for move_iterator post-increment
+			// BUGBUG doesn't correctly handle when decltype(current_++)
+			// is a reference.
 			using __postinc_t = std::decay_t<decltype(current_++)>;
 			Readable{R}
 			struct __proxy {
@@ -128,8 +130,9 @@ STL2_OPEN_NAMESPACE {
 				)
 			};
 
-			// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69096
+#if STL2_WORKAROUND_GCC_69096
 			template <class = void>
+#endif // STL2_WORKAROUND_GCC_69096
 			STL2_CONSTEXPR_EXT auto post_increment()
 			noexcept(noexcept(__proxy<__postinc_t>{current_++}))
 			requires !ForwardIterator<I>() && Readable<__postinc_t>() {

--- a/include/stl2/detail/iterator/ostreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/ostreambuf_iterator.hpp
@@ -23,89 +23,70 @@
 #include <stl2/detail/iterator/default_sentinel.hpp>
 
 STL2_OPEN_NAMESPACE {
-	namespace __ostreambuf_iterator {
-		template <MoveConstructible charT, class traits>
-		class cursor {
-			using ostream_type = std::basic_ostream<charT, traits>;
-			using streambuf_type = std::basic_streambuf<charT, traits>;
-			detail::raw_ptr<streambuf_type> sbuf_ = nullptr;
-
-		public:
-			class mixin : protected basic_mixin<cursor> {
-				using base_t = basic_mixin<cursor>;
-			public:
-				using difference_type = std::ptrdiff_t;
-				using char_type = charT;
-				using traits_type = traits;
-				using ostream_type = cursor::ostream_type;
-				using streambuf_type = cursor::streambuf_type;
-
-				constexpr mixin() noexcept = default;
-				STL2_CONSTEXPR_EXT mixin(streambuf_type* s) noexcept
-				: base_t{cursor{s}}
-				{}
-				mixin(ostream_type& s) noexcept
-				: base_t{cursor{s}}
-				{}
-				constexpr mixin(default_sentinel) noexcept
-				: base_t{}
-				{}
-#if STL2_WORKAROUND_GCC_79143
-				constexpr explicit mixin(const cursor& c)
-				noexcept(std::is_nothrow_copy_constructible<cursor>::value)
-				: base_t{c}
-				{}
-				constexpr explicit mixin(cursor&& c)
-				noexcept(std::is_nothrow_move_constructible<cursor>::value)
-				: base_t{std::move(c)}
-				{}
-#else  // STL2_WORKAROUND_GCC_79143
-				using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
-
-				STL2_CONSTEXPR_EXT bool failed() const noexcept {
-					return base_t::get().sbuf_ == nullptr;
-				}
-			};
-
-			constexpr cursor() noexcept = default;
-			STL2_CONSTEXPR_EXT cursor(streambuf_type* s) noexcept
-			: sbuf_{s}
-			{}
-			cursor(ostream_type& s) noexcept
-			: cursor{s.rdbuf()}
-			{}
-			// Extension
-			constexpr cursor(default_sentinel) noexcept
-			: cursor{}
-			{}
-
-			void write(charT c) {
-				if (sbuf_) {
-					if (traits::eq_int_type(sbuf_->sputc(__stl2::move(c)), traits::eof())) {
-						sbuf_ = nullptr;
-					}
-				}
-			}
-
-			// Extension
-			bool equal(const cursor& that) const noexcept {
-				return sbuf_ == that.sbuf_;
-			}
-			// Extension
-			bool equal(default_sentinel) const noexcept {
-				return sbuf_ == nullptr;
-			}
-		};
-	}
-
 	// Not to spec:
 	// * MoveConstructible requirement is implicit
 	//   See https://github.com/ericniebler/stl2/issues/246)
 	// * Extension: satisfies EqualityComparable and Sentinel<default_sentinel>
 	template <MoveConstructible charT, class traits = std::char_traits<charT>>
-	using ostreambuf_iterator =
-		basic_iterator<__ostreambuf_iterator::cursor<charT, traits>>;
+	class ostreambuf_iterator {
+	public:
+		using difference_type = ptrdiff_t;
+		using char_type = charT;
+		using traits_type = traits;
+		using ostream_type = std::basic_ostream<charT, traits>;
+		using streambuf_type = std::basic_streambuf<charT, traits>;
+
+		constexpr ostreambuf_iterator() noexcept = default;
+		constexpr ostreambuf_iterator(default_sentinel) noexcept
+		: ostreambuf_iterator{}
+		{}
+		STL2_CONSTEXPR_EXT ostreambuf_iterator(ostream_type& s) noexcept
+		: sbuf_(s.rdbuf()) {}
+		STL2_CONSTEXPR_EXT ostreambuf_iterator(streambuf_type* s) noexcept
+		: sbuf_(s) {}
+		ostreambuf_iterator& operator=(charT c) {
+			if (sbuf_) {
+				if (traits::eq_int_type(sbuf_->sputc(__stl2::move(c)), traits::eof())) {
+					sbuf_ = nullptr;
+				}
+			}
+			return *this;
+		}
+		ostreambuf_iterator& operator*() noexcept {
+			return *this;
+		}
+		ostreambuf_iterator& operator++() noexcept {
+			return *this;
+		}
+		// Not to spec:
+		// https://github.com/ericniebler/stl2/issues/232
+		ostreambuf_iterator& operator++(int) noexcept {
+			return *this;
+		}
+		bool failed() const noexcept {
+			return sbuf_ != nullptr;
+		}
+		friend bool operator==(ostreambuf_iterator a, ostreambuf_iterator b) noexcept {
+			return a.sbuf_ == b.sbuf_;
+		}
+		friend bool operator!=(ostreambuf_iterator a, ostreambuf_iterator b) noexcept {
+			return !(a == b);
+		}
+		friend bool operator==(ostreambuf_iterator a, default_sentinel) noexcept {
+			return a.sbuf_ == nullptr;
+		}
+		friend bool operator!=(ostreambuf_iterator a, default_sentinel b) noexcept {
+			return !(a == b);
+		}
+		friend bool operator==(default_sentinel a, ostreambuf_iterator b) noexcept {
+			return b.sbuf_ == nullptr;
+		}
+		friend bool operator!=(default_sentinel a, ostreambuf_iterator b) noexcept {
+			return !(a == b);
+		}
+	private:
+		detail::raw_ptr<streambuf_type> sbuf_{nullptr};
+	};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/test/iterator/common_iterator.cpp
+++ b/test/iterator/common_iterator.cpp
@@ -45,6 +45,12 @@ namespace {
 		int read() const { return 42; }
 		void next();
 	};
+	struct sz {
+		friend bool operator==(const char* p, sz) { return !*p;	}
+		friend bool operator!=(const char* p, sz) { return *p; }
+		friend bool operator==(sz, const char* p) { return !*p; }
+		friend bool operator!=(sz, const char* p) {	return *p; }
+	};
 
 	void test_operator_arrow() {
 		// I is a pointer type
@@ -150,7 +156,16 @@ int main() {
 		CI last{sentinel<int*>{rgi+10}};
 		CHECK(std::accumulate(first, last, 0, std::plus<int>{}) == 45);
 	}
-
+	// Check conversions:
+	{
+		char buff[] = "abcd";
+		__stl2::common_iterator<char*, sz> ci(buff);
+		__stl2::common_iterator<const char*, sz> ci2(ci);
+		ci2 = ci;
+		CHECK(ci2 == ci);
+		++ci2;
+		CHECK(ci2 != ci);
+	}
 	test_operator_arrow();
 
 	return test_result();

--- a/test/iterator/counted_iterator.cpp
+++ b/test/iterator/counted_iterator.cpp
@@ -12,6 +12,7 @@
 //
 #include <stl2/iterator.hpp>
 #include <stl2/type_traits.hpp>
+#include <stl2/algorithm.hpp>
 #include <list>
 #include "../test_iterators.hpp"
 #include "../simple_test.hpp"
@@ -54,6 +55,18 @@ int main()
 		CHECK((d - d) == 0);
 		CHECK((c - d) == 0);
 		CHECK((d - c) == 0);
+	}
+
+	{
+		int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+		counted_iterator<output_iterator<int*>> e{output_iterator<int*>{rgi}, 10};
+		fill(e, default_sentinel{}, 0);
+		int expected[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+		CHECK(std::equal(rgi, rgi + size(rgi), expected));
+		// Make sure advance compiles
+		advance(e, 4);
+		CHECK(e.base().base() == rgi + 4);
+		CHECK(e.count() == 10 - 4);
 	}
 
 	return ::test_result();

--- a/test/iterator/ostream_iterator.cpp
+++ b/test/iterator/ostream_iterator.cpp
@@ -49,7 +49,7 @@ int main() {
 	static_assert(models::Same<I&, decltype(*i)>);
 	static_assert(models::Same<I&, decltype(*i = 42)>);
 	static_assert(models::Same<I&, decltype(++i)>);
-	static_assert(models::Same<I, decltype(i++)>);
+	static_assert(models::Same<I&, decltype(i++)>);
 
 	static_assert(noexcept(I{}));
 	static_assert(noexcept(I{ss}));

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -123,8 +123,8 @@ public:
 	constexpr reference operator*() const {return *it_;}
 
 	constexpr output_iterator& operator++() {++it_; return *this;}
-	constexpr output_iterator operator++(int)
-	{output_iterator tmp(*this); ++(*this); return tmp;}
+	constexpr decltype(auto) operator++(int)
+	{return it_++;}
 };
 
 template <class It>


### PR DESCRIPTION
This implements the solution to the postfix increment problem that I am going to be suggesting in P0541, "Post-Increment on Input and Output Iterators". See ericniebler/stl2#232 and ericniebler/stl2#302.

For clarity, I implemented the following iterators by hand (without `basic_iterator`):
* `ostream_iterator`
* `ostreambuf_iterator`
* `insert_iterator`
* `counted_iterator`
* `common_iterator`

It's now easy to see that these are to spec except where noted (and with the exception of `noexcept` here and there).