### PR TITLE
avoid function-style casts in Common and CommonReference.

### DIFF
--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -181,6 +181,8 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool CommonReference<T, U> = true;
 	}
 
+	// Not to spec
+	// See https://github.com/ericniebler/stl2/issues/311
 	template <class T, class U>
 	concept bool CommonReference() {
 		return models::CommonReference<T, U>;
@@ -220,6 +222,8 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool Common<T, U> = true;
 	}
 
+	// Not to spec
+	// See https://github.com/ericniebler/stl2/issues/311
 	template <class T, class U>
 	concept bool Common() {
 		return models::Common<T, U>;

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -171,14 +171,13 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool CommonReference = false;
 		template <class T, class U>
 		requires
-			requires(T (&t)(), U (&u)()) {
+			requires {
 				typename common_reference_t<T, U>;
 				typename common_reference_t<U, T>;
-				requires Same<common_reference_t<T, U>,
-					common_reference_t<U, T>>;
-				common_reference_t<T, U>(t());
-				common_reference_t<T, U>(u());
-			}
+			} &&
+			Same<common_reference_t<T, U>, common_reference_t<U, T>> &&
+			ConvertibleTo<T, common_reference_t<T, U>> &&
+			ConvertibleTo<U, common_reference_t<T, U>>
 		constexpr bool CommonReference<T, U> = true;
 	}
 
@@ -206,18 +205,18 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool Common = false;
 		template <class T, class U>
 		requires
-			CommonReference<add_lvalue_reference_t<const T>,
-				add_lvalue_reference_t<const U>> &&
-			requires(T (&t)(), U (&u)()) {
+			requires {
 				typename common_type_t<T, U>;
 				typename common_type_t<U, T>;
-				requires Same<common_type_t<T, U>, common_type_t<U, T>>;
-				common_type_t<T, U>(t());
-				common_type_t<T, U>(u());
-				requires CommonReference<add_lvalue_reference_t<common_type_t<T, U>>,
-					common_reference_t<add_lvalue_reference_t<const T>,
-						add_lvalue_reference_t<const U>>>;
-			}
+			} &&
+			Same<common_type_t<T, U>, common_type_t<U, T>> &&
+			ConvertibleTo<T, common_type_t<T, U>> &&
+			ConvertibleTo<U, common_type_t<T, U>> &&
+			CommonReference<add_lvalue_reference_t<const T>,
+				add_lvalue_reference_t<const U>> &&
+			CommonReference<add_lvalue_reference_t<common_type_t<T, U>>,
+				common_reference_t<add_lvalue_reference_t<const T>,
+					add_lvalue_reference_t<const U>>>
 		constexpr bool Common<T, U> = true;
 	}
 

--- a/test/concepts/core.cpp
+++ b/test/concepts/core.cpp
@@ -62,6 +62,7 @@ CONCEPT_ASSERT(!models::ConvertibleTo<A, B>);
 CONCEPT_ASSERT(models::ConvertibleTo<B, A>);
 CONCEPT_ASSERT(models::ConvertibleTo<int, double>);
 CONCEPT_ASSERT(models::ConvertibleTo<double, int>);
+CONCEPT_ASSERT(models::ConvertibleTo<void, void>);
 }
 
 namespace common_test {
@@ -76,6 +77,7 @@ CONCEPT_ASSERT(!models::Common<void, int>);
 CONCEPT_ASSERT(!models::Common<int*, int>);
 CONCEPT_ASSERT(models::Common<void*, int*>);
 CONCEPT_ASSERT(models::Common<double,long long>);
+CONCEPT_ASSERT(models::Common<void, void>);
 //CONCEPT_ASSERT(models::Common<int, float, double>);
 //CONCEPT_ASSERT(!models::Common<int, float, double, void>);
 


### PR DESCRIPTION
This diff requires implicit convertibility to the common (reference)? type. I'n not sure that's the right thing, but it doesn't _seem_ to break anything.