### PR TITLE
Massive cleanup, removing workarounds, fixing bugs, better TS conformance

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Pred = equal_to<>,
 		class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, projected<I, Proj>>
+		IndirectRelation<
+			Pred, projected<I, Proj>>()
 	I adjacent_find(I first, S last, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		if (first == last) {
@@ -44,8 +44,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectRelation<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -57,8 +57,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, projected<const E*, Proj>>
+		IndirectRelation<
+			Pred, projected<const E*, Proj>>()
 	dangling<const E*>
 	adjacent_find(std::initializer_list<E>&& rng, Pred pred = Pred{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/all_of.hpp
+++ b/include/stl2/detail/algorithm/all_of.hpp
@@ -27,8 +27,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	bool all_of(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -43,8 +43,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange R, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<R>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<R>, Proj>>()
 	bool all_of(R&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::all_of(__stl2::begin(rng), __stl2::end(rng),
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	bool all_of(std::initializer_list<E> il, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::all_of(il.begin(), il.end(),

--- a/include/stl2/detail/algorithm/any_of.hpp
+++ b/include/stl2/detail/algorithm/any_of.hpp
@@ -26,8 +26,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	bool any_of(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -42,8 +42,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange R, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<R>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<R>, Proj>>()
 	bool any_of(R&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::any_of(__stl2::begin(rng), __stl2::end(rng),
@@ -53,8 +53,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	bool any_of(std::initializer_list<E> il, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::any_of(il.begin(), il.end(),

--- a/include/stl2/detail/algorithm/binary_search.hpp
+++ b/include/stl2/detail/algorithm/binary_search.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<I, Proj>>()
 	bool binary_search(I first, S last, const T& value, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	bool binary_search(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::binary_search(
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<const E*, Proj>>()
 	bool binary_search(std::initializer_list<E>&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/copy.hpp
+++ b/include/stl2/detail/algorithm/copy.hpp
@@ -22,7 +22,7 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
 	requires
-		models::IndirectlyCopyable<I, O>
+		IndirectlyCopyable<I, O>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	copy(I first, S last, O result)
 	{
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	copy(Rng&& rng, O&& result)
 	{
@@ -46,8 +46,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<const E*, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<const E*, __f<O>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	copy(std::initializer_list<E>&& rng, O&& result)
 	{
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <InputIterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
 		requires
-			models::IndirectlyCopyable<I1, I2>
+			IndirectlyCopyable<I1, I2>()
 		tagged_pair<tag::in(I1), tag::out(I2)>
 		copy(I1 first, S1 last, I2 result_first, S2 result_last)
 		{
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <InputRange Rng1, Range Rng2>
 		requires
-			models::IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>
+			IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>()
 		tagged_pair<tag::in(safe_iterator_t<Rng1>), tag::out(safe_iterator_t<Rng2>)>
 		copy(Rng1&& rng1, Rng2&& rng2)
 		{
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class E, Range Rng2>
 		requires
-			models::IndirectlyCopyable<const E*, iterator_t<Rng2>>
+			IndirectlyCopyable<const E*, iterator_t<Rng2>>()
 		tagged_pair<tag::in(dangling<const E*>), tag::out(safe_iterator_t<Rng2>)>
 		copy(std::initializer_list<E>&& rng1, Rng2&& rng2)
 		{

--- a/include/stl2/detail/algorithm/copy_backward.hpp
+++ b/include/stl2/detail/algorithm/copy_backward.hpp
@@ -24,7 +24,7 @@
 STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I1, Sentinel<I1> S1, BidirectionalIterator I2>
 	requires
-		models::IndirectlyCopyable<I1, I2>
+		IndirectlyCopyable<I1, I2>()
 	tagged_pair<tag::in(I1), tag::out(I2)>
 	copy_backward(I1 first, S1 sent, I2 out)
 	{
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class I>
 	requires
-		models::BidirectionalIterator<__f<I>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<I>>
+		BidirectionalIterator<__f<I>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<I>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<I>)>
 	copy_backward(Rng&& rng, I&& result)
 	{
@@ -51,8 +51,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class I>
 	requires
-		models::BidirectionalIterator<__f<I>> &&
-		models::IndirectlyCopyable<const E*, __f<I>>
+		BidirectionalIterator<__f<I>>() &&
+		IndirectlyCopyable<const E*, __f<I>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<I>)>
 	copy_backward(std::initializer_list<E>&& rng, I&& result)
 	{

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -26,9 +26,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
 		class Pred, class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectlyCopyable<I, O>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{})
 	{
@@ -45,10 +45,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	copy_if(Rng&& rng, O&& result, Pred pred, Proj proj = Proj{})
 	{
@@ -60,10 +60,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>> &&
-		models::IndirectlyCopyable<const E*, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>() &&
+		IndirectlyCopyable<const E*, __f<O>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	copy_if(std::initializer_list<E>&& rng, O&& result, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -22,7 +22,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, WeaklyIncrementable O>
-	requires models::IndirectlyCopyable<I, O>
+	requires IndirectlyCopyable<I, O>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	copy_n(I first_, difference_type_t<I> n, O result)
 	{

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -23,8 +23,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T*>()
 	difference_type_t<I>
 	count(I first, S last, const T& value, Proj proj = Proj{})
 	{
@@ -39,8 +39,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
 	difference_type_t<iterator_t<Rng>>
 	count(Rng&& rng, const T& value, Proj proj = Proj{})
 	{
@@ -51,8 +51,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<const E*, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<const E*, Proj>, const T*>()
 	std::ptrdiff_t
 	count(std::initializer_list<E>&& rng,
 				const T& value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -23,8 +23,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	difference_type_t<I> count_if(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		auto n = difference_type_t<I>{0};
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	difference_type_t<iterator_t<Rng>> count_if(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::count_if(__stl2::begin(rng), __stl2::end(rng),
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	std::ptrdiff_t count_if(std::initializer_list<E>&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::count_if(rng, __stl2::ref(pred), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/equal.hpp
+++ b/include/stl2/detail/algorithm/equal.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
 		class Pred, class Proj1, class Proj2>
 	requires
-		models::IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
 	bool __equal_3(I1 first1, S1 last1, I2 first2, Pred& pred,
 		Proj1& proj1, Proj2& proj2)
 	{
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		InputIterator I2, Sentinel<I2> S2,
 		class Pred, class Proj1, class Proj2>
 	requires
-		models::IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
 	bool __equal_4(I1 first1, S1 last1, I2 first2, S2 last2, Pred& pred,
 		Proj1& proj1, Proj2& proj2)
 	{
@@ -58,11 +58,11 @@ STL2_OPEN_NAMESPACE {
 	equal(I1&& first1, S1&& last1, I2&& first2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
-		models::InputIterator<__f<I1>> &&
-		models::Sentinel<__f<S1>, __f<I1>> &&
-		models::InputIterator<__f<I2>> &&
-		models::IndirectlyComparable<
-			__f<I1>, __f<I2>, Pred, Proj1, Proj2>
+		InputIterator<__f<I1>>() &&
+		Sentinel<__f<S1>, __f<I1>>() &&
+		InputIterator<__f<I2>>() &&
+		IndirectlyComparable<
+			__f<I1>, __f<I2>, Pred, Proj1, Proj2>()
 	{
 		return __stl2::__equal_3(
 			__stl2::forward<I1>(first1), __stl2::forward<S1>(last1),
@@ -75,9 +75,9 @@ STL2_OPEN_NAMESPACE {
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
 		!is_array<remove_reference_t<I2>>::value &&
-		models::InputIterator<__f<I2>> &&
-		models::IndirectlyComparable<
-			iterator_t<Rng1>, __f<I2>, Pred, Proj1, Proj2>
+		InputIterator<__f<I2>>() &&
+		IndirectlyComparable<
+			iterator_t<Rng1>, __f<I2>, Pred, Proj1, Proj2>()
 	{
 		auto first2 = std::forward<I2>(first2_);
 		return __stl2::__equal_3(__stl2::begin(rng1), __stl2::end(rng1),
@@ -87,12 +87,12 @@ STL2_OPEN_NAMESPACE {
 	template <class I1, class S1, class I2, class S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::InputIterator<__f<I1>> &&
-		models::InputIterator<__f<I2>> &&
+		InputIterator<__f<I1>>() &&
+		InputIterator<__f<I2>>() &&
 		Sentinel<__f<S1>, __f<I1>>() &&
 		Sentinel<__f<S2>, __f<I2>>() &&
-		models::IndirectlyComparable<
-			__f<I1>, __f<I2>, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			__f<I1>, __f<I2>, Pred, Proj1, Proj2>()
 	bool equal(I1&& first1, S1&& last1, I2&& first2, S2&& last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -105,12 +105,12 @@ STL2_OPEN_NAMESPACE {
 	template <class I1, class S1, class I2, class S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::InputIterator<__f<I1>> &&
-		models::InputIterator<__f<I2>> &&
+		InputIterator<__f<I1>>() &&
+		InputIterator<__f<I2>>() &&
 		SizedSentinel<__f<S1>, __f<I1>>() &&
 		SizedSentinel<__f<S2>, __f<I2>>() &&
-		models::IndirectlyComparable<
-			__f<I1>, __f<I2>, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			__f<I1>, __f<I2>, Pred, Proj1, Proj2>()
 	bool equal(I1&& first1_, S1&& last1_, I2&& first2_, S2&& last2_, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -133,9 +133,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
+		IndirectlyComparable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			Pred, Proj1, Proj2>
+			Pred, Proj1, Proj2>()
 	bool equal(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -148,10 +148,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::SizedRange<Rng1> && models::SizedRange<Rng2> &&
-		models::IndirectlyComparable<
+		SizedRange<Rng1>() && SizedRange<Rng2>() &&
+		IndirectlyComparable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			Pred, Proj1, Proj2>
+			Pred, Proj1, Proj2>()
 	bool equal(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{

--- a/include/stl2/detail/algorithm/equal_range.hpp
+++ b/include/stl2/detail/algorithm/equal_range.hpp
@@ -27,8 +27,8 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <ForwardIterator I, class T, class Comp = less<>, class Proj = identity>
 		requires
-			models::IndirectStrictWeakOrder<
-				Comp, const T*, projected<I, Proj>>
+			IndirectStrictWeakOrder<
+				Comp, const T*, projected<I, Proj>>()
 		ext::range<I> equal_range_n(I first, difference_type_t<I> dist, const T& value,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
@@ -63,8 +63,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<I, Proj>>()
 	ext::range<I> equal_range(I first, S last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -109,8 +109,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, SizedSentinel<I> S, class T,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<I, Proj>>()
 	ext::range<I> equal_range(I first, S last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -122,8 +122,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng, class T,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	ext::range<safe_iterator_t<Rng>> equal_range(Rng&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -135,9 +135,9 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng, class T, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>> &&
-		models::SizedRange<Rng>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>() &&
+		SizedRange<Rng>()
 	ext::range<safe_iterator_t<Rng>> equal_range(Rng&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -149,8 +149,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<const E*, Proj>>()
 	ext::range<dangling<const E*>>
 	equal_range(std::initializer_list<E>&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -24,8 +24,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T*>()
 	I find(I first, S last, const T& value, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
 	safe_iterator_t<Rng> find(Rng&& rng, const T& value, Proj proj = Proj{}) {
 		return __stl2::find(__stl2::begin(rng), __stl2::end(rng), value,
 												__stl2::ref(proj));
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			equal_to<>, projected<const E*, Proj>, const T*>
+		IndirectRelation<
+			equal_to<>, projected<const E*, Proj>, const T*>()
 	dangling<const E*>
 	find(std::initializer_list<E>&& il, const T& value, Proj proj = Proj{}) {
 		return __stl2::find(il.begin(), il.end(), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -28,8 +28,8 @@ STL2_OPEN_NAMESPACE {
 		ForwardIterator I2, Sentinel<I2> S2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
+		IndirectRelation<
+			Pred, I2, projected<I1, Proj>>()
 	I1 find_end(I1 first1, const S1 last1,
 		const I2 first2, const S2 last2,
 		Pred pred = Pred{}, Proj proj = Proj{})
@@ -60,8 +60,8 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I1, BidirectionalIterator I2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
+		IndirectRelation<
+			Pred, I2, projected<I1, Proj>>()
 	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
 		Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -92,8 +92,8 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I1, RandomAccessIterator I2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
+		IndirectRelation<
+			Pred, I2, projected<I1, Proj>>()
 	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
 		Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -123,8 +123,8 @@ STL2_OPEN_NAMESPACE {
 		BidirectionalIterator I2, Sentinel<I2> S2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
+		IndirectRelation<
+			Pred, I2, projected<I1, Proj>>()
 	I1 find_end(I1 first1, S1 s1, I2 first2, S2 s2, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		auto last1 = __stl2::next(first1, __stl2::move(s1));
@@ -138,8 +138,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectRelation<
-			Pred, iterator_t<Rng2>, projected<iterator_t<Rng1>, Proj>>
+		IndirectRelation<
+			Pred, iterator_t<Rng2>, projected<iterator_t<Rng1>, Proj>>()
 	safe_iterator_t<Rng1>
 	find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -26,9 +26,9 @@ STL2_OPEN_NAMESPACE {
 		class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<I1, Proj1>,
-			projected<I2, Proj2>>
+			projected<I2, Proj2>>()
 	I1 find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
 		Pred pred = Pred{}, Proj1 proj1 = Proj1{},
 		Proj2 proj2 = Proj2{})
@@ -46,9 +46,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	safe_iterator_t<Rng1>
 	find_first_of(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -64,9 +64,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<const E*, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	dangling<const E*>
 	find_first_of(std::initializer_list<E>&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -82,9 +82,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<const E*, Proj2>>
+			projected<const E*, Proj2>>()
 	safe_iterator_t<Rng1>
 	find_first_of(Rng1&& rng1, std::initializer_list<E>&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -100,9 +100,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<const E1*, Proj1>,
-			projected<const E2*, Proj2>>
+			projected<const E2*, Proj2>>()
 	dangling<const E1*>
 	find_first_of(std::initializer_list<E1>&& rng1,
 		std::initializer_list<E2>&& rng2, Pred pred = Pred{},

--- a/include/stl2/detail/algorithm/find_if.hpp
+++ b/include/stl2/detail/algorithm/find_if.hpp
@@ -24,8 +24,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I find_if(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	find_if(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
@@ -50,8 +50,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	dangling<const E*>
 	find_if(std::initializer_list<E>&& il, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/find_if_not.hpp
+++ b/include/stl2/detail/algorithm/find_if_not.hpp
@@ -25,10 +25,10 @@
 STL2_OPEN_NAMESPACE {
 	template <class I, class S, class Pred, class Proj = identity>
 	requires
-		models::InputIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::IndirectPredicate<
-			Pred, projected<__f<I>, Proj>>
+		InputIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		IndirectPredicate<
+			Pred, projected<__f<I>, Proj>>()
 	__f<I> find_if_not(I&& first, S&& last, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::find_if(__stl2::forward<I>(first), __stl2::forward<S>(last),
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	dangling<const E*>
 	find_if_not(std::initializer_list<E>&& il, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/for_each.hpp
+++ b/include/stl2/detail/algorithm/for_each.hpp
@@ -25,8 +25,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class F, class Proj = identity>
 	requires
-		models::IndirectInvocable<
-			F, projected<I, Proj>>
+		IndirectInvocable<
+			F, projected<I, Proj>>()
 	tagged_pair<tag::in(I), tag::fun(F)>
 	for_each(I first, S last, F fun, Proj proj = Proj{})
 	{
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class F, class Proj = identity>
 	requires
-		models::IndirectInvocable<
-			F, projected<iterator_t<Rng>, Proj>>
+		IndirectInvocable<
+			F, projected<iterator_t<Rng>, Proj>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::fun(F)>
 	for_each(Rng&& rng, F fun, Proj proj = Proj{})
 	{
@@ -50,8 +50,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class F, class Proj = identity>
 	requires
-		models::IndirectInvocable<
-			F, projected<const E*, Proj>>
+		IndirectInvocable<
+			F, projected<const E*, Proj>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::fun(F)>
 	for_each(std::initializer_list<E>&& il, F fun, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/forward_sort.hpp
+++ b/include/stl2/detail/algorithm/forward_sort.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			inline I merge_n_with_buffer(I f0, difference_type_t<I> n0,
 				I f1, difference_type_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			inline void merge_n_step_0(I f0, difference_type_t<I> n0,
 				I f1, difference_type_t<I> n1,
 				Comp& comp, Proj& proj,
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			inline void merge_n_step_1(I f0, difference_type_t<I> n0,
 				I f1, difference_type_t<I> n1,
 				Comp& comp, Proj& proj,
@@ -123,7 +123,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			I merge_n_adaptive(I f0, difference_type_t<I> n0,
 				I f1, difference_type_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
@@ -154,7 +154,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			I sort_n_adaptive(I first, const difference_type_t<I> n, buf_t<I>& buf,
 				Comp& comp, Proj& proj)
 			{
@@ -171,7 +171,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <class I, class Comp = less<>, class Proj = identity>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			inline I sort_n(I first, const difference_type_t<I> n,
 				Comp comp = Comp{}, Proj proj = Proj{})
 			{

--- a/include/stl2/detail/algorithm/generate.hpp
+++ b/include/stl2/detail/algorithm/generate.hpp
@@ -22,8 +22,8 @@
 STL2_OPEN_NAMESPACE {
 	template <class F, Iterator O, Sentinel<O> S>
 	requires
-		models::Invocable<F&> &&
-		models::Writable<O, result_of_t<F&()>>
+		Invocable<F&>() &&
+		Writable<O, result_of_t<F&()>>()
 	O generate(O first, S last, F gen)
 	{
 		for (; first != last; ++first) {
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class Rng, class F>
 	requires
-		models::Invocable<F&> &&
-		models::OutputRange<Rng, result_of_t<F&()>>
+		Invocable<F&>() &&
+		OutputRange<Rng, result_of_t<F&()>>()
 	safe_iterator_t<Rng>
 	generate(Rng&& rng, F gen)
 	{

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -22,8 +22,8 @@
 STL2_OPEN_NAMESPACE {
 	template <class F, Iterator O>
 	requires
-		models::Invocable<F&> &&
-		models::Writable<O, result_of_t<F&()>>
+		Invocable<F&>() &&
+		Writable<O, result_of_t<F&()>>()
 	O generate_n(O first, difference_type_t<O> n, F gen)
 	{
 		for (; n > 0; ++first, --n) {

--- a/include/stl2/detail/algorithm/heap_sift.hpp
+++ b/include/stl2/detail/algorithm/heap_sift.hpp
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
-			models::IndirectStrictWeakOrder<Comp,
-				projected<I, Proj>, projected<I, Proj>>
+			IndirectStrictWeakOrder<Comp,
+				projected<I, Proj>, projected<I, Proj>>()
 		void sift_up_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
@@ -61,8 +61,8 @@ STL2_OPEN_NAMESPACE {
 
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
-			models::IndirectStrictWeakOrder<Comp,
-				projected<I, Proj>, projected<I, Proj>>
+			IndirectStrictWeakOrder<Comp,
+				projected<I, Proj>, projected<I, Proj>>()
 		void sift_down_n(I first, difference_type_t<I> n, I start,
 			Comp comp, Proj proj)
 		{

--- a/include/stl2/detail/algorithm/includes.hpp
+++ b/include/stl2/detail/algorithm/includes.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 		InputIterator I2, Sentinel<I2> S2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
 	bool includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -50,9 +50,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	bool includes(Rng1&& rng1, Rng2&& rng2, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -68,9 +68,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<const E*, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	bool includes(std::initializer_list<E>&& rng1, Rng2&& rng2, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -86,9 +86,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<const E*, Proj2>>
+			projected<const E*, Proj2>>()
 	bool includes(Rng1&& rng1, std::initializer_list<E>&& rng2, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -104,9 +104,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<const E1*, Proj1>,
-			projected<const E2*, Proj2>>
+			projected<const E2*, Proj2>>()
 	bool includes(std::initializer_list<E1>&& rng1,
 		std::initializer_list<E2>&& rng2, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})

--- a/include/stl2/detail/algorithm/inplace_merge.hpp
+++ b/include/stl2/detail/algorithm/inplace_merge.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 		private:
 			template <BidirectionalIterator I, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			static void impl(I begin, I middle, I end, difference_type_t<I> len1,
 				difference_type_t<I> len2, temporary_buffer<value_type_t<I>>& buf,
 				C& pred, P& proj)
@@ -82,7 +82,7 @@ STL2_OPEN_NAMESPACE {
 		public:
 			template <BidirectionalIterator I, class C, class P>
 			requires
-				models::Sortable<I, __f<C>, __f<P>>
+				Sortable<I, __f<C>, __f<P>>()
 			void operator()(I begin, I middle, I end, difference_type_t<I> len1, difference_type_t<I> len2,
 				detail::temporary_buffer<value_type_t<I>>& buf, C pred, P proj) const
 			{
@@ -177,7 +177,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			template <BidirectionalIterator I, class C = less<>, class P = identity>
 			requires
-				models::Sortable<I, __f<C>, __f<P>>
+				Sortable<I, __f<C>, __f<P>>()
 			void operator()(I begin, I middle, I end, difference_type_t<I> len1,
 				difference_type_t<I> len2, C pred = C{}, P proj = P{}) const
 			{
@@ -195,7 +195,7 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I inplace_merge(I first, I middle, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto len1 = __stl2::distance(first, middle);
@@ -212,7 +212,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	inplace_merge(Rng&& rng, iterator_t<Rng> middle, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/is_heap.hpp
+++ b/include/stl2/detail/algorithm/is_heap.hpp
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	bool is_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return last == __stl2::is_heap_until(__stl2::move(first), last,
@@ -45,8 +45,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	bool is_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::end(rng) ==
@@ -57,8 +57,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	bool is_heap(std::initializer_list<E>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::end(rng) ==

--- a/include/stl2/detail/algorithm/is_heap_until.hpp
+++ b/include/stl2/detail/algorithm/is_heap_until.hpp
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <RandomAccessIterator I, class Comp = less<>, class Proj = identity>
 		requires
-			models::IndirectStrictWeakOrder<
-				Comp, projected<I, Proj>>
+			IndirectStrictWeakOrder<
+				Comp, projected<I, Proj>>()
 		I is_heap_until_n(I first, const difference_type_t<I> n,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
@@ -63,8 +63,8 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	I is_heap_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -74,8 +74,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	is_heap_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/is_partitioned.hpp
+++ b/include/stl2/detail/algorithm/is_partitioned.hpp
@@ -25,8 +25,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	bool is_partitioned(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		first = __stl2::find_if_not(__stl2::move(first), last,
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	bool is_partitioned(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::is_partitioned(__stl2::begin(rng), __stl2::end(rng),
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	bool is_partitioned(std::initializer_list<E>&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::is_partitioned(__stl2::begin(rng), __stl2::end(rng),

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 		ForwardIterator I2, Sentinel<I2> S2,
 		class Pred, class Proj1, class Proj2>
 	requires
-		models::IndirectlyComparable<I1, I2, __f<Pred&>, __f<Proj1&>, __f<Proj2&>>
+		IndirectlyComparable<I1, I2, __f<Pred&>, __f<Proj1&>, __f<Proj2&>>()
 	bool __is_permutation_tail(I1 first1, S1 last1, I2 first2, S2 last2,
 		Pred& pred, Proj1& proj1, Proj2& proj2)
 	{
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 	[[deprecated]] bool is_permutation(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
-		models::IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
 	{
 		// shorten sequences as much as possible by lopping off any equal parts
 		for (; first1 != last1; ++first1, ++first2) {
@@ -100,9 +100,9 @@ STL2_OPEN_NAMESPACE {
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
 		!is_array<remove_reference_t<I2>>::value &&
-		models::ForwardIterator<__f<I2>> &&
-		models::IndirectlyComparable<
-			iterator_t<Rng1>, __f<I2>, Pred, Proj1, Proj2>
+		ForwardIterator<__f<I2>>() &&
+		IndirectlyComparable<
+			iterator_t<Rng1>, __f<I2>, Pred, Proj1, Proj2>()
 	{
 		auto first2 = __stl2::forward<I2>(first2_);
 		return __stl2::is_permutation(
@@ -115,8 +115,8 @@ STL2_OPEN_NAMESPACE {
 		Sentinel<I2> S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			I1, I2, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			I1, I2, Pred, Proj1, Proj2>()
 	bool is_permutation(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -144,9 +144,9 @@ STL2_OPEN_NAMESPACE {
 		Sentinel<I2> S2, class Pred = equal_to<>, class Proj1 = identity,
 		class Proj2 = identity>
 	requires
-		models::SizedSentinel<S1, I1> &&
-		models::SizedSentinel<S2, I2> &&
-		models::IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		SizedSentinel<S1, I1>() &&
+		SizedSentinel<S2, I2>() &&
+		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>()
 	bool is_permutation(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -170,9 +170,9 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
+		IndirectlyComparable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			Pred, Proj1, Proj2>
+			Pred, Proj1, Proj2>()
 	bool is_permutation(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -186,11 +186,11 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::SizedRange<Rng1> &&
-		models::SizedRange<Rng2> &&
-		models::IndirectlyComparable<
+		SizedRange<Rng1>() &&
+		SizedRange<Rng2>() &&
+		IndirectlyComparable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			Pred, Proj1, Proj2>
+			Pred, Proj1, Proj2>()
 	bool is_permutation(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{

--- a/include/stl2/detail/algorithm/is_sorted.hpp
+++ b/include/stl2/detail/algorithm/is_sorted.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	bool is_sorted(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return last == __stl2::is_sorted_until(__stl2::move(first), last,
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	bool is_sorted(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::end(rng) ==
@@ -47,8 +47,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	bool is_sorted(std::initializer_list<E>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::end(rng) ==

--- a/include/stl2/detail/algorithm/is_sorted_until.hpp
+++ b/include/stl2/detail/algorithm/is_sorted_until.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	I is_sorted_until(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -42,8 +42,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	is_sorted_until(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	dangling<const E*>
 	is_sorted_until(std::initializer_list<E>&& rng,
 		Comp comp = Comp{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/lexicographical_compare.hpp
+++ b/include/stl2/detail/algorithm/lexicographical_compare.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
 		class Comp = less<>, class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
-			projected<I1, Proj1>, projected<I2, Proj2>>
+		IndirectStrictWeakOrder<Comp,
+			projected<I1, Proj1>, projected<I2, Proj2>>()
 	bool lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -43,9 +43,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	bool lexicographical_compare(Rng1&& rng1, Rng2&& rng2,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -61,9 +61,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<const E*, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	bool lexicographical_compare(std::initializer_list<E>&& rng1, Rng2&& rng2,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -79,9 +79,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<const E*, Proj2>>
+			projected<const E*, Proj2>>()
 	bool lexicographical_compare(Rng1&& rng1, std::initializer_list<E>&& rng2,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -97,9 +97,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectStrictWeakOrder<Comp,
 			projected<const E1*, Proj1>,
-			projected<const E2*, Proj2>>
+			projected<const E2*, Proj2>>()
 	bool lexicographical_compare(
 		std::initializer_list<E1>&& rng1, std::initializer_list<E2>&& rng2,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})

--- a/include/stl2/detail/algorithm/lower_bound.hpp
+++ b/include/stl2/detail/algorithm/lower_bound.hpp
@@ -38,9 +38,9 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <class I, class T, class Comp = less<>, class Proj = identity>
 		requires
-			models::ForwardIterator<__f<I>> &&
-			models::IndirectStrictWeakOrder<
-				Comp, const T*, projected<__f<I>, Proj>>
+			ForwardIterator<__f<I>>() &&
+			IndirectStrictWeakOrder<
+				Comp, const T*, projected<__f<I>, Proj>>()
 		__f<I> lower_bound_n(I&& first, difference_type_t<__f<I>> n,
 			const T& value, Comp comp = Comp{}, Proj proj = Proj{})
 		{
@@ -53,10 +53,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::ForwardIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<__f<I>, Proj>>
+		ForwardIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<__f<I>, Proj>>()
 	__f<I> lower_bound(I&& first, S&& last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -68,11 +68,11 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::SizedSentinel<__f<S>, __f<I>> &&
-		models::ForwardIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<__f<I>, Proj>>
+		SizedSentinel<__f<S>, __f<I>>() &&
+		ForwardIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<__f<I>, Proj>>()
 	__f<I> lower_bound(I&& first_, S&& last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -84,8 +84,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -95,9 +95,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::SizedRange<Rng> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		SizedRange<Rng>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	lower_bound(Rng&& rng, const T& value, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -109,8 +109,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<const E*, Proj>>()
 	dangling<const E*>
 	lower_bound(std::initializer_list<E>&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/make_heap.hpp
+++ b/include/stl2/detail/algorithm/make_heap.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
-			models::Sortable<I, Comp, Proj>
+			Sortable<I, Comp, Proj>()
 		void make_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I make_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	make_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -27,9 +27,9 @@ STL2_OPEN_NAMESPACE {
 	namespace __max {
 		template <InputRange Rng, class Comp, class Proj>
 		requires
-			models::Copyable<value_type_t<iterator_t<Rng>>> &&
-			models::IndirectStrictWeakOrder<
-				Comp, projected<iterator_t<Rng>, Proj>>
+			Copyable<value_type_t<iterator_t<Rng>>>() &&
+			IndirectStrictWeakOrder<
+				Comp, projected<iterator_t<Rng>, Proj>>()
 		constexpr value_type_t<iterator_t<Rng>>
 		impl(Rng&& rng, Comp comp, Proj proj)
 		{
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr const T& max(const T& a, const T& b, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
@@ -59,9 +59,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Copyable<value_type_t<iterator_t<Rng>>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		Copyable<value_type_t<iterator_t<Rng>>>() &&
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	STL2_CONSTEXPR_EXT value_type_t<iterator_t<Rng>>
 	max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -71,8 +71,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <Copyable T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr T max(std::initializer_list<T>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __max::impl(rng, __stl2::ref(comp), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/max_element.hpp
+++ b/include/stl2/detail/algorithm/max_element.hpp
@@ -24,8 +24,8 @@
 STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	I max_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -40,8 +40,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	max_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -52,8 +52,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	dangling<const E*>
 	max_element(std::initializer_list<E>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		Mergeable<I1, I2, O, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
 	merge(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 				Comp comp = Comp{}, Proj1 proj1 = Proj1{},
@@ -63,9 +63,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<
+		Mergeable<
 			iterator_t<Rng1>, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>),
 		tag::out(__f<O>)>
 	merge(Rng1&& rng1, Rng2&& rng2, O&& result, Comp comp = Comp{},
@@ -82,9 +82,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<
+		Mergeable<
 			const E*, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E*>),
 		tag::in2(safe_iterator_t<Rng2>), tag::out(__f<O>)>
 	merge(std::initializer_list<E>&& rng1, Rng2&& rng2, O&& result,
@@ -101,9 +101,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<
+		Mergeable<
 			iterator_t<Rng1>, const E*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>),
 		tag::in2(dangling<const E*>), tag::out(__f<O>)>
 	merge(Rng1&& rng1, std::initializer_list<E>&& rng2, O&& result,
@@ -120,9 +120,9 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<
+		Mergeable<
 			const E1*, const E2*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E1*>),
 		tag::in2(dangling<const E2*>), tag::out(__f<O>)>
 	merge(std::initializer_list<E1>&& rng1, std::initializer_list<E2>&& rng2,

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -26,9 +26,9 @@ STL2_OPEN_NAMESPACE {
 	namespace __min {
 		template <InputRange Rng, class Comp = less<>, class Proj = identity>
 		requires
-			models::Copyable<value_type_t<iterator_t<Rng>>> &&
-			models::IndirectStrictWeakOrder<
-				Comp, projected<iterator_t<Rng>, Proj>>
+			Copyable<value_type_t<iterator_t<Rng>>>() &&
+			IndirectStrictWeakOrder<
+				Comp, projected<iterator_t<Rng>, Proj>>()
 		constexpr value_type_t<iterator_t<Rng>>
 		impl(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 		{
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr const T& min(const T& a, const T& b, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
@@ -58,9 +58,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Copyable<value_type_t<iterator_t<Rng>>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		Copyable<value_type_t<iterator_t<Rng>>>() &&
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	STL2_CONSTEXPR_EXT value_type_t<iterator_t<Rng>>
 	min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -70,8 +70,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <Copyable T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr T min(std::initializer_list<T>&& rng,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/min_element.hpp
+++ b/include/stl2/detail/algorithm/min_element.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	I min_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -41,8 +41,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	min_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -53,8 +53,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	dangling<const E*>
 	min_element(std::initializer_list<E>&& rng,
 		Comp comp = Comp{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -27,9 +27,9 @@ STL2_OPEN_NAMESPACE {
 	namespace __minmax {
 		template <InputRange Rng, class Comp = less<>, class Proj = identity>
 		requires
-			models::Copyable<value_type_t<iterator_t<Rng>>> &&
-			models::IndirectStrictWeakOrder<
-				Comp, projected<iterator_t<Rng>, Proj>>
+			Copyable<value_type_t<iterator_t<Rng>>>() &&
+			IndirectStrictWeakOrder<
+				Comp, projected<iterator_t<Rng>, Proj>>()
 		constexpr tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
 			tag::max(value_type_t<iterator_t<Rng>>)>
 		impl(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
@@ -85,8 +85,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
 	minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -99,9 +99,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Copyable<value_type_t<iterator_t<Rng>>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		Copyable<value_type_t<iterator_t<Rng>>>() &&
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	STL2_CONSTEXPR_EXT tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
 		tag::max(value_type_t<iterator_t<Rng>>)>
 	minmax(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
@@ -111,8 +111,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <Copyable T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const T*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const T*, Proj>>()
 	constexpr tagged_pair<tag::min(T), tag::max(T)>
 	minmax(std::initializer_list<T>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/minmax_element.hpp
+++ b/include/stl2/detail/algorithm/minmax_element.hpp
@@ -30,8 +30,8 @@
 STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<I, Proj>>()
 	STL2_CONSTEXPR_EXT tagged_pair<tag::min(I), tag::max(I)>
 	minmax_element(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -76,8 +76,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<iterator_t<Rng>, Proj>>()
 	STL2_CONSTEXPR_EXT tagged_pair<tag::min(safe_iterator_t<Rng>),
 		tag::max(safe_iterator_t<Rng>)>
 	minmax_element(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
@@ -89,8 +89,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, projected<const E*, Proj>>()
 	STL2_CONSTEXPR_EXT tagged_pair<tag::min(dangling<const E*>), tag::max(dangling<const E*>)>
 	minmax_element(std::initializer_list<E>&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -29,9 +29,9 @@ STL2_OPEN_NAMESPACE {
 	mismatch(I1 first1, S1 last1, I2 first2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<I1, Proj1>,
-			projected<I2, Proj2>>
+			projected<I2, Proj2>>()
 	{
 		for (; first1 != last1; ++first1, ++first2) {
 			if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
@@ -45,8 +45,8 @@ STL2_OPEN_NAMESPACE {
 		InputIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I1, Proj1>, projected<I2, Proj2>>
+		IndirectPredicate<
+			Pred, projected<I1, Proj1>, projected<I2, Proj2>>()
 	tagged_pair<tag::in1(I1), tag::in2(I2)>
 	mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -67,10 +67,10 @@ STL2_OPEN_NAMESPACE {
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
 		!is_array<remove_reference_t<I2>>::value &&
-		models::InputIterator<__f<I2>> &&
-		models::IndirectPredicate<Pred,
+		InputIterator<__f<I2>>() &&
+		IndirectPredicate<Pred,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<__f<I2>, Proj2>>
+			projected<__f<I2>, Proj2>>()
 	{
 		auto first2 = std::forward<I2>(first2_);
 		return __stl2::mismatch(
@@ -82,9 +82,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectPredicate<Pred,
+		IndirectPredicate<Pred,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>)>
 	mismatch(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})

--- a/include/stl2/detail/algorithm/move.hpp
+++ b/include/stl2/detail/algorithm/move.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
 	requires
-		models::IndirectlyMovable<I, O>
+		IndirectlyMovable<I, O>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	move(I first, S last, O result) {
 #if 1
@@ -40,8 +40,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyMovable<iterator_t<Rng>, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyMovable<iterator_t<Rng>, __f<O>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	move(Rng&& rng, O&& result) {
 		return __stl2::move(__stl2::begin(rng), __stl2::end(rng), __stl2::forward<O>(result));
@@ -50,8 +50,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyMovable<const E*, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyMovable<const E*, __f<O>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	move(std::initializer_list<E>&& rng, O&& result) {
 		return __stl2::move(__stl2::begin(rng), __stl2::end(rng), __stl2::forward<O>(result));
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 		// Extension
 		template <InputIterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
 		requires
-			models::IndirectlyMovable<I1, I2>
+			IndirectlyMovable<I1, I2>()
 		tagged_pair<tag::in(I1), tag::out(I2)>
 		move(I1 first1, S1 last1, I2 first2, S2 last2) {
 #if 1
@@ -82,7 +82,7 @@ STL2_OPEN_NAMESPACE {
 		// Extension
 		template <InputRange Rng1, Range Rng2>
 		requires
-			models::IndirectlyMovable<iterator_t<Rng1>, iterator_t<Rng2>>
+			IndirectlyMovable<iterator_t<Rng1>, iterator_t<Rng2>>()
 		tagged_pair<
 			tag::in(safe_iterator_t<Rng1>),
 			tag::out(safe_iterator_t<Rng2>)>
@@ -94,7 +94,7 @@ STL2_OPEN_NAMESPACE {
 		// Extension
 		template <class E, Range Rng2>
 		requires
-			models::IndirectlyMovable<const E*, iterator_t<Rng2>>
+			IndirectlyMovable<const E*, iterator_t<Rng2>>()
 		tagged_pair<
 			tag::in(dangling<const E*>),
 			tag::out(safe_iterator_t<Rng2>)>

--- a/include/stl2/detail/algorithm/move_backward.hpp
+++ b/include/stl2/detail/algorithm/move_backward.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I1, BidirectionalIterator I2>
 	requires
-		models::IndirectlyMovable<I1, I2>
+		IndirectlyMovable<I1, I2>()
 	tagged_pair<tag::in(I1), tag::out(I2)>
 	move_backward(I1 first, I1 last, I2 result)
 	{
@@ -44,8 +44,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalIterator I1, Sentinel<I1> S1, class I2>
 	requires
-		models::BidirectionalIterator<__f<I2>> &&
-		models::IndirectlyMovable<I1, __f<I2>>
+		BidirectionalIterator<__f<I2>>() &&
+		IndirectlyMovable<I1, __f<I2>>()
 	tagged_pair<tag::in(I1), tag::out(__f<I2>)>
 	move_backward(I1 first, S1 s, I2&& out)
 	{
@@ -56,8 +56,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class I>
 	requires
-		models::BidirectionalIterator<__f<I>> &&
-		models::IndirectlyMovable<iterator_t<Rng>, __f<I>>
+		BidirectionalIterator<__f<I>>() &&
+		IndirectlyMovable<iterator_t<Rng>, __f<I>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<I>)>
 	move_backward(Rng&& rng, I&& result)
 	{
@@ -68,8 +68,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class I>
 	requires
-		models::BidirectionalIterator<__f<I>> &&
-		models::IndirectlyMovable<const E*, __f<I>>
+		BidirectionalIterator<__f<I>>() &&
+		IndirectlyMovable<const E*, __f<I>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<I>)>
 	move_backward(std::initializer_list<E>&& rng, I&& result)
 	{

--- a/include/stl2/detail/algorithm/next_permutation.hpp
+++ b/include/stl2/detail/algorithm/next_permutation.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I, Sentinel<I> S,
 		class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	bool next_permutation(I first, S last,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	bool next_permutation(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::next_permutation(__stl2::begin(rng), __stl2::end(rng),

--- a/include/stl2/detail/algorithm/none_of.hpp
+++ b/include/stl2/detail/algorithm/none_of.hpp
@@ -24,8 +24,8 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	bool none_of(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::none_of(__stl2::begin(rng), __stl2::end(rng),
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	bool none_of(std::initializer_list<E>&& rng,
 							 Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		// stable, 2-3 compares, 0-2 swaps
 		template <class I, class C, class P>
 		requires
-			models::Sortable<I, C, P>
+			Sortable<I, C, P>()
 		unsigned sort3(I x, I y, I z, C& comp, P& proj)
 		{
 			if (!__stl2::invoke(comp, __stl2::invoke(proj, *y), __stl2::invoke(proj, *x))) {      // if x <= y
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <BidirectionalIterator I, class C, class P>
 		requires
-			models::Sortable<I, C, P>
+			Sortable<I, C, P>()
 		void selection_sort(I begin, I end, C &comp, P &proj)
 		{
 			STL2_EXPECT(begin != end);
@@ -82,7 +82,7 @@ STL2_OPEN_NAMESPACE {
 	// TODO: refactor this monstrosity.
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I nth_element(I first, I nth, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		I end = __stl2::next(nth, last), end_orig = end;
@@ -260,7 +260,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	nth_element(Rng&& rng, iterator_t<Rng> nth, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/partial_sort.hpp
+++ b/include/stl2/detail/algorithm/partial_sort.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I partial_sort(I first, I middle, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		__stl2::make_heap(first, middle, __stl2::ref(comp), __stl2::ref(proj));
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	partial_sort(Rng&& rng, iterator_t<Rng> middle, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -33,10 +33,10 @@ STL2_OPEN_NAMESPACE {
 		class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyCopyable<I1, I2> &&
-		models::Sortable<I2, Comp, Proj2> &&
-		models::IndirectStrictWeakOrder<
-			Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+		IndirectlyCopyable<I1, I2>() &&
+		Sortable<I2, Comp, Proj2>() &&
+		IndirectStrictWeakOrder<
+			Comp, projected<I1, Proj1>, projected<I2, Proj2>>()
 	I2 partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -63,11 +63,11 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, RandomAccessRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>> &&
-		models::Sortable<iterator_t<Rng2>, Comp, Proj2> &&
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>() &&
+		Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
+		IndirectStrictWeakOrder<Comp,
 			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	safe_iterator_t<Rng2>
 	partial_sort_copy(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -83,11 +83,11 @@ STL2_OPEN_NAMESPACE {
 	template <class E, RandomAccessRange Rng2, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyCopyable<const E*, iterator_t<Rng2>> &&
-		models::Sortable<iterator_t<Rng2>, Comp, Proj2> &&
-		models::IndirectStrictWeakOrder<Comp,
+		IndirectlyCopyable<const E*, iterator_t<Rng2>>() &&
+		Sortable<iterator_t<Rng2>, Comp, Proj2>() &&
+		IndirectStrictWeakOrder<Comp,
 			projected<const E*, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+			projected<iterator_t<Rng2>, Proj2>>()
 	safe_iterator_t<Rng2>
 	partial_sort_copy(std::initializer_list<E>&& rng,
 		Rng2&& result_rng, Comp comp = Comp{},

--- a/include/stl2/detail/algorithm/partition.hpp
+++ b/include/stl2/detail/algorithm/partition.hpp
@@ -35,8 +35,8 @@
 STL2_OPEN_NAMESPACE {
 	template <Permutable I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I partition(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		first = __stl2::find_if_not(__stl2::move(first), last,
@@ -54,9 +54,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <Permutable I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::BidirectionalIterator<I> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		BidirectionalIterator<I>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I partition(I first, S last_, Pred pred, Proj proj = Proj{})
 	{
 		auto last = __stl2::next(first, __stl2::move(last_));
@@ -79,9 +79,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	partition(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/partition_copy.hpp
+++ b/include/stl2/detail/algorithm/partition_copy.hpp
@@ -26,10 +26,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O1,
 		WeaklyIncrementable O2, class Pred, class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O1> &&
-		models::IndirectlyCopyable<I, O2> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectlyCopyable<I, O1>() &&
+		IndirectlyCopyable<I, O2>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	tagged_tuple<tag::in(I), tag::out1(O1), tag::out2(O2)>
 	partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
 		Proj proj = Proj{})
@@ -50,12 +50,12 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O1, class O2, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O1>> &&
-		models::WeaklyIncrementable<__f<O2>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O1>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O2>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		WeaklyIncrementable<__f<O1>>() &&
+		WeaklyIncrementable<__f<O2>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O1>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O2>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	tagged_tuple<
 		tag::in(safe_iterator_t<Rng>),
 		tag::out1(__f<O1>),
@@ -72,12 +72,12 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O1, class O2, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O1>> &&
-		models::WeaklyIncrementable<__f<O2>> &&
-		models::IndirectlyCopyable<const E*, __f<O1>> &&
-		models::IndirectlyCopyable<const E*, __f<O2>> &&
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		WeaklyIncrementable<__f<O1>>() &&
+		WeaklyIncrementable<__f<O2>>() &&
+		IndirectlyCopyable<const E*, __f<O1>>() &&
+		IndirectlyCopyable<const E*, __f<O2>> ()&&
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	tagged_tuple<
 		tag::in(dangling<const E*>),
 		tag::out1(__f<O1>),

--- a/include/stl2/detail/algorithm/partition_point.hpp
+++ b/include/stl2/detail/algorithm/partition_point.hpp
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <ForwardIterator I, class Pred, class Proj = identity>
 		requires
-			models::IndirectPredicate<
-				Pred, projected<I, Proj>>
+			IndirectPredicate<
+				Pred, projected<I, Proj>>()
 		I partition_point_n(I first, difference_type_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
@@ -58,8 +58,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I partition_point(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		// Probe exponentially for either end-of-range or an iterator
@@ -80,9 +80,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::SizedSentinel<S, I> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		SizedSentinel<S, I>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I partition_point(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -92,8 +92,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	partition_point(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
@@ -103,9 +103,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred, class Proj = identity>
 	requires
-		models::SizedRange<Rng> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		SizedRange<Rng>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	partition_point(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
@@ -116,8 +116,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class Proj = identity>
 	requires
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	dangling<const E*>
 	partition_point(std::initializer_list<E>&& rng, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/pop_heap.hpp
+++ b/include/stl2/detail/algorithm/pop_heap.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <RandomAccessIterator I, class Proj, class Comp>
 		requires
-			models::Sortable<I, Comp, Proj>
+			Sortable<I, Comp, Proj>()
 		void pop_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>,
 						class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I pop_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	pop_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/prev_permutation.hpp
+++ b/include/stl2/detail/algorithm/prev_permutation.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	bool prev_permutation(I first, S last, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	bool prev_permutation(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __stl2::prev_permutation(__stl2::begin(rng), __stl2::end(rng),

--- a/include/stl2/detail/algorithm/push_heap.hpp
+++ b/include/stl2/detail/algorithm/push_heap.hpp
@@ -34,8 +34,8 @@
 STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, class S, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sentinel<__f<S>, I> &&
-		models::Sortable<I, Comp, Proj>
+		Sentinel<__f<S>, I>() &&
+		Sortable<I, Comp, Proj>()
 	I push_heap(I first, S&& last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::forward<S>(last));
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	push_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/random_access_sort.hpp
+++ b/include/stl2/detail/algorithm/random_access_sort.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 		namespace rsort {
 			template <RandomAccessIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			I choose_pivot(I first, I last, Comp& comp, Proj& proj)
 			{
 				STL2_EXPECT(first != last);
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			I unguarded_partition(I first, I last, Comp& comp, Proj& proj)
 			{
 				I pivot_pnt = rsort::choose_pivot(first, last, comp, proj);
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <BidirectionalIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void unguarded_linear_insert(I last, value_type_t<I> val, Comp& comp, Proj& proj)
 			{
 				I next = __stl2::prev(last);
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <BidirectionalIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void linear_insert(I first, I last, Comp& comp, Proj& proj)
 			{
 				value_type_t<I> val = __stl2::iter_move(last);
@@ -100,7 +100,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <BidirectionalIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void insertion_sort(I first, I last, Comp& comp, Proj& proj)
 			{
 				if (first != last) {
@@ -112,7 +112,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <BidirectionalIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void unguarded_insertion_sort(I first, I last, Comp& comp, Proj& proj)
 			{
 				for (I i = first; i != last; ++i) {
@@ -133,7 +133,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void introsort_loop(I first, I last, difference_type_t<I> depth_limit,
 				Comp& comp, Proj& proj)
 			{
@@ -151,7 +151,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class Comp, class Proj>
 			requires
-				models::Sortable<I, Comp, Proj>
+				Sortable<I, Comp, Proj>()
 			void final_insertion_sort(I first, I last, Comp &comp, Proj &proj)
 			{
 				if (__stl2::distance(first, last) > introsort_threshold) {

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -25,9 +25,9 @@
 STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
-		models::Permutable<I> &&
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
+		Permutable<I>() &&
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T*>()
 	I remove(I first, S last, const T& value, Proj proj = Proj{})
 	{
 		first = __stl2::find(__stl2::move(first), last, value, __stl2::ref(proj));
@@ -44,9 +44,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
 	safe_iterator_t<Rng>
 	remove(Rng&& rng, const T& value, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -25,9 +25,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
 		class T, class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O> &&
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
+		IndirectlyCopyable<I, O>() &&
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T*>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{})
 	{
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O, class T, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>() &&
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	remove_copy(Rng&& rng, O&& result, const T& value, Proj proj = Proj{})
 	{
@@ -57,10 +57,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O, class T, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<const E*, __f<O>> &&
-		models::IndirectRelation<
-			equal_to<>, projected<const E*, Proj>, const T*>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<const E*, __f<O>>() &&
+		IndirectRelation<
+			equal_to<>, projected<const E*, Proj>, const T*>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	remove_copy(std::initializer_list<E>&& rng, O&& result,
 		const T& value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/remove_copy_if.hpp
+++ b/include/stl2/detail/algorithm/remove_copy_if.hpp
@@ -25,9 +25,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Pred,
 		class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectlyCopyable<I, O>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{})
 	{
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class O, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	remove_copy_if(Rng&& rng, O&& result, Pred pred, Proj proj = Proj{})
 	{
@@ -58,10 +58,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O, class Pred, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<const E*, __f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<const E*, __f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	remove_copy_if(std::initializer_list<E>&& rng, O&& result,
 								 Pred pred, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/remove_if.hpp
+++ b/include/stl2/detail/algorithm/remove_if.hpp
@@ -24,9 +24,9 @@
 STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::Permutable<I> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		Permutable<I>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I remove_if(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		first = __stl2::find_if(__stl2::move(first), last,
@@ -44,9 +44,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	remove_if(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -24,9 +24,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T1, class T2,
 		class Proj = identity>
 	requires
-		models::Writable<I, const T2&> &&
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T1*>
+		Writable<I, const T2&>() &&
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T1*>()
 	I replace(I first, S last, const T1& old_value, const T2& new_value,
 		Proj proj = Proj{})
 	{
@@ -43,9 +43,9 @@ STL2_OPEN_NAMESPACE {
 	// Extension: Relax to InputRange
 	template <InputRange Rng, class T1, class T2, class Proj = identity>
 	requires
-		models::Writable<iterator_t<Rng>, const T2&> &&
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>
+		Writable<iterator_t<Rng>, const T2&>() &&
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
 	safe_iterator_t<Rng>
 	replace(Rng&& rng, const T1& old_value, const T2& new_value,
 		Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -23,9 +23,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T1, class T2,
 		OutputIterator<const T2&> O, class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O> &&
-		models::IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T1*>
+		IndirectlyCopyable<I, O>() &&
+		IndirectRelation<
+			equal_to<>, projected<I, Proj>, const T1*>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	replace_copy(I first, S last, O result, const T1& old_value,
 		const T2& new_value, Proj proj = Proj{})
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class T1, class T2, class O, class Proj = identity>
 	requires
-		models::OutputIterator<__f<O>, const T2&> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		models::IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>
+		OutputIterator<__f<O>, const T2&>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>() &&
+		IndirectRelation<
+			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	replace_copy(Rng&& rng, O&& result, const T1& old_value,
 		const T2& new_value, Proj proj = Proj{})
@@ -59,10 +59,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T1, class T2, class O, class Proj = identity>
 	requires
-		models::OutputIterator<__f<O>, const T2&> &&
-		models::IndirectlyCopyable<const E*, __f<O>> &&
-		models::IndirectRelation<
-			equal_to<>, projected<const E*, Proj>, const T1*>
+		OutputIterator<__f<O>, const T2&>() &&
+		IndirectlyCopyable<const E*, __f<O>>() &&
+		IndirectRelation<
+			equal_to<>, projected<const E*, Proj>, const T1*>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	replace_copy(std::initializer_list<E>&& rng,
 		O&& result, const T1& old_value,

--- a/include/stl2/detail/algorithm/replace_copy_if.hpp
+++ b/include/stl2/detail/algorithm/replace_copy_if.hpp
@@ -23,9 +23,9 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class Pred, class T,
 		OutputIterator<const T&> O, class Proj = identity>
 	requires
-		models::IndirectlyCopyable<I, O> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		IndirectlyCopyable<I, O>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	replace_copy_if(I first, S last, O result, Pred pred,
 		const T& new_value, Proj proj = Proj{})
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Pred, class T, class O, class Proj = identity>
 	requires
-		models::OutputIterator<__f<O>, const T&> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		OutputIterator<__f<O>, const T&>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	replace_copy_if(Rng&& rng, O&& result, Pred pred, const T& new_value,
 		Proj proj = Proj{})
@@ -59,10 +59,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class Pred, class T, class O, class Proj = identity>
 	requires
-		models::OutputIterator<__f<O>, const T&> &&
-		models::IndirectlyCopyable<const E*, __f<O>> &&
-		models::IndirectPredicate<
-			Pred, projected<const E*, Proj>>
+		OutputIterator<__f<O>, const T&>() &&
+		IndirectlyCopyable<const E*, __f<O>>() &&
+		IndirectPredicate<
+			Pred, projected<const E*, Proj>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	replace_copy_if(std::initializer_list<E>&& rng, O&& result, Pred pred,
 		const T& new_value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/replace_if.hpp
+++ b/include/stl2/detail/algorithm/replace_if.hpp
@@ -23,9 +23,9 @@ STL2_OPEN_NAMESPACE {
 	// Extension: Relax to InputIterator
 	template <InputIterator I, Sentinel<I> S, class Pred, class T, class Proj = identity>
 	requires
-		models::Writable<I, const T&> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		Writable<I, const T&>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = Proj{})
 	{
 		if (first != last) {
@@ -41,9 +41,9 @@ STL2_OPEN_NAMESPACE {
 	// Extension: Relax to InputRange
 	template <InputRange Rng, class Pred, class T, class Proj = identity>
 	requires
-		models::Writable<iterator_t<Rng>, const T&> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		Writable<iterator_t<Rng>, const T&>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng> replace_if(Rng&& rng, Pred pred, const T& new_value,
 		Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/reverse.hpp
+++ b/include/stl2/detail/algorithm/reverse.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		// Complexity: n moves + n / 2 swaps
 		template <class I>
 		requires
-			models::Permutable<I>
+			Permutable<I>()
 		I reverse_n_with_half_buffer(I first, const difference_type_t<I> n,
 			temporary_buffer<value_type_t<I>>& buf)
 		{
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 		// From EoP
 		template <class I>
 		requires
-			models::Permutable<I>
+			Permutable<I>()
 		I reverse_n_adaptive(I first, const difference_type_t<I> n,
 			temporary_buffer<value_type_t<I>>& buf)
 		{
@@ -101,7 +101,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		requires
-			models::Permutable<I>
+			Permutable<I>()
 		I reverse_n(I first, difference_type_t<I> n)
 		{
 			auto ufirst = ext::uncounted(first);
@@ -116,7 +116,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalIterator I>
 	requires
-		models::Permutable<I>
+		Permutable<I>()
 	I reverse(I first, I last)
 	{
 		auto m = last;
@@ -129,7 +129,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessIterator I>
 	requires
-		models::Permutable<I>
+		Permutable<I>()
 	I reverse(I first, I last)
 	{
 		if (first != last) {
@@ -152,7 +152,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <Permutable I, Sentinel<I> S>
 	requires
-		models::BidirectionalIterator<I>
+		BidirectionalIterator<I>()
 	I reverse(I first, S last)
 	{
 		auto bound = __stl2::next(first, __stl2::move(last));
@@ -162,7 +162,7 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <ForwardRange Rng>
 	requires
-		models::Permutable<iterator_t<Rng>>
+		Permutable<iterator_t<Rng>>()
 	safe_iterator_t<Rng> reverse(Rng&& rng)
 	{
 		return detail::reverse_n(__stl2::begin(rng), __stl2::distance(rng));
@@ -170,7 +170,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng>
 	requires
-		models::Permutable<iterator_t<Rng>>
+		Permutable<iterator_t<Rng>>()
 	safe_iterator_t<Rng> reverse(Rng&& rng)
 	{
 		return __stl2::reverse(__stl2::begin(rng), __stl2::end(rng));

--- a/include/stl2/detail/algorithm/reverse_copy.hpp
+++ b/include/stl2/detail/algorithm/reverse_copy.hpp
@@ -24,7 +24,7 @@
 STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I, Sentinel<I> S, WeaklyIncrementable O>
 	requires
-		models::IndirectlyCopyable<I, O>
+		IndirectlyCopyable<I, O>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	reverse_copy(I first, S last, O result)
 	{
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	reverse_copy(Rng&& rng, O&& result)
 	{
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<const E*, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<const E*, __f<O>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	reverse_copy(std::initializer_list<E>&& rng, O&& result)
 	{

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -38,7 +38,7 @@
 STL2_OPEN_NAMESPACE {
 	template <class I>
 	requires
-		models::Permutable<I>
+		Permutable<I>()
 	ext::range<I> __rotate_left(I first, I last)
 	{
 		value_type_t<I> tmp = __stl2::iter_move(first);
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalIterator I>
 	requires
-		models::Permutable<I>
+		Permutable<I>()
 	ext::range<I> __rotate_right(I first, I last)
 	{
 		I lm1 = __stl2::prev(last);
@@ -104,7 +104,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessIterator I>
 	requires
-		models::Permutable<I>
+		Permutable<I>()
 	ext::range<I> __rotate_gcd(I first, I middle, I last)
 	{
 		using D = difference_type_t<I>;
@@ -204,7 +204,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng>
 	requires
-		models::Permutable<iterator_t<Rng>>
+		Permutable<iterator_t<Rng>>()
 	ext::range<safe_iterator_t<Rng>> rotate(Rng&& rng, iterator_t<Rng> middle)
 	{
 		return __stl2::rotate(__stl2::begin(rng), __stl2::move(middle), __stl2::end(rng));

--- a/include/stl2/detail/algorithm/rotate_copy.hpp
+++ b/include/stl2/detail/algorithm/rotate_copy.hpp
@@ -24,10 +24,10 @@
 STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, class F, class S, class O>
 	requires
-		models::Same<I, __f<F>> &&
-		models::Sentinel<__f<S>, I> &&
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<I, __f<O>>
+		Same<I, __f<F>>() &&
+		Sentinel<__f<S>, I>() &&
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<I, __f<O>>()
 	tagged_pair<tag::in(I), tag::out(__f<O>)>
 	rotate_copy(F&& first, I middle, S&& last, O&& out)
 	{
@@ -39,9 +39,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class M, class O>
 	requires
-		models::Same<iterator_t<Rng>, __f<M>> &&
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<iterator_t<Rng>, __f<O>>
+		Same<iterator_t<Rng>, __f<M>>() &&
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<iterator_t<Rng>, __f<O>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	rotate_copy(Rng&& rng, M&& middle, O&& result)
 	{
@@ -52,8 +52,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::IndirectlyCopyable<const E*, __f<O>>
+		WeaklyIncrementable<__f<O>>() &&
+		IndirectlyCopyable<const E*, __f<O>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	rotate_copy(std::initializer_list<E>&& rng, const E* middle, O&& result)
 	{

--- a/include/stl2/detail/algorithm/search.hpp
+++ b/include/stl2/detail/algorithm/search.hpp
@@ -38,8 +38,8 @@ STL2_OPEN_NAMESPACE {
 			ForwardIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
 			class Proj1 = identity, class Proj2 = identity>
 		requires
-			models::IndirectlyComparable<
-				I1, I2, Pred, Proj1, Proj2>
+			IndirectlyComparable<
+				I1, I2, Pred, Proj1, Proj2>()
 		I1 unsized(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred pred, Proj1 proj1, Proj2 proj2)
 		{
@@ -72,8 +72,8 @@ STL2_OPEN_NAMESPACE {
 			ForwardIterator I2, Sentinel<I2> S2,
 			class Pred, class Proj1, class Proj2>
 		requires
-			models::IndirectlyComparable<
-				I1, I2, Pred, Proj1, Proj2>
+			IndirectlyComparable<
+				I1, I2, Pred, Proj1, Proj2>()
 		I1 sized(
 			const I1 first1_, S1 last1, const difference_type_t<I1> d1_,
 			I2 first2, S2 last2, const difference_type_t<I2> d2,
@@ -104,8 +104,8 @@ STL2_OPEN_NAMESPACE {
 		ForwardIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			I1, I2, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			I1, I2, Pred, Proj1, Proj2>()
 	I1 search(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 						Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -119,10 +119,10 @@ STL2_OPEN_NAMESPACE {
 		ForwardIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::SizedSentinel<S1, I1> &&
-		models::SizedSentinel<S2, I2> &&
-		models::IndirectlyComparable<
-			I1, I2, Pred, Proj1, Proj2>
+		SizedSentinel<S1, I1>() &&
+		SizedSentinel<S2, I2>() &&
+		IndirectlyComparable<
+			I1, I2, Pred, Proj1, Proj2>()
 	I1 search(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -136,8 +136,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>()
 	safe_iterator_t<Rng1> search(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -152,9 +152,9 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 						class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::SizedRange<Rng1> && models::SizedRange<Rng2> &&
-		models::IndirectlyComparable<
-			iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>
+		SizedRange<Rng1>() && SizedRange<Rng2>() &&
+		IndirectlyComparable<
+			iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>()
 	safe_iterator_t<Rng1> search(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
@@ -169,8 +169,8 @@ STL2_OPEN_NAMESPACE {
 	template <class E, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			const E*, iterator_t<Rng2>, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			const E*, iterator_t<Rng2>, Pred, Proj1, Proj2>()
 	dangling<const E*>
 	search(std::initializer_list<E>&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -183,8 +183,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, class E, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			iterator_t<Rng1>, const E*, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			iterator_t<Rng1>, const E*, Pred, Proj1, Proj2>()
 	safe_iterator_t<Rng1>
 	search(Rng1&& rng1, std::initializer_list<E>&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -197,8 +197,8 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class Pred = equal_to<>,
 						class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::IndirectlyComparable<
-			const E1*, const E2*, Pred, Proj1, Proj2>
+		IndirectlyComparable<
+			const E1*, const E2*, Pred, Proj1, Proj2>()
 	dangling<const E1*>
 	search(std::initializer_list<E1>&& rng1,
 		std::initializer_list<E2>&& rng2, Pred pred = Pred{},

--- a/include/stl2/detail/algorithm/search_n.hpp
+++ b/include/stl2/detail/algorithm/search_n.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __search_n {
 		template <ForwardIterator I, Sentinel<I> S, class T, class Pred, class Proj>
 		requires
-			models::IndirectlyComparable<I, const T*, Pred, Proj>
+			IndirectlyComparable<I, const T*, Pred, Proj>()
 		I unsized(I first, S last, difference_type_t<I> count,
 			const T& value, Pred pred, Proj proj)
 		{
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <ForwardIterator I, Sentinel<I> S, class T, class Pred, class Proj>
 		requires
-			models::IndirectlyComparable<I, const T*, Pred, Proj>
+			IndirectlyComparable<I, const T*, Pred, Proj>()
 		I sized(I first_, S last, difference_type_t<I> d_,
 			difference_type_t<I> count,
 			const T& value, Pred pred, Proj proj)
@@ -100,7 +100,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectlyComparable<I, const T*, Pred, Proj>
+		IndirectlyComparable<I, const T*, Pred, Proj>()
 	I search_n(I first, S last, difference_type_t<I> count,
 						 const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -111,8 +111,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::SizedSentinel<S, I> &&
-		models::IndirectlyComparable<I, const T*, Pred, Proj>
+		SizedSentinel<S, I>() &&
+		IndirectlyComparable<I, const T*, Pred, Proj>()
 	I search_n(I first, S last, difference_type_t<I> count,
 						 const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -123,8 +123,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectlyComparable<
-			iterator_t<Rng>, const T*, Pred, Proj>
+		IndirectlyComparable<
+			iterator_t<Rng>, const T*, Pred, Proj>()
 	safe_iterator_t<Rng>
 	search_n(Rng&& rng, difference_type_t<iterator_t<Rng>> count,
 		const T& value, Pred pred = Pred{}, Proj proj = Proj{})
@@ -136,9 +136,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::SizedRange<Rng> &&
-		models::IndirectlyComparable<
-			iterator_t<Rng>, const T*, Pred, Proj>
+		SizedRange<Rng>() &&
+		IndirectlyComparable<
+			iterator_t<Rng>, const T*, Pred, Proj>()
 	safe_iterator_t<Rng>
 	search_n(Rng&& rng, difference_type_t<iterator_t<Rng>> count,
 		const T& value, Pred pred = Pred{}, Proj proj = Proj{})
@@ -151,8 +151,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class E, class T, class Pred = equal_to<>, class Proj = identity>
 	requires
-		models::IndirectlyComparable<
-			const E*, const T*, Pred, Proj>
+		IndirectlyComparable<
+			const E*, const T*, Pred, Proj>()
 	dangling<const E*>
 	search_n(std::initializer_list<E>&& rng, std::ptrdiff_t count,
 		const T& value, Pred pred = Pred{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		WeaklyIncrementable O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		Mergeable<I1, I2, O, Comp, Proj1, Proj2>()
 	tagged_pair<tag::in(I1), tag::out(O)>
 	set_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -56,10 +56,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_pair<tag::in(safe_iterator_t<Rng1>), tag::out(__f<O>)>
 	set_difference(Rng1&& rng1, Rng2&& rng2, O&& result, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -74,10 +74,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E*, iterator_t<Rng2>,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	set_difference(std::initializer_list<E>&& rng1,
 		Rng2&& rng2, O&& result, Comp comp = Comp{},
@@ -93,10 +93,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, const E*,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_pair<tag::in(safe_iterator_t<Rng1>), tag::out(__f<O>)>
 	set_difference(Rng1&& rng1, std::initializer_list<E>&& rng2,
 								 O&& result, Comp comp = Comp{},
@@ -112,10 +112,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E1*, const E2*,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_pair<tag::in(dangling<const E1*>), tag::out(__f<O>)>
 	set_difference(std::initializer_list<E1>&& rng1,
 		std::initializer_list<E2>&& rng2,

--- a/include/stl2/detail/algorithm/set_intersection.hpp
+++ b/include/stl2/detail/algorithm/set_intersection.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 		WeaklyIncrementable O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		Mergeable<I1, I2, O, Comp, Proj1, Proj2>()
 	O set_intersection(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{},
 		Proj2 proj2 = Proj2{})
@@ -54,10 +54,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	__f<O>
 	set_intersection(Rng1&& rng1, Rng2&& rng2, O&& result, Comp comp = Comp{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -72,10 +72,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E*, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	__f<O>
 	set_intersection(std::initializer_list<E>&& rng1, Rng2&& rng2,
 		O&& result, Comp comp = Comp{},
@@ -91,10 +91,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, const E*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	__f<O>
 	set_intersection(Rng1&& rng1, std::initializer_list<E>&& rng2,
 		O&& result, Comp comp = Comp{},
@@ -110,10 +110,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E1*, const E2*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	__f<O>
 	set_intersection(std::initializer_list<E1>&& rng1,
 		std::initializer_list<E2>&& rng2, O&& result, Comp comp = Comp{},

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		WeaklyIncrementable O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		Mergeable<I1, I2, O, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
 	set_symmetric_difference(
 		I1 first1, S1 last1, I2 first2, S2 last2, O result,
@@ -73,10 +73,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, iterator_t<Rng2>,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>),
 							 tag::in2(safe_iterator_t<Rng2>), tag::out(__f<O>)>
 	set_symmetric_difference(Rng1&& rng1, Rng2&& rng2, O&& result,
@@ -92,10 +92,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E*, iterator_t<Rng2>,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E*>),
 		tag::in2(safe_iterator_t<Rng2>), tag::out(__f<O>)>
 	set_symmetric_difference(std::initializer_list<E>&& rng1, Rng2&& rng2, O&& result,
@@ -111,10 +111,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, const E*,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>),
 							 tag::in2(dangling<const E*>), tag::out(__f<O>)>
 	set_symmetric_difference(Rng1&& rng1, std::initializer_list<E>&& rng2, O&& result,
@@ -130,10 +130,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E1*, const E2*,
-			__f<O>, Comp, Proj1, Proj2>
+			__f<O>, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E1*>),
 							 tag::in2(dangling<const E2*>), tag::out(__f<O>)>
 	set_symmetric_difference(std::initializer_list<E1>&& rng1,

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		WeaklyIncrementable O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		Mergeable<I1, I2, O, Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
 	set_union(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -67,10 +67,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>),
 		tag::in2(safe_iterator_t<Rng2>), tag::out(__f<O>)>
 	set_union(Rng1&& rng1, Rng2&& rng2, O&& result, Comp comp = Comp{},
@@ -87,10 +87,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E, InputRange Rng2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E*, iterator_t<Rng2>, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E*>),
 		tag::in2(safe_iterator_t<Rng2>), tag::out(__f<O>)>
 	set_union(std::initializer_list<E>&& rng1, Rng2&& rng2, O&& result,
@@ -107,10 +107,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, class E, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			iterator_t<Rng1>, const E*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(safe_iterator_t<Rng1>),
 		tag::in2(dangling<const E*>), tag::out(__f<O>)>
 	set_union(Rng1&& rng1, std::initializer_list<E>&& rng2, O&& result,
@@ -127,10 +127,10 @@ STL2_OPEN_NAMESPACE {
 	template <class E1, class E2, class O, class Comp = less<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
-		models::Mergeable<
+		WeaklyIncrementable<__f<O>>() &&
+		Mergeable<
 			const E1*, const E2*, __f<O>,
-			Comp, Proj1, Proj2>
+			Comp, Proj1, Proj2>()
 	tagged_tuple<tag::in1(dangling<const E1*>),
 		tag::in2(dangling<const E2*>), tag::out(__f<O>)>
 	set_union(std::initializer_list<E1>&& rng1,

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -27,9 +27,9 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S,
 		class Gen = detail::default_random_engine&, class D = difference_type_t<I>>
 	requires
-		models::Permutable<I> &&
-		models::UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-		models::ConvertibleTo<result_of_t<Gen&()>, D>
+		Permutable<I>() &&
+		UniformRandomNumberGenerator<remove_reference_t<Gen>>() &&
+		ConvertibleTo<result_of_t<Gen&()>, D>()
 	I shuffle(I const first, S const last, Gen&& g = detail::get_random_engine())
 	{
 		auto mid = first;
@@ -49,9 +49,9 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessRange Rng, class Gen = detail::default_random_engine&,
 		class D = difference_type_t<iterator_t<Rng>>>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-		models::ConvertibleTo<result_of_t<Gen&()>, D>
+		Permutable<iterator_t<Rng>>() &&
+		UniformRandomNumberGenerator<remove_reference_t<Gen>>() &&
+		ConvertibleTo<result_of_t<Gen&()>, D>()
 	inline safe_iterator_t<Rng> shuffle(
 		Rng&& rng, Gen&& g = detail::get_random_engine())
 	{

--- a/include/stl2/detail/algorithm/sort.hpp
+++ b/include/stl2/detail/algorithm/sort.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I sort(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S, class Comp = less<>,
 		class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I sort(I first, S sent, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		if (first == sent) {
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	sort(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	sort(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/sort_heap.hpp
+++ b/include/stl2/detail/algorithm/sort_heap.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
-			models::Sortable<I, Comp, Proj>
+			Sortable<I, Comp, Proj>()
 		void sort_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
 		{
 			if (n < 2) {
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S,
 						class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<I, Comp, Proj>
+		Sortable<I, Comp, Proj>()
 	I sort_heap(I first, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	sort_heap(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 			template <ForwardIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			ext::range<I>
 			forward_buffer(I first, I next, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 			template <ForwardIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			ext::range<I>
 			forward_reduce(I first, difference_type_t<I> n, buf_t<I>& buf,
 				Pred& pred, Proj& proj);
@@ -83,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 			template <ForwardIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			ext::range<I>
 			forward(I first, difference_type_t<I> n, buf_t<I>& buf, Pred& pred,
 				Proj& proj)
@@ -114,7 +114,7 @@ STL2_OPEN_NAMESPACE {
 			template <ForwardIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			ext::range<I>
 			forward_reduce(I first, difference_type_t<I> n, buf_t<I>& buf,
 				Pred& pred, Proj& proj)
@@ -146,7 +146,7 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional_buffer(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -177,21 +177,21 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional_reduce_front(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj);
 
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional_reduce_back(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj);
 
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -225,7 +225,7 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional_reduce_front(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -243,7 +243,7 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class Proj,
 				IndirectPredicate<projected<I, Proj>> Pred>
 			requires
-				models::Permutable<I>
+				Permutable<I>()
 			I bidirectional_reduce_back(I first, I last, difference_type_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -263,9 +263,9 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <ForwardIterator I, class Pred, class Proj = identity>
 		requires
-			models::Permutable<I> &&
-			models::IndirectPredicate<
-				Pred, projected<I, Proj>>
+			Permutable<I>() &&
+			IndirectPredicate<
+				Pred, projected<I, Proj>>()
 		I stable_partition_n(I first, difference_type_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
@@ -287,9 +287,9 @@ STL2_OPEN_NAMESPACE {
 
 		template <BidirectionalIterator I, class Pred, class Proj = identity>
 		requires
-			models::Permutable<I> &&
-			models::IndirectPredicate<
-				Pred, projected<I, Proj>>
+			Permutable<I>() &&
+			IndirectPredicate<
+				Pred, projected<I, Proj>>()
 		I stable_partition_n(I first, I last, difference_type_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
@@ -319,9 +319,9 @@ STL2_OPEN_NAMESPACE {
 
 		template <BidirectionalIterator I, class Pred, class Proj = identity>
 		requires
-			models::Permutable<I> &&
-			models::IndirectPredicate<
-				Pred, projected<I, Proj>>
+			Permutable<I>() &&
+			IndirectPredicate<
+				Pred, projected<I, Proj>>()
 		I stable_partition_n(I first, difference_type_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
@@ -334,9 +334,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardIterator I, Sentinel<I> S, class Pred, class Proj = identity>
 	requires
-		models::Permutable<I> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		Permutable<I>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I stable_partition(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::move(last));
@@ -348,9 +348,9 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I, Sentinel<I> S, class Pred,
 		class Proj = identity>
 	requires
-		models::Permutable<I> &&
-		models::IndirectPredicate<
-			Pred, projected<I, Proj>>
+		Permutable<I>() &&
+		IndirectPredicate<
+			Pred, projected<I, Proj>>()
 	I stable_partition(I first, S last, Pred pred, Proj proj = Proj{})
 	{
 		auto bound = ext::enumerate(first, __stl2::move(last));
@@ -361,9 +361,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
@@ -374,9 +374,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <BidirectionalRange Rng, class Pred, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectPredicate<
+			Pred, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	stable_partition(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/stable_sort.hpp
+++ b/include/stl2/detail/algorithm/stable_sort.hpp
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			void inplace_stable_sort(I first, I last, C &pred, P &proj)
 			{
 				if (last - first < 15) {
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, WeaklyIncrementable O, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			void merge_sort_loop(I first, I last, O result,
 				difference_type_t<I> step_size, C &pred, P &proj)
 			{
@@ -102,7 +102,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			void chunk_insertion_sort(I first, I last, difference_type_t<I> chunk_size,
 				C &comp, P &proj)
 			{
@@ -115,7 +115,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			void merge_sort_with_buffer(I first, I last, buf_t<I>& buf, C &comp, P &proj)
 			{
 				auto len = difference_type_t<I>(last - first);
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <RandomAccessIterator I, class C, class P>
 			requires
-				models::Sortable<I, C, P>
+				Sortable<I, C, P>()
 			void stable_sort_adaptive(I first, I last, buf_t<I>& buf, C &comp, P &proj)
 			{
 				auto len = difference_type_t<I>((last - first + 1) / 2);
@@ -162,8 +162,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension: Supports forward iterators.
 	template <class I, class S, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sentinel<__f<S>, I> &&
-		models::Sortable<I, Comp, Proj>
+		Sentinel<__f<S>, I>() &&
+		Sortable<I, Comp, Proj>()
 	I stable_sort(I first, S&& last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, __stl2::forward<S>(last));
@@ -174,8 +174,8 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, class S, class Comp = less<>,
 						class Proj = identity>
 	requires
-		models::Sentinel<__f<S>, I> &&
-		models::Sortable<I, Comp, Proj>
+		Sentinel<__f<S>, I>() &&
+		Sortable<I, Comp, Proj>()
 	I stable_sort(I first, S&& last_, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto last = __stl2::next(first, __stl2::forward<S>(last_));
@@ -193,7 +193,7 @@ STL2_OPEN_NAMESPACE {
 	// Extension: supports forward ranges.
 	template <ForwardRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	stable_sort(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -203,7 +203,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <RandomAccessRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		models::Sortable<iterator_t<Rng>, Comp, Proj>
+		Sortable<iterator_t<Rng>, Comp, Proj>()
 	safe_iterator_t<Rng>
 	stable_sort(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/swap_ranges.hpp
+++ b/include/stl2/detail/algorithm/swap_ranges.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __swap_ranges {
 		template <ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2>
 		requires
-			models::IndirectlySwappable<I1, I2>
+			IndirectlySwappable<I1, I2>()
 		constexpr tagged_pair<tag::in1(I1), tag::in2(I2)>
 		impl(I1 first1, S1 last1, I2 first2)
 		{
@@ -38,10 +38,10 @@ STL2_OPEN_NAMESPACE {
 	[[deprecated]] tagged_pair<tag::in1(__f<I1>), tag::in2(__f<I2>)>
 	swap_ranges(I1&& first1, S1&& last1, I2&& first2)
 	requires
-		models::ForwardIterator<__f<I1>> &&
-		models::Sentinel<__f<S1>, __f<I1>> &&
-		models::ForwardIterator<__f<I2>> &&
-		models::IndirectlySwappable<__f<I1>, __f<I2>>
+		ForwardIterator<__f<I1>>() &&
+		Sentinel<__f<S1>, __f<I1>>() &&
+		ForwardIterator<__f<I2>>() &&
+		IndirectlySwappable<__f<I1>, __f<I2>>()
 	{
 		return __swap_ranges::impl(
 			std::forward<I1>(first1), std::forward<S1>(last1),
@@ -53,8 +53,8 @@ STL2_OPEN_NAMESPACE {
 	swap_ranges(Rng&& rng1, I&& first2_)
 	requires
 		!is_array<remove_reference_t<I>>::value &&
-		models::ForwardIterator<__f<I>> &&
-		models::IndirectlySwappable<iterator_t<Rng>, __f<I>>
+		ForwardIterator<__f<I>>() &&
+		IndirectlySwappable<iterator_t<Rng>, __f<I>>()
 	{
 		auto first2 = std::forward<I>(first2_);
 		return __swap_ranges::impl(__stl2::begin(rng1), __stl2::end(rng1), std::move(first2));
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I1, Sentinel<I1> S1,
 		ForwardIterator I2, Sentinel<I2> S2>
 	requires
-		models::IndirectlySwappable<I1, I2>
+		IndirectlySwappable<I1, I2>()
 	tagged_pair<tag::in1(I1), tag::in2(I2)>
 	swap_ranges(I1 first1, S1 last1, I2 first2, S2 last2)
 	{
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng1, ForwardRange Rng2>
 	requires
-		models::IndirectlySwappable<iterator_t<Rng1>, iterator_t<Rng2>>
+		IndirectlySwappable<iterator_t<Rng1>, iterator_t<Rng2>>()
 	tagged_pair<tag::in1(safe_iterator_t<Rng1>),
 							tag::in2(safe_iterator_t<Rng2>)>
 	swap_ranges(Rng1&& rng1, Rng2&& rng2)

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -27,8 +27,8 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
 		CopyConstructible F, class Proj = identity>
 	requires
-		models::Writable<O,
-			indirect_result_of_t<F&(projected<I, Proj>)>>
+		Writable<O,
+			indirect_result_of_t<F&(projected<I, Proj>)>>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	transform(I first, S last, O result, F op, Proj proj = Proj{})
 	{
@@ -40,8 +40,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange R, WeaklyIncrementable O, CopyConstructible F, class Proj = identity>
 	requires
-		models::Writable<O,
-			indirect_result_of_t<F&(projected<iterator_t<R>, Proj>)>>
+		Writable<O,
+			indirect_result_of_t<F&(projected<iterator_t<R>, Proj>)>>()
 	tagged_pair<tag::in(safe_iterator_t<R>), tag::out(O)>
 	transform(R&& r, O result, F op, Proj proj = Proj{})
 	{
@@ -57,10 +57,10 @@ STL2_OPEN_NAMESPACE {
 	transform(I1 first1, S1 last1, I2 first2, O result,
 		F op, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
-		models::Writable<O,
+		Writable<O,
 			indirect_result_of_t<F&(
 				projected<I1, Proj1>,
-				projected<I2, Proj2>)>>
+				projected<I2, Proj2>)>>()
 	{
 		for (; first1 != last1; ++first1, ++first2, ++result) {
 			*result = __stl2::invoke(op, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2));
@@ -77,11 +77,11 @@ STL2_OPEN_NAMESPACE {
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
 		!is_array<remove_reference_t<I>>::value &&
-		models::InputIterator<__f<I>> &&
-		models::Writable<O,
+		InputIterator<__f<I>>() &&
+		Writable<O,
 			indirect_result_of_t<F&(
 				projected<iterator_t<Rng>, Proj1>,
-				projected<__f<I>, Proj2>)>>
+				projected<__f<I>, Proj2>)>>()
 	{
 		auto first2 = std::forward<I>(first2_);
 		return __stl2::transform(
@@ -96,10 +96,10 @@ STL2_OPEN_NAMESPACE {
 		WeaklyIncrementable O, CopyConstructible F,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Writable<O,
+		Writable<O,
 			indirect_result_of_t<F&(
 				projected<I1, Proj1>,
-				projected<I2, Proj2>)>>
+				projected<I2, Proj2>)>>()
 	tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
 	transform(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 		F op, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -113,10 +113,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, WeaklyIncrementable O, CopyConstructible F,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		models::Writable<O,
+		Writable<O,
 			indirect_result_of_t<F&(
 				projected<iterator_t<Rng1>, Proj1>,
-				projected<iterator_t<Rng2>, Proj2>)>>
+				projected<iterator_t<Rng2>, Proj2>)>>()
 	tagged_tuple<
 		tag::in1(safe_iterator_t<Rng1>),
 		tag::in2(safe_iterator_t<Rng2>),

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -26,8 +26,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S,
 		class R = equal_to<>, class Proj = identity>
 	requires
-		models::Permutable<I> &&
-		models::IndirectRelation<__f<R>, projected<I, Proj>>
+		Permutable<I>() &&
+		IndirectRelation<__f<R>, projected<I, Proj>>()
 	I unique(I first, S last, R comp = R{}, Proj proj = Proj{})
 	{
 		first = __stl2::adjacent_find(
@@ -45,9 +45,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class R = equal_to<>, class Proj = identity>
 	requires
-		models::Permutable<iterator_t<Rng>> &&
-		models::IndirectRelation<
-			__f<R>, projected<iterator_t<Rng>, Proj>>
+		Permutable<iterator_t<Rng>>() &&
+		IndirectRelation<
+			__f<R>, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	unique(Rng&& rng, R comp = R{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -84,20 +84,20 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class O>
 	constexpr bool __unique_copy_req =
-		models::IndirectlyCopyable<I, O> &&
-			(models::ForwardIterator<I> ||
-			 models::ForwardIterator<O> ||
-			 models::IndirectlyCopyableStorable<I, O>);
+		IndirectlyCopyable<I, O>() &&
+			(ForwardIterator<I>() ||
+			 ForwardIterator<O>() ||
+			 IndirectlyCopyableStorable<I, O>());
 
 	template <class I, class S, class O, class R = equal_to<>,
 		class Proj = identity>
 	requires
-		models::InputIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::WeaklyIncrementable<__f<O>> &&
+		InputIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		WeaklyIncrementable<__f<O>>() &&
 		__unique_copy_req<__f<I>, __f<O>> &&
-		models::IndirectRelation<
-			__f<R>, projected<__f<I>, Proj>>
+		IndirectRelation<
+			__f<R>, projected<__f<I>, Proj>>()
 	tagged_pair<tag::in(__f<I>), tag::out(__f<O>)>
 	unique_copy(I&& first, S&& last, O&& result, R comp = R{},
 		Proj proj = Proj{})
@@ -114,10 +114,10 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng, class O, class R = equal_to<>,
 		class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
+		WeaklyIncrementable<__f<O>>() &&
 		__unique_copy_req<iterator_t<Rng>, __f<O>> &&
-		models::IndirectRelation<
-			__f<R>, projected<iterator_t<Rng>, Proj>>
+		IndirectRelation<
+			__f<R>, projected<iterator_t<Rng>, Proj>>()
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	unique_copy(Rng&& rng, O&& result, R comp = R{}, Proj proj = Proj{})
 	{
@@ -133,10 +133,10 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class O, class R = equal_to<>, class Proj = identity>
 	requires
-		models::WeaklyIncrementable<__f<O>> &&
+		WeaklyIncrementable<__f<O>>() &&
 		__unique_copy_req<const E*, __f<O>> &&
-		models::IndirectRelation<
-			__f<R>, projected<const E*, Proj>>
+		IndirectRelation<
+			__f<R>, projected<const E*, Proj>>()
 	tagged_pair<tag::in(dangling<const E*>), tag::out(__f<O>)>
 	unique_copy(std::initializer_list<E>&& rng, O&& result, R comp = R{},
 		Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/upper_bound.hpp
+++ b/include/stl2/detail/algorithm/upper_bound.hpp
@@ -38,9 +38,9 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <class I, class T, class Comp = less<>, class Proj = identity>
 		requires
-			models::ForwardIterator<__f<I>> &&
-			models::IndirectStrictWeakOrder<
-				Comp, const T*, projected<__f<I>, Proj>>
+			ForwardIterator<__f<I>>() &&
+			IndirectStrictWeakOrder<
+				Comp, const T*, projected<__f<I>, Proj>>()
 		__f<I> upper_bound_n(I&& first, difference_type_t<__f<I>> n, const T& value,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
@@ -52,10 +52,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::ForwardIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<__f<I>, Proj>>
+		ForwardIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<__f<I>, Proj>>()
 	__f<I> upper_bound(I&& first, S&& last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -67,11 +67,11 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::SizedSentinel<__f<S>, __f<I>> &&
-		models::ForwardIterator<__f<I>> &&
-		models::Sentinel<__f<S>, __f<I>> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<__f<I>, Proj>>
+		SizedSentinel<__f<S>, __f<I>>() &&
+		ForwardIterator<__f<I>>() &&
+		Sentinel<__f<S>, __f<I>>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<__f<I>, Proj>>()
 	__f<I> upper_bound(I&& first_, S&& last, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
 	{
@@ -83,8 +83,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	upper_bound(Rng&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
@@ -95,9 +95,9 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::SizedRange<Rng> &&
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		SizedRange<Rng>() &&
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<iterator_t<Rng>, Proj>>()
 	safe_iterator_t<Rng>
 	upper_bound(Rng&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})
@@ -109,8 +109,8 @@ STL2_OPEN_NAMESPACE {
 	// Extension
 	template <class E, class T, class Comp = less<>, class Proj = identity>
 	requires
-		models::IndirectStrictWeakOrder<
-			Comp, const T*, projected<const E*, Proj>>
+		IndirectStrictWeakOrder<
+			Comp, const T*, projected<const E*, Proj>>()
 	dangling<const E*>
 	upper_bound(std::initializer_list<E>&& rng, const T& value,
 		Comp comp = Comp{}, Proj proj = Proj{})

--- a/include/stl2/detail/cheap_storage.hpp
+++ b/include/stl2/detail/cheap_storage.hpp
@@ -27,14 +27,14 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool cheaply_copyable = false;
 		template <class T>
 		requires
-			models::CopyConstructible<T> &&
+			CopyConstructible<T>() &&
 			std::is_trivially_copyable<T>::value &&
 			((_Is<T, std::is_empty> && !_Is<T, std::is_final>) ||
 				sizeof(T) <= cheap_copy_size)
 		constexpr bool cheaply_copyable<T> = true;
 
 		template <class T, class Tag = void>
-		requires models::Addressable<T>
+		requires ext::Addressable<T>()
 		class ref_box {
 		public:
 			ref_box() = default;
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 
 		// Note: promotes to CopyConstructible
 		template <class T, class Tag = void>
-		requires models::Addressable<T>
+		requires ext::Addressable<T>()
 		using cheap_reference_box_t = meta::if_c<
 			cheaply_copyable<remove_cv_t<T>>,
 			ebo_box<remove_cv_t<T>, Tag>,

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 	// See https://github.com/ericniebler/stl2/issues/238
 	template <class F, class...Is>
 	requires
-		models::Invocable<F, reference_t<Is>...>
+		Invocable<F, reference_t<Is>...>()
 	struct indirect_result_of<F(Is...)>
 	: result_of<F(reference_t<Is>...)> {};
 

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -17,7 +17,7 @@
 #include <stl2/detail/fwd.hpp>
 #include <stl2/detail/meta.hpp>
 #include <stl2/detail/concepts/core.hpp>
-#include <stl2/detail/concepts/object/move_constructible.hpp>
+#include <stl2/detail/concepts/object/movable.hpp>
 
 /////////////////////////////////////////////
 // Comparison Concepts [concepts.lib.compare]
@@ -25,39 +25,36 @@
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// Boolean [concepts.lib.compare.boolean]
+	// Not to spec: see https://github.com/ericniebler/stl2/issues/155
 	//
-	template <class>
-	constexpr bool __boolean = false;
-	template <class B>
-		requires requires(const B& b1, const B& b2, const bool a) {
-			// Requirements common to both Boolean and BooleanTestable.
-			STL2_BINARY_DEDUCTION_CONSTRAINT(b1, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(!b1, ConvertibleTo, bool);
-			STL2_EXACT_TYPE_CONSTRAINT(b1 && a, bool);
-			STL2_EXACT_TYPE_CONSTRAINT(b1 || a, bool);
-
-			// Requirements of Boolean that are also be valid for
-			// BooleanTestable, but for which BooleanTestable does not
-			// require validation.
-			STL2_EXACT_TYPE_CONSTRAINT(b1 && b2, bool);
-			STL2_EXACT_TYPE_CONSTRAINT(a && b2, bool);
-			STL2_EXACT_TYPE_CONSTRAINT(b1 || b2, bool);
-			STL2_EXACT_TYPE_CONSTRAINT(a || b2, bool);
-
-			// Requirements of Boolean that are not required by
-			// BooleanTestable.
-			STL2_BINARY_DEDUCTION_CONSTRAINT(b1 == b2, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(b1 == a, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(a == b2, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(b1 != b2, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(b1 != a, ConvertibleTo, bool);
-			STL2_BINARY_DEDUCTION_CONSTRAINT(a != b2, ConvertibleTo, bool);
-		}
-	constexpr bool __boolean<B> = true;
-
 	template <class B>
 	concept bool Boolean() {
-		return MoveConstructible<B>() && __boolean<B>;
+		return Movable<decay_t<B>>() &&
+			requires(const remove_reference_t<B>& b1,
+					 const remove_reference_t<B>& b2, const bool a) {
+				// Requirements common to both Boolean and BooleanTestable.
+				{ b1 } -> ConvertibleTo<bool>&&;
+				{ !b1 } -> ConvertibleTo<bool>&&;
+				{ b1 && a } ->  Same<bool>&&;
+				{ b1 || a } ->  Same<bool>&&;
+
+				// Requirements of Boolean that are also be valid for
+				// BooleanTestable, but for which BooleanTestable does not
+				// require validation.
+				{ b1 && b2 } -> Same<bool>&&;
+				{ a && b2  } -> Same<bool>&&;
+				{ b1 || b2 } -> Same<bool>&&;
+				{ a || b2  } -> Same<bool>&&;
+
+				// Requirements of Boolean that are not required by
+				// BooleanTestable.
+				{ b1 == b2 } -> ConvertibleTo<bool>&&;
+				{ b1 == a  } -> ConvertibleTo<bool>&&;
+				{ a == b2  } -> ConvertibleTo<bool>&&;
+				{ b1 != b2 } -> ConvertibleTo<bool>&&;
+				{ b1 != a  } -> ConvertibleTo<bool>&&;
+				{ a != b2  } -> ConvertibleTo<bool>&&;
+			};
 	}
 
 	namespace models {
@@ -66,18 +63,6 @@ STL2_OPEN_NAMESPACE {
 		__stl2::Boolean{B}
 		constexpr bool Boolean<B> = true;
 	}
-
-	template <class T, class U>
-	constexpr bool __equality_comparable = false;
-	template <class T, class U>
-	requires
-		requires(const T& t, const U& u) {
-			STL2_DEDUCTION_CONSTRAINT(t == u, Boolean);
-			STL2_DEDUCTION_CONSTRAINT(t != u, Boolean);
-			// Axiom: t == u and t != u have the same definition space
-			// Axiom: bool(t != u) == !bool(t == u)
-		}
-	constexpr bool __equality_comparable<T, U> = true;
 
 	///////////////////////////////////////////////////////////////////////////
 	// WeaklyEqualityComparable [concepts.lib.compare.equalitycomparable]
@@ -88,10 +73,15 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <class T, class U>
 	concept bool WeaklyEqualityComparable() {
-		return __equality_comparable<T, U> &&
-			__equality_comparable<U, T>;
-		// Axiom: u == t and t == u have the same definition space
-		// Axiom: bool(u == t) == bool(t == u)
+		return requires(const remove_reference_t<T>& t,
+		                const remove_reference_t<U>& u) {
+			{ t == u } -> Boolean&&;
+			{ t != u } -> Boolean&&;
+			{ u == t } -> Boolean&&;
+			{ u != t } -> Boolean&&;
+			// Axiom: t == u and t != u have the same definition space
+			// Axiom: bool(t != u) == !bool(t == u)
+		};
 	}
 
 	namespace models {
@@ -115,8 +105,13 @@ STL2_OPEN_NAMESPACE {
 			EqualityComparable<T>() &&
 			EqualityComparable<U>() &&
 			WeaklyEqualityComparable<T, U>() &&
-			CommonReference<const T&, const U&>() &&
-			EqualityComparable<__uncvref<common_reference_t<const T&, const U&>>>();
+			CommonReference<
+				const remove_reference_t<T>&,
+				const remove_reference_t<U>&>() &&
+			EqualityComparable<
+				common_reference_t<
+					const remove_reference_t<T>&,
+					const remove_reference_t<U>&>>();
 	}
 
 	namespace models {
@@ -132,20 +127,19 @@ STL2_OPEN_NAMESPACE {
 	// StrictTotallyOrdered [concepts.lib.compare.stricttotallyordered]
 	//
 	template <class T, class U>
-	constexpr bool __totally_ordered = false;
-	template <class T, class U>
-		requires requires(const T& t, const U& u) {
-			STL2_DEDUCTION_CONSTRAINT(t < u, Boolean);
-			STL2_DEDUCTION_CONSTRAINT(t > u, Boolean);
-			STL2_DEDUCTION_CONSTRAINT(t <= u, Boolean);
-			STL2_DEDUCTION_CONSTRAINT(t >= u, Boolean);
+	concept bool __totally_ordered =
+		requires(const remove_reference_t<T>& t,
+		         const remove_reference_t<U>& u) {
+			{ t < u  } -> Boolean&&;
+			{ t > u  } -> Boolean&&;
+			{ t <= u } -> Boolean&&;
+			{ t >= u } -> Boolean&&;
 			// Axiom: t < u, t > u, t <= u, t >= u have the same definition space.
 			// Axiom: If bool(t < u) then bool(t <= u)
 			// Axiom: If bool(t > u) then bool(t >= u)
 			// Axiom: Exactly one of bool(t < u), bool(t > u), or
 			//        (bool(t <= u) && bool(t >= u)) is true
-		}
-	constexpr bool __totally_ordered<T, U> = true;
+		};
 
 	template <class T>
 	concept bool StrictTotallyOrdered() {
@@ -160,8 +154,13 @@ STL2_OPEN_NAMESPACE {
 			EqualityComparable<T, U>() &&
 			__totally_ordered<T, U> &&
 			__totally_ordered<U, T> &&
-			CommonReference<const T&, const U&>() &&
-			StrictTotallyOrdered<__uncvref<common_reference_t<const T&, const U&>>>();
+			CommonReference<
+				const remove_reference_t<T>&,
+				const remove_reference_t<U>&>() &&
+			StrictTotallyOrdered<
+				common_reference_t<
+					const remove_reference_t<T>&,
+					const remove_reference_t<U>&>>();
 	}
 
 	namespace models {

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	// the decayed type can in fact be constructed from the actual type.
 	//
 	template <class T>
-		requires models::Constructible<decay_t<T>, T>
+		requires Constructible<decay_t<T>, T>()
 	using __f = decay_t<T>;
 
 

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -24,20 +24,13 @@ STL2_OPEN_NAMESPACE {
 	//
 	// Not to spec
 	// See https://github.com/ericniebler/stl2/issues/229
-	template <class, class>
-	constexpr bool __assignable = false;
-	template <class T, class U>
-	requires
-		requires(T& t, U&& u) {
-			STL2_EXACT_TYPE_CONSTRAINT(t = (U&&)u, T&);
-		}
-	constexpr bool __assignable<T&, U> = true;
-
 	template <class T, class U>
 	concept bool Assignable() {
 		return _Is<T, is_lvalue_reference> &&
 		    CommonReference<T, const U&>() &&
-			__assignable<T, U>;
+			requires(T t, U&& u) {
+				{ t = (U&&)u } -> Same<T>&&;
+			};
 	}
 
 	namespace models {

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -27,7 +27,9 @@ STL2_OPEN_NAMESPACE {
 	template <class T, class U>
 	concept bool Assignable() {
 		return _Is<T, is_lvalue_reference> &&
-		    CommonReference<T, const U&>() &&
+		    CommonReference<
+				const remove_reference_t<T>&,
+				const remove_reference_t<U>&>() &&
 			requires(T t, U&& u) {
 				{ t = (U&&)u } -> Same<T>&&;
 			};

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -22,15 +22,13 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// Addressable [Extension]
 	//
-	template <class>
-	constexpr bool __addressable = false;
 	template <class T>
-		requires requires(T& t, const remove_reference_t<T>& ct) {
-			STL2_EXACT_TYPE_CONSTRAINT(&t, remove_reference_t<T>*);
-			STL2_EXACT_TYPE_CONSTRAINT(&ct, const remove_reference_t<T>*);
+	concept bool __addressable =
+		requires(T& t, const remove_reference_t<T>& ct) {
+			{ &t } -> Same<remove_reference_t<T>*>&&;
+			{ &ct } -> Same<const remove_reference_t<T>*>&&;
 			// Axiom: &ct == addressof(ct)
-		}
-	constexpr bool __addressable<T> = true;
+		};
 
 	namespace ext {
 		template <class T>

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -23,8 +23,8 @@ STL2_OPEN_NAMESPACE {
 		requires(G&& g) {
 			g();
 			requires UnsignedIntegral<decltype(g())>();
-			STL2_EXACT_TYPE_CONSTRAINT(G::min(), decltype(g()));
-			STL2_EXACT_TYPE_CONSTRAINT(G::max(), decltype(g()));
+			{ G::min() } -> Same<decltype(g())>&&;
+			{ G::max() } -> Same<decltype(g())>&&;
 		};
 
 	namespace models {

--- a/include/stl2/detail/ebo_box.hpp
+++ b/include/stl2/detail/ebo_box.hpp
@@ -30,25 +30,25 @@ STL2_OPEN_NAMESPACE {
 			ebo_box() = default;
 			constexpr ebo_box(const T& t)
 			noexcept(std::is_nothrow_copy_constructible<T>::value)
-			requires models::CopyConstructible<T>
+			requires CopyConstructible<T>()
 			: item_(t) {}
 			constexpr ebo_box(T&& t)
 			noexcept(std::is_nothrow_move_constructible<T>::value)
-			requires models::MoveConstructible<T>
+			requires MoveConstructible<T>()
 			: item_(std::move(t)) {}
 
 			template <class First>
 			requires
-				!models::_OneOf<std::decay_t<First>, ebo_box, T> &&
-				models::Constructible<T, First> &&
-				models::ConvertibleTo<First, T>
+				!_OneOf<std::decay_t<First>, ebo_box, T> &&
+				Constructible<T, First>() &&
+				ConvertibleTo<First, T>()
 			constexpr ebo_box(First&& f)
 			noexcept(std::is_nothrow_constructible<T, First>::value)
 			: item_(std::forward<First>(f)) {}
 			template <class First, class... Rest>
 			requires
-				(sizeof...(Rest) > 0 || !models::_OneOf<std::decay_t<First>, ebo_box, T>) &&
-				models::Constructible<T, First, Rest...>
+				(sizeof...(Rest) > 0 || !_OneOf<std::decay_t<First>, ebo_box, T>) &&
+				Constructible<T, First, Rest...>()
 			constexpr explicit ebo_box(First&& f, Rest&&...r)
 			noexcept(std::is_nothrow_constructible<T, First, Rest...>::value)
 			: item_(std::forward<First>(f), std::forward<Rest>(r)...) {}
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 			noexcept(std::is_nothrow_move_constructible<T>::value)
 			requires MoveConstructible<T>()
 			: T(std::move(t)) {}
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template <class First>
 			requires
 				!models::_OneOf<std::decay_t<First>, ebo_box, T> &&

--- a/include/stl2/detail/functional/comparisons.hpp
+++ b/include/stl2/detail/functional/comparisons.hpp
@@ -23,10 +23,9 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// equal_to [comparisons]
 	//
-	template <class = void> struct equal_to;
-
-	EqualityComparable{T}
-	struct equal_to<T> {
+	template <class T = void>
+		requires EqualityComparable<T>() || Same<T, void>()
+	struct equal_to {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a == b;
 		}
@@ -35,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 	template <>
 	struct equal_to<void> {
 		EqualityComparable{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return t == u;
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) == std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;
@@ -45,10 +44,9 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// not_equal_to
 	//
-	template <class = void> struct not_equal_to;
-
-	EqualityComparable{T}
-	struct not_equal_to<T> {
+	template <class T = void>
+		requires EqualityComparable<T>() || Same<T, void>()
+	struct not_equal_to {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a != b;
 		}
@@ -57,8 +55,8 @@ STL2_OPEN_NAMESPACE {
 	template <>
 	struct not_equal_to<void> {
 		EqualityComparable{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return t != u;
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) != std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;
@@ -67,20 +65,19 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// greater
 	//
-	template <class = void> struct greater;
-
-	StrictTotallyOrdered{T}
-	struct greater<T> {
+	template <class T = void>
+		requires StrictTotallyOrdered<T>() || Same<T, void>()
+	struct greater {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a > b;
 		}
 	};
 
 	template <>
-	struct greater<void> : private std::greater<void> {
+	struct greater<void> {
 		StrictTotallyOrdered{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return std::greater<void>::operator()(t, u);
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) > std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;
@@ -94,20 +91,19 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// less
 	//
-	template <class = void> struct less;
-
-	StrictTotallyOrdered{T}
-	struct less<T> {
+	template <class T = void>
+		requires StrictTotallyOrdered<T>() || Same<T, void>()
+	struct less {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a < b;
 		}
 	};
 
 	template <>
-	struct less<void> : private std::less<void> {
+	struct less<void> {
 		StrictTotallyOrdered{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return std::less<void>::operator()(t, u);
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) < std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;
@@ -121,20 +117,19 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// greater_equal
 	//
-	template <class = void> struct greater_equal;
-
-	StrictTotallyOrdered{T}
-	struct greater_equal<T> {
+	template <class T = void>
+		requires StrictTotallyOrdered<T>() || Same<T, void>()
+	struct greater_equal {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a >= b;
 		}
 	};
 
 	template <>
-	struct greater_equal<void> : private std::greater_equal<void> {
+	struct greater_equal<void> {
 		StrictTotallyOrdered{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return std::greater_equal<void>::operator()(t, u);
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) >= std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;
@@ -148,20 +143,19 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// less_equal
 	//
-	template <class = void> struct less_equal;
-
-	StrictTotallyOrdered{T}
-	struct less_equal<T> {
+	template <class T = void>
+		requires StrictTotallyOrdered<T>() || Same<T, void>()
+	struct less_equal {
 		constexpr bool operator()(const T& a, const T& b) const {
 			return a <= b;
 		}
 	};
 
 	template <>
-	struct less_equal<void> : private std::less_equal<void> {
+	struct less_equal<void> {
 		StrictTotallyOrdered{T, U}
-		constexpr decltype(auto) operator()(const T& t, const U& u) const {
-			return std::less_equal<void>::operator()(t, u);
+		constexpr decltype(auto) operator()(T&& t, U&& u) const {
+			return std::forward<T>(t) <= std::forward<U>(u);
 		}
 
 		using is_transparent = true_type;

--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -75,65 +75,6 @@ STL2_OPEN_NAMESPACE {
 // Used to qualify STL2 names
 namespace __stl2 = ::std::experimental::ranges;
 
-// Workaround bugs in deduction constraints by replacing:
-// * { E } -> T with requires T<decltype(E)>()
-// * { E } -> Same<T> with requires Same<decltype(E), T>()
-// * { E } -> ConvertibleTo<T> with requires ConvertibleTo<decltype(E), T>()
-#if 0
-#define STL2_DEDUCTION_CONSTRAINT(E, ...) \
-	{ E } -> __VA_ARGS__
-
-#define STL2_BINARY_DEDUCTION_CONSTRAINT(E, C, ...) \
-	STL2_DEDUCTION_CONSTRAINT(E, C<__VA_ARGS__>)
-
-#else
-#define STL2_DEDUCTION_CONSTRAINT(E, ...) \
-	E; requires __VA_ARGS__ <decltype(E)>()
-
-#define STL2_BINARY_DEDUCTION_CONSTRAINT(E, C, ...) \
-	E; requires C<decltype(E), __VA_ARGS__>()
-#endif
-
-#define STL2_EXACT_TYPE_CONSTRAINT(E, ...) \
-	STL2_BINARY_DEDUCTION_CONSTRAINT(E, Same, __VA_ARGS__)
-
-#define STL2_CONVERSION_CONSTRAINT(E, ...) \
-	STL2_BINARY_DEDUCTION_CONSTRAINT(E, ConvertibleTo, __VA_ARGS__)
-
-// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67384
-// Use the expression constraint "deduce_auto_ref_ref(E);" in place
-// of the compound constraint "{ E } -> auto&&;"
-STL2_OPEN_NAMESPACE {
-	namespace detail {
-		void deduce_auto_ref(auto&); // undefined
-		void deduce_auto_ref_ref(auto&&); // undefined
-	}
-} STL2_CLOSE_NAMESPACE
-
-#define STL2_DEDUCE_AUTO_REF(E) \
-	::__stl2::detail::deduce_auto_ref(E)
-
-#define STL2_DEDUCE_AUTO_REF_REF(E) \
-	::__stl2::detail::deduce_auto_ref_ref(E)
-
-// Workaround bugs in constrained return types
-// (e.g., Iterator begin(Range&&);) by simply disabling
-// the feature and using "auto"
-#if 1
-#define STL2_CONSTRAINED_RETURN(...) __VA_ARGS__
-#else
-#define STL2_CONSTRAINED_RETURN(...) auto
-#endif
-
-// Workaround bugs in constrained variable definitions
-// (e.g., Iterator x = begin(r);) by simply disabling
-// the feature and using "auto"
-#if 1
-#define STL2_CONSTRAINED_VAR(...) __VA_ARGS__
-#else
-#define STL2_CONSTRAINED_VAR(...) auto
-#endif
-
 #define STL2_NOEXCEPT_RETURN(...) \
 	noexcept(noexcept(__VA_ARGS__)) \
 	{ return __VA_ARGS__; }

--- a/include/stl2/detail/iostream/concepts.hpp
+++ b/include/stl2/detail/iostream/concepts.hpp
@@ -20,18 +20,12 @@ STL2_OPEN_NAMESPACE {
 	// StreamExtractable [Extension]
 	//
 	namespace ext {
-		template <class, class>
-		constexpr bool __stream_extractable = false;
-		template <class T, class Stream>
-		requires
-			requires(Stream& is, T& t) {
-				STL2_EXACT_TYPE_CONSTRAINT(is >> t, Stream&);
-				// Axiom: &is == &(is << t)
-			}
-		constexpr bool __stream_extractable<T, Stream> = true;
-
 		template <class T, class Stream = std::istream>
-		concept bool StreamExtractable = __stream_extractable<T, Stream>;
+		concept bool StreamExtractable =
+			requires(Stream& is, T& t) {
+				{ is >> t } -> Same<Stream&>&&;
+				// Axiom: &is == &(is << t)
+			};
 	}
 
 	namespace models {
@@ -45,18 +39,12 @@ STL2_OPEN_NAMESPACE {
 	// StreamInsertable [Extension]
 	//
 	namespace ext {
-		template <class T, class Stream>
-		constexpr bool __stream_insertable = false;
-		template <class T, class Stream>
-		requires
-			requires(Stream& os, const T& t) {
-				STL2_EXACT_TYPE_CONSTRAINT(os << t, Stream&);
-				// Axiom: &os == &(os << t)
-			}
-		constexpr bool __stream_insertable<T, Stream> = true;
-
 		template <class T, class Stream = std::ostream>
-		concept bool StreamInsertable = __stream_insertable<T, Stream>;
+		concept bool StreamInsertable =
+			requires(Stream& os, const T& t) {
+				{ os << t } -> Same<Stream&>&&;
+				// Axiom: &os == &(os << t)
+			};
 	}
 
 	namespace models {

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 			template <class U>
 			constexpr explicit operator_arrow_proxy(U&& u)
 			noexcept(std::is_nothrow_constructible<T, U>::value)
-			requires models::Constructible<T, U>
+			requires Constructible<T, U>()
 			: value_(std::forward<U>(u)) {}
 
 			constexpr const T* operator->() const noexcept {
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		requires
-			models::Readable<I> &&
+			Readable<I>() &&
 			(std::is_pointer<I>::value ||
 				requires(const I& i) { i.operator->(); })
 		constexpr I operator_arrow_(const I& i, ext::priority_tag<2>)
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		requires
-			models::Readable<I> &&
+			Readable<I>() &&
 			_Is<reference_t<const I>, std::is_reference>
 		constexpr auto operator_arrow_(const I& i, ext::priority_tag<1>)
 		noexcept(noexcept(*i)) {
@@ -70,9 +70,9 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		requires
-			models::Readable<I> &&
+			Readable<I>() &&
 			!std::is_reference<reference_t<I>>::value &&
-			models::Constructible<value_type_t<I>, reference_t<I>>
+			Constructible<value_type_t<I>, reference_t<I>>()
 		constexpr auto operator_arrow_(const I& i, ext::priority_tag<0>)
 		noexcept(
 			std::is_nothrow_move_constructible<
@@ -84,7 +84,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		requires
-			models::Readable<I> &&
+			Readable<I>() &&
 			requires(const I& i) {
 				__common_iterator::operator_arrow_(i, ext::max_priority_tag);
 			}

--- a/include/stl2/detail/iterator/istream_iterator.hpp
+++ b/include/stl2/detail/iterator/istream_iterator.hpp
@@ -34,9 +34,9 @@ STL2_OPEN_NAMESPACE {
 			class traits = std::char_traits<charT>,
 			SignedIntegral Distance = std::ptrdiff_t>
 		requires
-			models::DefaultConstructible<T> &&
-			models::CopyConstructible<T> &&
-			models::StreamExtractable<T, std::basic_istream<charT, traits>>
+			DefaultConstructible<T>() &&
+			CopyConstructible<T>() &&
+			ext::StreamExtractable<T, std::basic_istream<charT, traits>>
 		class istream_cursor : semiregular_box<T> {
 			using box_t = semiregular_box<T>;
 		public:
@@ -129,9 +129,9 @@ STL2_OPEN_NAMESPACE {
 	template <class T, class charT = char, class traits = std::char_traits<charT>,
 		SignedIntegral Distance = std::ptrdiff_t>
 	requires
-		models::DefaultConstructible<T> &&
-		models::CopyConstructible<T> &&
-		models::StreamExtractable<T, std::basic_istream<charT, traits>>
+		DefaultConstructible<T>() &&
+		CopyConstructible<T>() &&
+		ext::StreamExtractable<T, std::basic_istream<charT, traits>>
 	using istream_iterator =
 		basic_iterator<detail::istream_cursor<T, charT, traits, Distance>>;
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -282,7 +282,7 @@ STL2_OPEN_NAMESPACE {
 	// Not to spec: constexpr per P0579
 	template <class S>
 	requires
-		models::Semiregular<__f<S>>
+		Semiregular<__f<S>>()
 	constexpr auto make_move_sentinel(S&& s)
 	STL2_NOEXCEPT_RETURN(
 		move_sentinel<__f<S>>(__stl2::forward<S>(s))

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __advance {
 		template <class I>
 		requires
-			models::Iterator<I>
+			Iterator<I>()
 			// Pre: 0 <= n && [i,i+n)
 		constexpr void impl(I& i, difference_type_t<I> n)
 		noexcept(noexcept(++std::declval<I&>()))
@@ -69,7 +69,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S>
 	requires
-		models::Sentinel<S, I>
+		Sentinel<S, I>()
 		// Pre: [i,bound)
 	constexpr void advance(I& i, S bound)
 	noexcept(noexcept(++i != bound))
@@ -81,7 +81,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S>
 	requires
-		models::Sentinel<S, I> && models::Assignable<I&, S&&>
+		Sentinel<S, I>() && Assignable<I&, S&&>()
 	constexpr void advance(I& i, S bound)
 	STL2_NOEXCEPT_RETURN(
 		(void)(i = std::move(bound))
@@ -89,8 +89,8 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S>
 	requires
-		models::Sentinel<S, I> && !models::Assignable<I&, S&&> &&
-		models::SizedSentinel<S, I>
+		Sentinel<S, I>() && !Assignable<I&, S&&>() &&
+		SizedSentinel<S, I>()
 		// Pre: [i,bound)
 	constexpr void advance(I& i, S bound)
 	noexcept(noexcept(__stl2::advance(i, bound - i)))
@@ -103,7 +103,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __advance {
 		template <class I, class S>
 		requires
-			models::Sentinel<S, I>
+			Sentinel<S, I>()
 			// Pre: 0 == n || (0 < n && [i,bound))
 		constexpr difference_type_t<I>
 		impl(I& i, difference_type_t<I> n, const S& bound)
@@ -120,7 +120,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S>
 	requires
-		models::Sentinel<S, I>
+		Sentinel<S, I>()
 		// Pre: 0 == n || (0 < n && [i,bound))
 	constexpr difference_type_t<I>
 	advance(I& i, difference_type_t<I> n, S bound)
@@ -130,7 +130,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I, class S>
 	requires
-		models::Sentinel<S, I> && models::SizedSentinel<S, I>
+		Sentinel<S, I>() && SizedSentinel<S, I>()
 		// Pre: 0 <= n && [i,bound)
 	constexpr difference_type_t<I>
 	advance(I& i, difference_type_t<I> n, S bound)
@@ -151,7 +151,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I>
 	requires
-		models::BidirectionalIterator<I>
+		BidirectionalIterator<I>()
 		// Pre: 0 == n || (0 < n ? [i,bound) : [bound,i))
 	constexpr difference_type_t<I>
 	advance(I& i, difference_type_t<I> n, I bound)
@@ -172,7 +172,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I>
 	requires
-		models::BidirectionalIterator<I> && models::SizedSentinel<I, I>
+		BidirectionalIterator<I>() && SizedSentinel<I, I>()
 		// Pre: 0 == n ? ([i,bound) || [bound,i)) : (0 < n ? [i,bound) : [bound,i))
 	constexpr difference_type_t<I>
 	advance(I& i, difference_type_t<I> n, I bound)
@@ -200,7 +200,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class S, class I>
 	requires
-		models::Sentinel<__f<S>, I>
+		Sentinel<__f<S>, I>()
 	constexpr I next(I x, S&& bound)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, std::forward<S>(bound)),
@@ -209,7 +209,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class S, class I>
 	requires
-		models::Sentinel<__f<S>, I>
+		Sentinel<__f<S>, I>()
 	constexpr I next(I x, difference_type_t<I> n, S&& bound)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, n, std::forward<S>(bound)),

--- a/include/stl2/detail/iterator/ostream_iterator.hpp
+++ b/include/stl2/detail/iterator/ostream_iterator.hpp
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <class T = void, class charT = char, class traits = std::char_traits<charT>>
 	requires
-		models::Same<T, void> ||
-		models::StreamInsertable<T, std::basic_ostream<charT, traits>>
+		Same<T, void>() ||
+		ext::StreamInsertable<T, std::basic_ostream<charT, traits>>
 	class ostream_iterator {
 	public:
 		using difference_type = ptrdiff_t;

--- a/include/stl2/detail/iterator/ostreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/ostreambuf_iterator.hpp
@@ -78,7 +78,7 @@ STL2_OPEN_NAMESPACE {
 		friend bool operator!=(ostreambuf_iterator a, default_sentinel b) noexcept {
 			return !(a == b);
 		}
-		friend bool operator==(default_sentinel a, ostreambuf_iterator b) noexcept {
+		friend bool operator==(default_sentinel, ostreambuf_iterator b) noexcept {
 			return b.sbuf_ == nullptr;
 		}
 		friend bool operator!=(default_sentinel a, ostreambuf_iterator b) noexcept {

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 			// Prefer member if it returns Iterator.
 			template <class R>
 			requires has_member<R>
-			constexpr STL2_CONSTRAINED_RETURN(Iterator)
+			constexpr Iterator
 			operator()(R& r) const
 			STL2_NOEXCEPT_RETURN(
 				r.begin()
@@ -63,13 +63,13 @@ STL2_OPEN_NAMESPACE {
 			// Use ADL if it returns Iterator.
 			template <class R>
 			requires !has_member<R> && has_non_member<R>
-			constexpr STL2_CONSTRAINED_RETURN(Iterator)
+			constexpr Iterator
 			operator()(R& r) const
 			STL2_NOEXCEPT_RETURN(
 				begin(r)
 			)
 			template <_IsNot<is_array> R>
-			[[deprecated]] constexpr STL2_CONSTRAINED_RETURN(Iterator)
+			[[deprecated]] constexpr Iterator
 			operator()(const R&& r) const
 			noexcept(noexcept(declval<const fn&>()(r)))
 			requires has_member<const R> || has_non_member<const R>
@@ -416,7 +416,7 @@ STL2_OPEN_NAMESPACE {
 		template <class R>
 		requires
 			requires(const R& r) {
-				STL2_CONVERSION_CONSTRAINT(r.empty(), bool);
+				{ r.empty() } -> bool;
 			}
 		constexpr bool has_member<R> = true;
 

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -62,19 +62,13 @@ STL2_OPEN_NAMESPACE {
 	constexpr bool disable_sized_range = false;
 
 	template <class R>
-	constexpr bool __sized_range = false;
-	template <class R>
-		requires requires(const R& r) {
-			STL2_DEDUCTION_CONSTRAINT(__stl2::size(r), Integral);
-			STL2_CONVERSION_CONSTRAINT(__stl2::size(r), difference_type_t<iterator_t<R>>);
-		}
-	constexpr bool __sized_range<R> = true;
-
-	template <class R>
 	concept bool SizedRange() {
 		return Range<R>() &&
 			!disable_sized_range<__uncvref<R>> &&
-			__sized_range<remove_reference_t<R>>;
+			requires(const remove_reference_t<R>& r) {
+				{ __stl2::size(r) } -> Integral;
+				{ __stl2::size(r) } -> difference_type_t<iterator_t<R>>;
+			};
 	}
 
 	namespace models {
@@ -235,17 +229,11 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template <class R>
-		constexpr bool __contiguous_range = false;
-		template <class R>
-			requires requires(R& r) {
-				STL2_EXACT_TYPE_CONSTRAINT(__stl2::data(r), add_pointer_t<reference_t<iterator_t<R>>>);
-			}
-		constexpr bool __contiguous_range<R> = true;
-
-		template <class R>
 		concept bool ContiguousRange() {
 			return SizedRange<R>() && ContiguousIterator<iterator_t<R>>() &&
-				__contiguous_range<remove_reference_t<R>>;
+				requires(R& r) {
+				    { __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>&&;
+				};
 		}
 	}
 

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	// See https://github.com/ericniebler/stl2/322
 	template <class T, class U = T>
 	requires
-		models::MoveConstructible<T> && models::Assignable<T&, U>
+		MoveConstructible<T>() && Assignable<T&, U>()
 	constexpr T exchange(T& t, U&& u)
 	noexcept(is_nothrow_move_constructible<T>::value &&
 		is_nothrow_assignable<T&, U>::value)
@@ -78,8 +78,8 @@ STL2_OPEN_NAMESPACE {
 			)
 			template <class T>
 			requires
-				!has_customization<T&, T&> && models::MoveConstructible<T> &&
-				models::Assignable<T&, T&&>
+				!has_customization<T&, T&> && MoveConstructible<T>() &&
+				Assignable<T&, T&&>()
 			constexpr void operator()(T& a, T& b) const
 			STL2_NOEXCEPT_RETURN(
 				(void)(b = __stl2::exchange(a, __stl2::move(b)))

--- a/include/stl2/detail/variant/fwd.hpp
+++ b/include/stl2/detail/variant/fwd.hpp
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr std::size_t index_of_type = I;
 
 		template <class...Ts>
-		requires(models::Destructible<element_t<Ts>> && ...)
+		requires (Destructible<element_t<Ts>>() && ...)
 		class base;
 
 		// VariantTypes<T> is a list of the alternative types of T if
@@ -121,7 +121,7 @@ STL2_OPEN_NAMESPACE {
 	} // namespace __variant
 
 	template <class...Ts>
-	requires(models::Destructible<__variant::element_t<Ts>> && ...)
+	requires (Destructible<__variant::element_t<Ts>>() && ...)
 	class variant;
 
 	class bad_variant_access : public std::logic_error {

--- a/include/stl2/optional.hpp
+++ b/include/stl2/optional.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template <class T>
-	requires models::Destructible<T> && _Is<T, is_object>
+	requires Destructible<T>() && _Is<T, is_object>
 	class optional;
 
 	namespace __optional {
@@ -57,31 +57,31 @@ STL2_OPEN_NAMESPACE {
 
 		template <class T, class U>
 		requires
-			models::Swappable<T&, U&> &&
-			models::Constructible<T, U> &&
-			models::Constructible<U, T>
+			Swappable<T&, U&>() &&
+			Constructible<T, U>() &&
+			Constructible<U, T>()
 		void swap(optional<T>& lhs, optional<U>& rhs)
 		STL2_NOEXCEPT_RETURN(
 			lhs.swap(rhs)
 		)
 		template <class T>
 		requires
-			models::Swappable<T&> &&
-			models::MoveConstructible<T>
+			Swappable<T&>() &&
+			MoveConstructible<T>()
 		void swap(optional<T>& lhs, optional<T>& rhs)
 		STL2_NOEXCEPT_RETURN(
 			lhs.swap(rhs)
 		)
 
 		template <class T>
-		requires models::Destructible<T>
+		requires Destructible<T>()
 		class storage_destruct_layer {
 		public:
 			~storage_destruct_layer() { if (engaged_) clear(); }
 
 			constexpr storage_destruct_layer() noexcept {}
 			template <class... Args>
-			requires models::Constructible<T, Args...>
+			requires Constructible<T, Args...>()
 			constexpr explicit storage_destruct_layer(in_place_t, Args&&... args)
 			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			: item_(std::forward<Args>(args)...), engaged_{true} {}
@@ -100,13 +100,13 @@ STL2_OPEN_NAMESPACE {
 
 		template <class T>
 		requires
-			models::Destructible<T> &&
+			Destructible<T>() &&
 			std::is_trivially_destructible<T>::value
 		class storage_destruct_layer<T> {
 		public:
 			constexpr storage_destruct_layer() noexcept {}
 			template <class... Args>
-			requires models::Constructible<T, Args...>
+			requires Constructible<T, Args...>()
 			constexpr explicit storage_destruct_layer(in_place_t, Args&&... args)
 			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			: item_(std::forward<Args>(args)...), engaged_{true} {}
@@ -125,7 +125,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		class storage_construct_layer : public storage_destruct_layer<T> {
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			storage_construct_layer() = default;
 			template <class... Args>
 			requires models::Constructible<T, Args...>
@@ -138,7 +138,7 @@ STL2_OPEN_NAMESPACE {
 #endif // STL2_WORKAROUND_GCC_79143
 
 			template <class... Args>
-			requires models::Constructible<T, Args...>
+			requires Constructible<T, Args...>()
 			void construct(Args&&... args)
 			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			{
@@ -178,7 +178,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		class smf_layer : public storage_construct_layer<T> {
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template <class... Args>
 			requires models::Constructible<T, Args...>
 			constexpr explicit smf_layer(in_place_t, Args&&... args)
@@ -208,7 +208,7 @@ STL2_OPEN_NAMESPACE {
 			{ return assign(std::move(that)); }
 		private:
 			template <class That>
-			requires models::Same<smf_layer, __uncvref<That>>
+			requires Same<smf_layer, __uncvref<That>>()
 			void construct_from(That&& that) &
 			noexcept(std::is_nothrow_constructible<T, That>::value)
 			{
@@ -217,7 +217,7 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 			template <class That>
-			requires models::Same<smf_layer, __uncvref<That>>
+			requires Same<smf_layer, __uncvref<That>>()
 			smf_layer& assign(That&& that) &
 			noexcept(std::is_nothrow_constructible<T, That>::value &&
 				std::is_nothrow_assignable<T&, That>::value)
@@ -238,7 +238,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		requires std::is_trivially_copyable<T>::value
 		struct smf_layer<T> : storage_construct_layer<T> {
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			smf_layer() = default;
 
 			template <class... Args>
@@ -257,14 +257,14 @@ STL2_OPEN_NAMESPACE {
 		template <class> struct optional_storage {};
 
 		template <class T>
-		requires models::Destructible<T>
+		requires Destructible<T>()
 		struct optional_storage<T> {
 			using type = __optional::smf_layer<T>;
 		};
 	} // namespace ext
 
 	template <class T>
-	requires models::Destructible<T> && _Is<T, is_object>
+	requires Destructible<T>() && _Is<T, is_object>
 	class optional
 	: public meta::_t<ext::optional_storage<T>>
 	, detail::smf_control::copy<models::CopyConstructible<T>>
@@ -309,56 +309,56 @@ STL2_OPEN_NAMESPACE {
 		optional(optional&&) = default;
 
 		template <class... Args>
-		requires models::Constructible<T, Args...>
+		requires Constructible<T, Args...>()
 		constexpr explicit optional(in_place_t, Args&&... args)
 		: base_t{in_place, std::forward<Args>(args)...} {}
 		template <class E, class... Args>
-		requires models::Constructible<T, std::initializer_list<E>&, Args...>
+		requires Constructible<T, std::initializer_list<E>&, Args...>()
 		constexpr explicit optional(in_place_t, std::initializer_list<E> il, Args&&... args)
 		: base_t{in_place, il, std::forward<Args>(args)...} {}
 		template <class U = T>
 		requires
-			!models::Same<U, in_place_t> &&
-			!models::Same<optional, std::decay_t<U>> &&
-			models::Constructible<T, U>
+			!Same<U, in_place_t>() &&
+			!Same<optional, std::decay_t<U>>() &&
+			Constructible<T, U>()
 		constexpr explicit optional(U&& u)
 		noexcept(std::is_nothrow_constructible<T, U>::value)
 		: base_t{in_place, std::forward<U>(u)} {}
 		template <class U = T>
 		requires
-			!models::Same<U, in_place_t> &&
-			!models::Same<optional, std::decay_t<U>> &&
-			models::Constructible<T, U> &&
-			models::ConvertibleTo<U, T>
+			!Same<U, in_place_t>() &&
+			!Same<optional, std::decay_t<U>>() &&
+			Constructible<T, U>() &&
+			ConvertibleTo<U, T>()
 		constexpr optional(U&& u)
 		noexcept(std::is_nothrow_constructible<T, U>::value)
 		: base_t{in_place, std::forward<U>(u)} {}
 		template <class U>
 		requires
-			models::Constructible<T, const U&> &&
+			Constructible<T, const U&>() &&
 			should_unwrap_construct<U>
 		explicit optional(const optional<U>& that)
 		noexcept(std::is_nothrow_constructible<T, const U&>::value)
 		{ if (that) this->construct(*that); }
 		template <class U>
 		requires
-			models::Constructible<T, const U&> &&
+			Constructible<T, const U&>() &&
 			should_unwrap_construct<U> &&
-			models::ConvertibleTo<U, T>
+			ConvertibleTo<U, T>()
 		optional(const optional<U>& that)
 		noexcept(std::is_nothrow_constructible<T, const U&>::value)
 		{ if (that) this->construct(*that); }
 
 		template <class U>
 		requires
-			models::Constructible<T, U>
+			Constructible<T, U>()
 		explicit optional(optional<U>&& that)
 		noexcept(std::is_nothrow_constructible<T, U>::value)
 		{ if (that) this->construct(std::move(*that)); }
 		template <class U>
 		requires
-			models::Constructible<T, U> &&
-			models::ConvertibleTo<U, T>
+			Constructible<T, U>() &&
+			ConvertibleTo<U, T>()
 		optional(optional<U>&& that)
 		noexcept(std::is_nothrow_constructible<T, U>::value)
 		{ if (that) this->construct(std::move(*that)); }
@@ -374,10 +374,10 @@ STL2_OPEN_NAMESPACE {
 
 		template <class U = T>
 		requires
-			!models::Same<optional, std::decay_t<U>> &&
-			!(std::is_scalar<T>::value && models::Same<T, std::decay_t<U>>) &&
-			models::Constructible<T, U> &&
-			models::Assignable<T&, U>
+			!Same<optional, std::decay_t<U>>() &&
+			!(std::is_scalar<T>::value && Same<T, std::decay_t<U>>()) &&
+			Constructible<T, U>() &&
+			Assignable<T&, U>()
 		optional& operator=(U&& u) &
 		noexcept(std::is_nothrow_assignable<T&, U>::value &&
 			std::is_nothrow_constructible<T, U>::value)
@@ -392,8 +392,8 @@ STL2_OPEN_NAMESPACE {
 
 		template <class U>
 		requires
-			models::Constructible<T, const U&> &&
-			models::Assignable<T, const U&> &&
+			Constructible<T, const U&>() &&
+			Assignable<T, const U&>() &&
 			should_unwrap_assign<U>
 		optional& operator=(const optional<U>& that) &
 		noexcept(std::is_nothrow_constructible<T, const U&>::value &&
@@ -413,8 +413,8 @@ STL2_OPEN_NAMESPACE {
 
 		template <class U>
 		requires
-			models::Constructible<T, U> &&
-			models::Assignable<T, U> &&
+			Constructible<T, U>() &&
+			Assignable<T, U>() &&
 			should_unwrap_assign<U>
 		optional& operator=(optional<U>&& that) &
 		noexcept(std::is_nothrow_constructible<T, U>::value &&
@@ -433,7 +433,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template <class...Args>
-		requires models::Constructible<T, Args...>
+		requires Constructible<T, Args...>()
 		void emplace(Args&&...args)
 		noexcept(std::is_nothrow_constructible<T, Args...>::value)
 		{
@@ -441,7 +441,7 @@ STL2_OPEN_NAMESPACE {
 			this->construct(std::forward<Args>(args)...);
 		}
 		template <class U, class...Args>
-		requires models::Constructible<T, std::initializer_list<U>&, Args...>
+		requires Constructible<T, std::initializer_list<U>&, Args...>()
 		void emplace(std::initializer_list<U> il, Args&&...args)
 		noexcept(std::is_nothrow_constructible<T,
 			std::initializer_list<U>&, Args...>::value)
@@ -452,9 +452,9 @@ STL2_OPEN_NAMESPACE {
 
 		template <class U>
 		requires
-			models::Swappable<T&, U&> &&
-			models::Constructible<T, U> &&
-			models::Constructible<U, T>
+			Swappable<T&, U&>() &&
+			Constructible<T, U>() &&
+			Constructible<U, T>()
 		void swap(optional<U>& that)
 		noexcept(is_nothrow_swappable_v<T&, U&> &&
 			std::is_nothrow_constructible<T, U>::value &&
@@ -508,8 +508,8 @@ STL2_OPEN_NAMESPACE {
 
 		template <ConvertibleTo<T> U>
 		requires
-			models::ConvertibleTo<U, T> &&
-			models::CopyConstructible<T>
+			ConvertibleTo<U, T>() &&
+			CopyConstructible<T>()
 		constexpr T value_or(U&& u) const & {
 			return *this
 				? **this
@@ -517,8 +517,8 @@ STL2_OPEN_NAMESPACE {
 		}
 		template <class U>
 		requires
-			models::ConvertibleTo<U, T> &&
-			models::MoveConstructible<T>
+			ConvertibleTo<U, T>() &&
+			MoveConstructible<T>()
 		constexpr T value_or(U&& u) && {
 			return *this
 				? std::move(**this)
@@ -529,59 +529,41 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	namespace __optional {
-		template <class, class>
-		constexpr bool can_eq = false;
 		template <class T, class U>
-		requires
+		concept bool can_eq =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t == u, Boolean);
-			}
-		constexpr bool can_eq<T, U> = true;
+				{ t == u } -> Boolean;
+			};
 
-		template <class, class>
-		constexpr bool can_neq = false;
 		template <class T, class U>
-		requires
+		concept bool can_neq =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t != u, Boolean);
-			}
-		constexpr bool can_neq<T, U> = true;
+				{ t != u } -> Boolean;
+			};
 
-		template <class, class>
-		constexpr bool can_lt = false;
 		template <class T, class U>
-		requires
+		concept bool can_lt =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t < u, Boolean);
-			}
-		constexpr bool can_lt<T, U> = true;
+				{ t < u } -> Boolean;
+			};
 
-		template <class, class>
-		constexpr bool can_gt = false;
 		template <class T, class U>
-		requires
+		concept bool can_gt =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t > u, Boolean);
-			}
-		constexpr bool can_gt<T, U> = true;
+				{ t > u } -> Boolean;
+			};
 
-		template <class, class>
-		constexpr bool can_lte = false;
 		template <class T, class U>
-		requires
+		concept bool can_lte =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t <= u, Boolean);
-			}
-		constexpr bool can_lte<T, U> = true;
+				{ t <= u } -> Boolean;
+			};
 
-		template <class, class>
-		constexpr bool can_gte = false;
 		template <class T, class U>
-		requires
+		concept bool can_gte =
 			requires(const T& t, const U& u) {
-				STL2_DEDUCTION_CONSTRAINT(t >= u, Boolean);
-			}
-		constexpr bool can_gte<T, U> = true;
+				{ t >= u } -> Boolean;
+			};
 
 		template <class T, class U>
 		requires can_eq<T, U>

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -166,26 +166,25 @@ STL2_OPEN_NAMESPACE {
 	struct common_reference<T, U, V, W...>
 	: common_reference<common_reference_t<T, U>, V, W...> {};
 
-	namespace models {
-		template <class, class>
-		constexpr bool CommonReference = false;
-		template <class T, class U>
-		requires
-			requires {
-				typename common_reference_t<T, U>;
-				typename common_reference_t<U, T>;
-			} &&
-			Same<common_reference_t<T, U>, common_reference_t<U, T>> &&
-			ConvertibleTo<T, common_reference_t<T, U>> &&
-			ConvertibleTo<U, common_reference_t<T, U>>
-		constexpr bool CommonReference<T, U> = true;
-	}
-
 	// Not to spec
 	// See https://github.com/ericniebler/stl2/issues/311
 	template <class T, class U>
 	concept bool CommonReference() {
-		return models::CommonReference<T, U>;
+		return
+			requires {
+				typename common_reference_t<T, U>;
+				typename common_reference_t<U, T>;
+			} &&
+			Same<common_reference_t<T, U>, common_reference_t<U, T>>() &&
+			ConvertibleTo<T, common_reference_t<T, U>>() &&
+			ConvertibleTo<U, common_reference_t<T, U>>();
+	}
+
+	namespace models {
+		template <class, class>
+		constexpr bool CommonReference = false;
+		__stl2::CommonReference{T, U}
+		constexpr bool CommonReference<T, U> = true;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -202,31 +201,30 @@ STL2_OPEN_NAMESPACE {
 	// This concept augments the axiom with added syntax requirements to
 	// provide "SomewhatVerifiablyCommon."
 	//
-	namespace models {
-		template <class, class>
-		constexpr bool Common = false;
-		template <class T, class U>
-		requires
-			requires {
-				typename common_type_t<T, U>;
-				typename common_type_t<U, T>;
-			} &&
-			Same<common_type_t<T, U>, common_type_t<U, T>> &&
-			ConvertibleTo<T, common_type_t<T, U>> &&
-			ConvertibleTo<U, common_type_t<T, U>> &&
-			CommonReference<add_lvalue_reference_t<const T>,
-				add_lvalue_reference_t<const U>> &&
-			CommonReference<add_lvalue_reference_t<common_type_t<T, U>>,
-				common_reference_t<add_lvalue_reference_t<const T>,
-					add_lvalue_reference_t<const U>>>
-		constexpr bool Common<T, U> = true;
-	}
-
 	// Not to spec
 	// See https://github.com/ericniebler/stl2/issues/311
 	template <class T, class U>
 	concept bool Common() {
-		return models::Common<T, U>;
+		return
+			requires {
+				typename common_type_t<T, U>;
+				typename common_type_t<U, T>;
+			} &&
+			Same<common_type_t<T, U>, common_type_t<U, T>>() &&
+			ConvertibleTo<T, common_type_t<T, U>>() &&
+			ConvertibleTo<U, common_type_t<T, U>>() &&
+			CommonReference<add_lvalue_reference_t<const T>,
+				add_lvalue_reference_t<const U>>() &&
+			CommonReference<add_lvalue_reference_t<common_type_t<T, U>>,
+				common_reference_t<add_lvalue_reference_t<const T>,
+					add_lvalue_reference_t<const U>>>();
+	}
+
+	namespace models {
+		template <class, class>
+		constexpr bool Common = false;
+		__stl2::Common{T, U}
+		constexpr bool Common<T, U> = true;
 	}
 
 	template <typename T>

--- a/include/stl2/variant.hpp
+++ b/include/stl2/variant.hpp
@@ -157,7 +157,7 @@ STL2_OPEN_NAMESPACE {
 		// __variant::base: lowest layer of the variant implementation.
 		//
 		template <class...Ts>
-		requires(models::Destructible<element_t<Ts>> && ...)
+		requires(Destructible<element_t<Ts>>() && ...)
 		class base {
 			friend v_access;
 		protected:
@@ -434,7 +434,7 @@ STL2_OPEN_NAMESPACE {
 			destruct_base& operator=(destruct_base&&) & = default;
 			destruct_base& operator=(const destruct_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr destruct_base(Args&&... args)
@@ -449,7 +449,7 @@ STL2_OPEN_NAMESPACE {
 		class destruct_base<Ts...> : public base<Ts...> {
 			using base_t = base<Ts...>;
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr destruct_base(Args&&... args)
@@ -472,7 +472,7 @@ STL2_OPEN_NAMESPACE {
 			move_base& operator=(move_base&&) & = default;
 			move_base& operator=(const move_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_base(Args&&... args)
@@ -483,7 +483,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <class...Ts>
-		requires(models::MoveConstructible<element_t<Ts>> && ...)
+		requires(MoveConstructible<element_t<Ts>>() && ...)
 		class move_base<Ts...> : public destruct_base<Ts...> {
 			using base_t = destruct_base<Ts...>;
 		public:
@@ -497,7 +497,7 @@ STL2_OPEN_NAMESPACE {
 			move_base& operator=(move_base&&) & = default;
 			move_base& operator=(const move_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_base(Args&&... args)
@@ -509,12 +509,12 @@ STL2_OPEN_NAMESPACE {
 
 		template <class...Ts>
 		requires
-			(models::MoveConstructible<element_t<Ts>> && ...) &&
+			(MoveConstructible<element_t<Ts>>() && ...) &&
 			ext::TriviallyMoveConstructible<storage<element_t<Ts>...>>()
 		class move_base<Ts...> : public destruct_base<Ts...> {
 			using base_t = destruct_base<Ts...>;
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_base(Args&&... args)
@@ -537,7 +537,7 @@ STL2_OPEN_NAMESPACE {
 			move_assign_base& operator=(move_assign_base&&) & = delete;
 			move_assign_base& operator=(const move_assign_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_assign_base(Args&&... args)
@@ -548,7 +548,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <class...Ts>
-		requires(models::Movable<element_t<Ts>> && ...)
+		requires(Movable<element_t<Ts>>() && ...)
 		class move_assign_base<Ts...> : public move_base<Ts...> {
 			using base_t = move_base<Ts...>;
 		public:
@@ -567,7 +567,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			move_assign_base& operator=(const move_assign_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_assign_base(Args&&... args)
@@ -579,12 +579,12 @@ STL2_OPEN_NAMESPACE {
 
 		template <class...Ts>
 		requires
-			(models::Movable<element_t<Ts>> && ...) &&
+			(Movable<element_t<Ts>>() && ...) &&
 			ext::TriviallyMovable<storage<element_t<Ts>...>>()
 		class move_assign_base<Ts...> : public move_base<Ts...> {
 			using base_t = move_base<Ts...>;
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr move_assign_base(Args&&... args)
@@ -607,7 +607,7 @@ STL2_OPEN_NAMESPACE {
 			copy_base& operator=(copy_base&&) & = default;
 			copy_base& operator=(const copy_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_base(Args&&... args)
@@ -618,7 +618,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <class...Ts>
-		requires(models::CopyConstructible<element_t<Ts>> && ...)
+		requires(CopyConstructible<element_t<Ts>>() && ...)
 		class copy_base<Ts...> : public move_assign_base<Ts...> {
 			using base_t = move_assign_base<Ts...>;
 		public:
@@ -632,7 +632,7 @@ STL2_OPEN_NAMESPACE {
 			copy_base& operator=(copy_base&&) & = default;
 			copy_base& operator=(const copy_base&) & = default;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_base(Args&&... args)
@@ -644,12 +644,12 @@ STL2_OPEN_NAMESPACE {
 
 		template <class...Ts>
 		requires
-			(models::CopyConstructible<element_t<Ts>> && ...) &&
+			(CopyConstructible<element_t<Ts>>() && ...) &&
 			ext::TriviallyCopyConstructible<storage<element_t<Ts>...>>()
 		class copy_base<Ts...> : public move_assign_base<Ts...> {
 			using base_t = move_assign_base<Ts...>;
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_base(Args&&... args)
@@ -672,7 +672,7 @@ STL2_OPEN_NAMESPACE {
 			copy_assign_base& operator=(copy_assign_base&&) & = default;
 			copy_assign_base& operator=(const copy_assign_base&) & = delete;
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_assign_base(Args&&... args)
@@ -683,7 +683,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <class...Ts>
-		requires(models::Copyable<element_t<Ts>> && ...)
+		requires(Copyable<element_t<Ts>>() && ...)
 		class copy_assign_base<Ts...> : public copy_base<Ts...> {
 			using base_t = copy_base<Ts...>;
 		public:
@@ -702,7 +702,7 @@ STL2_OPEN_NAMESPACE {
 				return *this;
 			}
 
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_assign_base(Args&&... args)
@@ -714,12 +714,12 @@ STL2_OPEN_NAMESPACE {
 
 		template <class...Ts>
 		requires
-			(models::Copyable<element_t<Ts>> && ...) &&
+			(Copyable<element_t<Ts>>() && ...) &&
 			ext::TriviallyCopyable<storage<element_t<Ts>...>>()
 		class copy_assign_base<Ts...> : public copy_base<Ts...> {
 			using base_t = copy_base<Ts...>;
 		public:
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 			template<class... Args>
 			requires models::Constructible<base_t, Args...>
 			constexpr copy_assign_base(Args&&... args)
@@ -735,7 +735,7 @@ STL2_OPEN_NAMESPACE {
 	// operators, and converting assignments.
 	//
 	template <class...Ts>
-	requires(models::Destructible<__variant::element_t<Ts>> && ...)
+	requires(Destructible<__variant::element_t<Ts>>() && ...)
 	class variant : public __variant::copy_assign_base<Ts...> {
 		using base_t = __variant::copy_assign_base<Ts...>;
 
@@ -776,7 +776,7 @@ STL2_OPEN_NAMESPACE {
 
 	public:
 		using types = meta::list<Ts...>;
-#if STL2_WORKAROUND_GCC_79143
+#if 0 //STL2_WORKAROUND_GCC_79143
 		template <class First>
 		requires
 			!models::Same<variant, std::decay_t<First>> &&
@@ -866,7 +866,7 @@ STL2_OPEN_NAMESPACE {
 				__variant::element_t<Ts>&, __variant::element_t<Ts>&>...>>)
 		requires
 			Movable<base_t>() && // Movable<variant>() explodes here.
-			(models::Swappable<__variant::element_t<Ts>&> && ...)
+			(Swappable<__variant::element_t<Ts>&>() && ...)
 		{
 			if (this->index_ == that.index_) {
 				if (this->valid()) {
@@ -886,7 +886,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		friend constexpr bool operator==(const variant& lhs, const variant& rhs)
-		requires(models::EqualityComparable<__variant::element_t<Ts>> && ...)
+		requires(EqualityComparable<__variant::element_t<Ts>>() && ...)
 		{
 			if (lhs.index_ != rhs.index_) {
 				return false;
@@ -895,13 +895,13 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		friend constexpr bool operator!=(const variant& lhs, const variant& rhs)
-		requires(models::EqualityComparable<__variant::element_t<Ts>> && ...)
+		requires(EqualityComparable<__variant::element_t<Ts>>() && ...)
 		{
 			return !(lhs == rhs);
 		}
 
 		friend constexpr bool operator<(const variant& lhs, const variant& rhs)
-		requires(models::StrictTotallyOrdered<__variant::element_t<Ts>> && ...)
+		requires(StrictTotallyOrdered<__variant::element_t<Ts>>() && ...)
 		{
 			if (lhs.index_ < rhs.index_) {
 				return true;
@@ -913,19 +913,19 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		friend constexpr bool operator>(const variant& lhs, const variant& rhs)
-		requires(models::StrictTotallyOrdered<__variant::element_t<Ts>> && ...)
+		requires(StrictTotallyOrdered<__variant::element_t<Ts>>() && ...)
 		{
 			return rhs < lhs;
 		}
 
 		friend constexpr bool operator<=(const variant& lhs, const variant& rhs)
-		requires(models::StrictTotallyOrdered<__variant::element_t<Ts>> && ...)
+		requires(StrictTotallyOrdered<__variant::element_t<Ts>>() && ...)
 		{
 			return !(rhs < lhs);
 		}
 
 		friend constexpr bool operator>=(const variant& lhs, const variant& rhs)
-		requires(models::StrictTotallyOrdered<__variant::element_t<Ts>> && ...)
+		requires(StrictTotallyOrdered<__variant::element_t<Ts>>() && ...)
 		{
 			return !(lhs < rhs);
 		}

--- a/test/concepts/compare.cpp
+++ b/test/concepts/compare.cpp
@@ -60,20 +60,24 @@ struct A {
 CONCEPT_ASSERT(models::EqualityComparable<int>);
 CONCEPT_ASSERT(models::EqualityComparable<A>);
 CONCEPT_ASSERT(!models::EqualityComparable<void>);
+CONCEPT_ASSERT(models::EqualityComparable<int&>);
 
 CONCEPT_ASSERT(models::EqualityComparable<int, int>);
 CONCEPT_ASSERT(models::EqualityComparable<A, A>);
 CONCEPT_ASSERT(!models::EqualityComparable<void, void>);
+CONCEPT_ASSERT(models::EqualityComparable<int&, int>);
 } // namespace equality_comparable_test
 
 CONCEPT_ASSERT(models::StrictTotallyOrdered<int>);
 CONCEPT_ASSERT(models::StrictTotallyOrdered<float>);
 CONCEPT_ASSERT(models::StrictTotallyOrdered<std::nullptr_t>);
 CONCEPT_ASSERT(!models::StrictTotallyOrdered<void>);
+CONCEPT_ASSERT(models::StrictTotallyOrdered<int&>);
 
 CONCEPT_ASSERT(models::StrictTotallyOrdered<int, int>);
 CONCEPT_ASSERT(models::StrictTotallyOrdered<int, double>);
 CONCEPT_ASSERT(!models::StrictTotallyOrdered<int, void>);
+CONCEPT_ASSERT(models::StrictTotallyOrdered<int&, int>);
 
 int main() {
 	return ::test_result();


### PR DESCRIPTION
* Fix up Boolean, EqualityComparable, and StrictTotallyOrdered (refs ericniebler/stl2#155)
* remove argument deduction constraint work-arounds
* fix up deduction constraints (refs ericniebler/stl2#331)
* function objects implemented to spec

Tested with gcc-6.2.0 and gcc-trunk.