### PR TITLE
Small cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cmcstl2
-An implementation of the Ranges TS "C++ Extensions for Ranges" [N4560](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4560.pdf) with extensions for proxy iterators from [P0022: Proxy Iterators for the Ranges Extensions](http://wg21.link/p0022) and updates from [P0370: Ranges TS Design Updates Omnibus](http://wg21.link/p0370). There are still quite a few rough edges, but the library is now feature-complete.
+An implementation of the Ranges TS "C++ Extensions for Ranges" as specified in working paper [N4620](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/n4620.pdf) with many many proposed resolutions implemented for issues as documented at http://github.com/ericniebler/stl2/issues. There are still quite a few rough edges, but the library is now feature-complete.
 
-Compilation requires [GCC 6.1](https://gcc.gnu.org/) with the `-fconcepts` command line option. Compile times are currently on the slow side, even for C++. The implementation of Concepts in GCC is brand-spanking-new and hasn't yet had proper performance tuning.
+Compilation requires [GCC 6](https://gcc.gnu.org/) with the `-std=c++1z` and `-fconcepts` command line options. Compile times are currently on the slow side, even for C++.
 
 **Build status**
 - on Travis-CI: [![Travis Build Status](https://travis-ci.org/CaseyCarter/cmcstl2.svg?branch=master)](https://travis-ci.org/CaseyCarter/cmcstl2)

--- a/include/stl2/detail/algorithm/move.hpp
+++ b/include/stl2/detail/algorithm/move.hpp
@@ -26,16 +26,10 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyMovable<I, O>()
 	tagged_pair<tag::in(I), tag::out(O)>
 	move(I first, S last, O result) {
-#if 1
-		auto res = __stl2::copy(__stl2::make_move_iterator(__stl2::move(first)),
-			__stl2::make_move_sentinel(__stl2::move(last)), __stl2::move(result));
-		return {__stl2::move(res.in()).base(), __stl2::move(res.out())};
-#else
 		for (; first != last; ++first, ++result) {
 			*result = __stl2::iter_move(first);
 		}
 		return {__stl2::move(first), __stl2::move(result)};
-#endif
 	}
 
 	template <InputRange Rng, class O>
@@ -64,19 +58,10 @@ STL2_OPEN_NAMESPACE {
 			IndirectlyMovable<I1, I2>()
 		tagged_pair<tag::in(I1), tag::out(I2)>
 		move(I1 first1, S1 last1, I2 first2, S2 last2) {
-#if 1
-			auto res = ext::copy(
-				__stl2::make_move_iterator(__stl2::move(first1)),
-				__stl2::make_move_sentinel(__stl2::move(last1)),
-				__stl2::make_move_iterator(__stl2::move(first2)),
-				__stl2::make_move_sentinel(__stl2::move(last2)));
-			return {__stl2::move(res.in()).base(), __stl2::move(res.out())};
-#else
 			for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
 				*first2 = __stl2::iter_move(first1);
 			}
 			return {__stl2::move(first1), __stl2::move(first2)};
-#endif
 		}
 
 		// Extension

--- a/include/stl2/detail/algorithm/move_backward.hpp
+++ b/include/stl2/detail/algorithm/move_backward.hpp
@@ -15,7 +15,6 @@
 #include <stl2/iterator.hpp>
 #include <stl2/utility.hpp>
 #include <stl2/detail/fwd.hpp>
-#include <stl2/detail/algorithm/copy.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
 // move_backward [alg.move]
@@ -27,19 +26,11 @@ STL2_OPEN_NAMESPACE {
 	tagged_pair<tag::in(I1), tag::out(I2)>
 	move_backward(I1 first, I1 last, I2 result)
 	{
-#if 1
-		auto res = __stl2::copy(
-			__stl2::make_move_iterator(__stl2::make_reverse_iterator(last)),
-			__stl2::make_move_iterator(__stl2::make_reverse_iterator(__stl2::move(first))),
-			__stl2::make_reverse_iterator(__stl2::move(result)));
-		return {__stl2::move(last), __stl2::move(res.out()).base()};
-#else
 		auto i = last;
 		while (i != first) {
 			*--result = __stl2::iter_move(--i);
 		}
 		return {__stl2::move(last), __stl2::move(result)};
-#endif
 	}
 
 	template <BidirectionalIterator I1, Sentinel<I1> S1, class I2>

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -42,18 +42,18 @@ STL2_OPEN_NAMESPACE {
 				// BooleanTestable, but for which BooleanTestable does not
 				// require validation.
 				{ b1 && b2 } -> Same<bool>&&;
-				{ a && b2  } -> Same<bool>&&;
+				{  a && b2 } -> Same<bool>&&;
 				{ b1 || b2 } -> Same<bool>&&;
-				{ a || b2  } -> Same<bool>&&;
+				{  a || b2 } -> Same<bool>&&;
 
 				// Requirements of Boolean that are not required by
 				// BooleanTestable.
 				{ b1 == b2 } -> ConvertibleTo<bool>&&;
 				{ b1 == a  } -> ConvertibleTo<bool>&&;
-				{ a == b2  } -> ConvertibleTo<bool>&&;
+				{  a == b2 } -> ConvertibleTo<bool>&&;
 				{ b1 != b2 } -> ConvertibleTo<bool>&&;
 				{ b1 != a  } -> ConvertibleTo<bool>&&;
-				{ a != b2  } -> ConvertibleTo<bool>&&;
+				{  a != b2 } -> ConvertibleTo<bool>&&;
 			};
 	}
 
@@ -79,8 +79,6 @@ STL2_OPEN_NAMESPACE {
 			{ t != u } -> Boolean&&;
 			{ u == t } -> Boolean&&;
 			{ u != t } -> Boolean&&;
-			// Axiom: t == u and t != u have the same definition space
-			// Axiom: bool(t != u) == !bool(t == u)
 		};
 	}
 
@@ -130,8 +128,8 @@ STL2_OPEN_NAMESPACE {
 	concept bool __totally_ordered =
 		requires(const remove_reference_t<T>& t,
 		         const remove_reference_t<U>& u) {
-			{ t < u  } -> Boolean&&;
-			{ t > u  } -> Boolean&&;
+			{ t <  u } -> Boolean&&;
+			{ t >  u } -> Boolean&&;
 			{ t <= u } -> Boolean&&;
 			{ t >= u } -> Boolean&&;
 			// Axiom: t < u, t > u, t <= u, t >= u have the same definition space.
@@ -144,6 +142,8 @@ STL2_OPEN_NAMESPACE {
 	template <class T>
 	concept bool StrictTotallyOrdered() {
 		return EqualityComparable<T>() && __totally_ordered<T, T>;
+		// Axiom: t1 == t2 and t1 < t2 have the same definition space.
+		// Axiom: bool(t <= t)
 	}
 
 	template <class T, class U>

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -25,8 +25,9 @@ STL2_OPEN_NAMESPACE {
 	template <class T>
 	concept bool __addressable =
 		requires(T& t, const remove_reference_t<T>& ct) {
-			{ &t } -> Same<remove_reference_t<T>*>&&;
-			{ &ct } -> Same<const remove_reference_t<T>*>&&;
+			{ &t } -> Same<remove_reference_t<T>*>;
+			{ &ct } -> Same<const remove_reference_t<T>*>;
+			// Axiom: &t == addressof(t)
 			// Axiom: &ct == addressof(ct)
 		};
 

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	template <class T>
 	concept bool __addressable =
 		requires(T& t, const remove_reference_t<T>& ct) {
-			{ &t } -> Same<remove_reference_t<T>*>;
-			{ &ct } -> Same<const remove_reference_t<T>*>;
+			{ &t } -> Same<remove_reference_t<T>*>&&;
+			{ &ct } -> Same<const remove_reference_t<T>*>&&;
 			// Axiom: &t == addressof(t)
 			// Axiom: &ct == addressof(ct)
 		};

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -23,8 +23,10 @@ STL2_OPEN_NAMESPACE {
 		requires(G&& g) {
 			g();
 			requires UnsignedIntegral<decltype(g())>();
-			{ G::min() } -> Same<decltype(g())>;
-			{ G::max() } -> Same<decltype(g())>;
+			{ G::min() } -> Same<decltype(g())>&&;
+			{ G::max() } -> Same<decltype(g())>&&;
+			requires (G::min(), true);
+			requires (G::max(), true);
 		};
 
 	namespace models {
@@ -35,6 +37,8 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool UniformRandomNumberGenerator<G> = true;
 	}
 
+	// Not to spec: requires G::min() and G::max() to be constant expressions
+	// See https://github.com/ericniebler/stl2/issues/334
 	template <class G>
 	concept bool UniformRandomNumberGenerator() {
 		return models::UniformRandomNumberGenerator<G>;

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -23,8 +23,8 @@ STL2_OPEN_NAMESPACE {
 		requires(G&& g) {
 			g();
 			requires UnsignedIntegral<decltype(g())>();
-			{ G::min() } -> Same<decltype(g())>&&;
-			{ G::max() } -> Same<decltype(g())>&&;
+			{ G::min() } -> Same<decltype(g())>;
+			{ G::max() } -> Same<decltype(g())>;
 		};
 
 	namespace models {

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -25,8 +25,6 @@ STL2_OPEN_NAMESPACE {
 			requires UnsignedIntegral<decltype(g())>();
 			{ G::min() } -> Same<decltype(g())>&&;
 			{ G::max() } -> Same<decltype(g())>&&;
-			requires (G::min(), true);
-			requires (G::max(), true);
 		};
 
 	namespace models {
@@ -37,8 +35,6 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool UniformRandomNumberGenerator<G> = true;
 	}
 
-	// Not to spec: requires G::min() and G::max() to be constant expressions
-	// See https://github.com/ericniebler/stl2/issues/334
 	template <class G>
 	concept bool UniformRandomNumberGenerator() {
 		return models::UniformRandomNumberGenerator<G>;

--- a/include/stl2/detail/ebo_box.hpp
+++ b/include/stl2/detail/ebo_box.hpp
@@ -75,25 +75,7 @@ STL2_OPEN_NAMESPACE {
 			noexcept(std::is_nothrow_move_constructible<T>::value)
 			requires MoveConstructible<T>()
 			: T(std::move(t)) {}
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template <class First>
-			requires
-				!models::_OneOf<std::decay_t<First>, ebo_box, T> &&
-				models::Constructible<T, First> &&
-				models::ConvertibleTo<First, T>
-			constexpr ebo_box(First&& f)
-			noexcept(std::is_nothrow_constructible<T, First>::value)
-			: T(std::forward<First>(f)) {}
-			template <class First, class... Rest>
-			requires
-				(sizeof...(Rest) > 0 || !models::_OneOf<std::decay_t<First>, ebo_box, T>) &&
-				models::Constructible<T, First, Rest...>
-			constexpr explicit ebo_box(First&& f, Rest&&...r)
-			noexcept(std::is_nothrow_constructible<T, First, Rest...>::value)
-			: T(std::forward<First>(f), std::forward<Rest>(r)...) {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using T::T;
-#endif //  STL2_WORKAROUND_GCC_79143
 
 			constexpr T& get() & noexcept { return *this; }
 			constexpr const T& get() const& noexcept { return *this; }

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -232,7 +232,7 @@ STL2_OPEN_NAMESPACE {
 		concept bool ContiguousRange() {
 			return SizedRange<R>() && ContiguousIterator<iterator_t<R>>() &&
 				requires(R& r) {
-				    { __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>&&;
+				    { __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>;
 				};
 		}
 	}

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -232,7 +232,7 @@ STL2_OPEN_NAMESPACE {
 		concept bool ContiguousRange() {
 			return SizedRange<R>() && ContiguousIterator<iterator_t<R>>() &&
 				requires(R& r) {
-				    { __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>;
+					{ __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>&&;
 				};
 		}
 	}

--- a/include/stl2/optional.hpp
+++ b/include/stl2/optional.hpp
@@ -125,17 +125,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		class storage_construct_layer : public storage_destruct_layer<T> {
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			storage_construct_layer() = default;
-			template <class... Args>
-			requires models::Constructible<T, Args...>
-			constexpr explicit storage_construct_layer(in_place_t, Args&&... args)
-			noexcept(std::is_nothrow_constructible<T, Args...>::value)
-			: storage_destruct_layer<T>(in_place, std::forward<Args>(args)...)
-			{}
-#else  // STL2_WORKAROUND_GCC_79143
 			using storage_destruct_layer<T>::storage_destruct_layer;
-#endif // STL2_WORKAROUND_GCC_79143
 
 			template <class... Args>
 			requires Constructible<T, Args...>()
@@ -178,16 +168,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		class smf_layer : public storage_construct_layer<T> {
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template <class... Args>
-			requires models::Constructible<T, Args...>
-			constexpr explicit smf_layer(in_place_t, Args&&... args)
-			noexcept(std::is_nothrow_constructible<T, Args...>::value)
-			: storage_construct_layer<T>(in_place, std::forward<Args>(args)...)
-			{}
-#else  // STL2_WORKAROUND_GCC_79143
 			using storage_construct_layer<T>::storage_construct_layer;
-#endif // STL2_WORKAROUND_GCC_79143
 
 			smf_layer() = default;
 
@@ -238,18 +219,7 @@ STL2_OPEN_NAMESPACE {
 		template <class T>
 		requires std::is_trivially_copyable<T>::value
 		struct smf_layer<T> : storage_construct_layer<T> {
-#if 0 //STL2_WORKAROUND_GCC_79143
-			smf_layer() = default;
-
-			template <class... Args>
-			requires models::Constructible<T, Args...>
-			constexpr explicit smf_layer(in_place_t, Args&&... args)
-			noexcept(std::is_nothrow_constructible<T, Args...>::value)
-			: storage_construct_layer<T>(in_place, std::forward<Args>(args)...)
-			{}
-#else  // STL2_WORKAROUND_GCC_79143
 			using storage_construct_layer<T>::storage_construct_layer;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 	} // namespace __optional
 

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -189,18 +189,6 @@ STL2_OPEN_NAMESPACE {
 
 	///////////////////////////////////////////////////////////////////////////
 	// Common [concepts.lib.corelang.common]
-	//
-	// Common<T, U> is a purely semantic concept with a single axiom:
-	//   For some type C, there exist total injective functions f: T -> C
-	//   and g: U -> C. (In other words, values of T and U correspond to values
-	//   of C.)
-	//
-	// That axiom is obviously satisfied if T and U are the same type, since
-	// T is a common type with f and g both identity functions.
-	//
-	// This concept augments the axiom with added syntax requirements to
-	// provide "SomewhatVerifiablyCommon."
-	//
 	// Not to spec
 	// See https://github.com/ericniebler/stl2/issues/311
 	template <class T, class U>

--- a/include/stl2/variant.hpp
+++ b/include/stl2/variant.hpp
@@ -163,9 +163,6 @@ STL2_OPEN_NAMESPACE {
 		protected:
 			using storage_t = storage<element_t<Ts>...>;
 			using index_t =
-		#if 0
-				std::size_t;
-		#else
 				meta::if_c<
 					(sizeof...(Ts) <= std::numeric_limits<std::int_least8_t>::max()),
 					std::int_least8_t,
@@ -176,7 +173,6 @@ STL2_OPEN_NAMESPACE {
 							(sizeof...(Ts) <= std::numeric_limits<std::int_least32_t>::max()),
 							std::int_least32_t,
 							std::size_t>>>;
-		#endif
 			static_assert(sizeof...(Ts) - is_unsigned<index_t>::value <
 				std::numeric_limits<index_t>::max());
 			static constexpr auto invalid_index = index_t(-1);
@@ -434,14 +430,7 @@ STL2_OPEN_NAMESPACE {
 			destruct_base& operator=(destruct_base&&) & = default;
 			destruct_base& operator=(const destruct_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr destruct_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -449,14 +438,7 @@ STL2_OPEN_NAMESPACE {
 		class destruct_base<Ts...> : public base<Ts...> {
 			using base_t = base<Ts...>;
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr destruct_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -472,14 +454,7 @@ STL2_OPEN_NAMESPACE {
 			move_base& operator=(move_base&&) & = default;
 			move_base& operator=(const move_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -497,14 +472,7 @@ STL2_OPEN_NAMESPACE {
 			move_base& operator=(move_base&&) & = default;
 			move_base& operator=(const move_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -514,14 +482,7 @@ STL2_OPEN_NAMESPACE {
 		class move_base<Ts...> : public destruct_base<Ts...> {
 			using base_t = destruct_base<Ts...>;
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -537,14 +498,7 @@ STL2_OPEN_NAMESPACE {
 			move_assign_base& operator=(move_assign_base&&) & = delete;
 			move_assign_base& operator=(const move_assign_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -567,14 +521,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			move_assign_base& operator=(const move_assign_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -584,14 +531,7 @@ STL2_OPEN_NAMESPACE {
 		class move_assign_base<Ts...> : public move_base<Ts...> {
 			using base_t = move_base<Ts...>;
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr move_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -607,14 +547,7 @@ STL2_OPEN_NAMESPACE {
 			copy_base& operator=(copy_base&&) & = default;
 			copy_base& operator=(const copy_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -632,14 +565,7 @@ STL2_OPEN_NAMESPACE {
 			copy_base& operator=(copy_base&&) & = default;
 			copy_base& operator=(const copy_base&) & = default;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -649,14 +575,7 @@ STL2_OPEN_NAMESPACE {
 		class copy_base<Ts...> : public move_assign_base<Ts...> {
 			using base_t = move_assign_base<Ts...>;
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		///////////////////////////////////////////////////////////////////////////
@@ -672,14 +591,7 @@ STL2_OPEN_NAMESPACE {
 			copy_assign_base& operator=(copy_assign_base&&) & = default;
 			copy_assign_base& operator=(const copy_assign_base&) & = delete;
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -702,14 +614,7 @@ STL2_OPEN_NAMESPACE {
 				return *this;
 			}
 
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 
 		template <class...Ts>
@@ -719,14 +624,7 @@ STL2_OPEN_NAMESPACE {
 		class copy_assign_base<Ts...> : public copy_base<Ts...> {
 			using base_t = copy_base<Ts...>;
 		public:
-#if 0 //STL2_WORKAROUND_GCC_79143
-			template<class... Args>
-			requires models::Constructible<base_t, Args...>
-			constexpr copy_assign_base(Args&&... args)
-			: base_t{std::forward<Args>(args)...} {}
-#else  // STL2_WORKAROUND_GCC_79143
 			using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 		};
 	} // namespace __variant
 
@@ -776,25 +674,7 @@ STL2_OPEN_NAMESPACE {
 
 	public:
 		using types = meta::list<Ts...>;
-#if 0 //STL2_WORKAROUND_GCC_79143
-		template <class First>
-		requires
-			!models::Same<variant, std::decay_t<First>> &&
-			models::Constructible<base_t, First> &&
-			models::ConvertibleTo<First, base_t>
-		constexpr variant(First&& f)
-		noexcept(std::is_nothrow_constructible<base_t, First>::value)
-		: base_t(std::forward<First>(f)) {}
-		template <class First, class... Rest>
-		requires
-			!models::Same<variant, decay_t<First>> &&
-			models::Constructible<base_t, First, Rest...>
-		constexpr explicit variant(First&& f, Rest&&...r)
-		noexcept(std::is_nothrow_constructible<base_t, First, Rest...>::value)
-		: base_t(__stl2::forward<First>(f), __stl2::forward<Rest>(r)...) {}
-#else  // STL2_WORKAROUND_GCC_79143
 		using base_t::base_t;
-#endif // STL2_WORKAROUND_GCC_79143
 
 		variant() = default;
 		template <std::size_t I, class E, class...Args, _IsNot<is_reference> T = meta::at_c<types, I>>

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -42,7 +42,8 @@ STL2_OPEN_NAMESPACE {
 			noexcept(noexcept(__stl2::make_counted_iterator(__stl2::begin(std::declval<Base&>()), n_)))
 			requires !Range<Base const>()
 			{ return __stl2::make_counted_iterator(__stl2::begin(get()), n_); }
-	#if 0
+
+	#if 0 // FIXME: Untagged bug workaround
 			constexpr auto data()
 			noexcept(noexcept(__stl2::data(std::declval<Base&>())))
 			requires
@@ -64,7 +65,8 @@ STL2_OPEN_NAMESPACE {
 			noexcept(noexcept(__stl2::make_counted_iterator(__stl2::begin(std::declval<Base const&>()), n_)))
 			requires Range<Base const>()
 			{ return __stl2::make_counted_iterator(__stl2::begin(get()), n_); }
-	#if 0
+
+	#if 0 // FIXME: Untagged bug workaround
 			constexpr auto data() const
 			noexcept(noexcept(__stl2::data(std::declval<Base const&>())))
 			requires

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -20,15 +20,6 @@
 
 #include <stl2/detail/algorithm/sort.hpp>
 #include <stl2/detail/algorithm/copy.hpp>
-#if 0
-#include <range/v3/view/for_each.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/repeat_n.hpp>
-#include <range/v3/view/reverse.hpp>
-#include <range/v3/view/zip.hpp>
-#include <range/v3/view/transform.hpp>
-#include <range/v3/to_container.hpp>
-#endif
 #include <algorithm>
 #include <cassert>
 #include <memory>


### PR DESCRIPTION
* Remove the `#if 0` disabled workarounds for GCC 79143.

* Implement `move_backward` and `move` algorithms directly, instead of via `copy`, `make_move_iterator`, `make_move_sentinel`, and `make_reverse_iterator`.

* ~~We can `-> Same<T>` instead of `-> Same<T>&&` when `T` is known to be `Copyable`. This is notably true for pointer types and integral types.~~

* Remove WIP `_MixinTestWrapper` from basic_iterator.hpp
