### PR TITLE
Make iterators that return by value non-Writable

### DIFF
--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -186,8 +186,8 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// Writable [iterators.writable]
 	// Not to spec, but getting closer.
-	// See https://github.com/ericniebler/stl2/issues/240
-	// Additional changes from P0547
+	// See https://github.com/ericniebler/stl2/issues/339
+	// and https://github.com/ericniebler/stl2/issues/381
 	//
 	template <class Out, class R>
 	concept bool Writable() {
@@ -198,6 +198,8 @@ STL2_OPEN_NAMESPACE {
 			// Axiom: If r equals foo && Readable<Out>() &&
 			//        Same<value_type_t<Out>, ????>() then
 			//        (*o = (R&&)r, *o equals foo)
+			(void)(const_cast<const reference_t<Out>&&>(*o) = (R&&)r);
+			// Axiom: This expression is equivalent to the previous expression.
 		};
 	}
 

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -239,6 +239,20 @@ struct proxy_wrapper {
 		return *this;
 	}
 
+	proxy_wrapper const& operator=(const T& t) const
+	noexcept(std::is_nothrow_copy_assignable<T>::value)
+	{
+		get() = t;
+		return *this;
+	}
+
+	proxy_wrapper const& operator=(T&& t) const
+	noexcept(std::is_nothrow_move_assignable<T>::value)
+	{
+		get() = stl2::move(t);
+		return *this;
+	}
+
 	operator T&() const noexcept { return get(); }
 };
 

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -33,13 +33,23 @@ struct reference_wrapper {
 		return *ptr_;
 	}
 
-	reference_wrapper& operator=(const T& t)
+	reference_wrapper & operator=(const T& t)
 		noexcept(std::is_nothrow_copy_assignable<T>::value) {
 		get() = t;
 		return *this;
 	}
+	reference_wrapper & operator=(T&& t)
+		noexcept(std::is_nothrow_move_assignable<T>::value) {
+		get() = __stl2::move(t);
+		return *this;
+	}
 
-	reference_wrapper& operator=(T&& t)
+	reference_wrapper const& operator=(const T& t) const
+		noexcept(std::is_nothrow_copy_assignable<T>::value) {
+		get() = t;
+		return *this;
+	}
+	reference_wrapper const& operator=(T&& t) const
 		noexcept(std::is_nothrow_move_assignable<T>::value) {
 		get() = __stl2::move(t);
 		return *this;
@@ -447,6 +457,18 @@ void test_std_traits() {
 	static_assert(models::Same<std::iterator_traits<RV>::iterator_category,
 		std::input_iterator_tag>);
 }
+
+struct MakeString {
+	using value_type = std::string;
+	std::string operator*() const;
+};
+
+static_assert(models::Readable<MakeString>);
+static_assert(!models::Writable<MakeString, std::string>);
+static_assert(!models::Writable<MakeString, const std::string &>);
+static_assert(!models::IndirectlyMovable<MakeString, MakeString>);
+static_assert(!models::IndirectlyCopyable<MakeString, MakeString>);
+static_assert(!models::IndirectlySwappable<MakeString, MakeString>);
 
 int main() {
 	test_iter_swap2();


### PR DESCRIPTION
refs ericniebler/stl2#381, refs ericniebler/range-v3#573

Interestingly, none of the standard output iterators (ostream(buf) or the various insert iterators) are affected since their `operator*` returns `*this` by reference. :-)

This fix works out quite well in practice. More generally, I feel like testing for the writability of a `const`-qualified prvalue could play a part in the resolution of ericniebler/stl2#226. We could make it the hallmark of proxy reference types. (That still doesn't help us with specifying the *semantics* of the various operations on proxy references, but at least we have an inkling of how we might specify the syntax.)