### PR TITLE
iterator_range:

### DIFF
--- a/include/stl2/view/iterator_range.hpp
+++ b/include/stl2/view/iterator_range.hpp
@@ -26,11 +26,12 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <Iterator I, Sentinel<I> S = I>
 		struct iterator_range
-			: tagged_pair<tag::begin(I), tag::end(S)>,
-			  view_interface<iterator_range<I, S>> {
-		public:
+			: tagged_pair<tag::begin(I), tag::end(S)>
+			, view_interface<iterator_range<I, S>>
+		{
 			using iterator = I;
 			using sentinel = S;
+
 			iterator_range() = default;
 
 			constexpr iterator_range(I i, S s)
@@ -38,36 +39,20 @@ STL2_OPEN_NAMESPACE {
 
 			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
 			constexpr iterator_range(iterator_range<X, Y> r)
-			: tagged_pair<tag::begin(I), tag::end(S)>{r.begin(), r.end()} {}
+			: iterator_range{r.begin(), r.end()} {}
 
 			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
 			constexpr iterator_range(pair<X, Y> r)
-			: tagged_pair<tag::begin(I), tag::end(S)>{r.first, r.second} {}
+			: iterator_range{r.first, r.second} {}
 
 			template <Range R>
 			requires ConvertibleTo<iterator_t<R>, I> && ConvertibleTo<sentinel_t<R>, S>
 			constexpr iterator_range(R& r)
-			: tagged_pair<tag::begin(I), tag::end(S)>{__stl2::begin(r), __stl2::end(r)} {}
-
-			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
-			constexpr iterator_range& operator=(iterator_range<X, Y> r) {
-				this->first = r.begin();
-				this->second = r.end();
-				return *this;
-			}
-
-			template <Range R>
-			requires ConvertibleTo<iterator_t<R>, I> && ConvertibleTo<sentinel_t<R>, S>
-			constexpr iterator_range& operator=(R& r)
-			{
-				this->first = __stl2::begin(r);
-				this->second = __stl2::end(r);
-				return *this;
-			}
+			: iterator_range{__stl2::begin(r), __stl2::end(r)} {}
 
 			template <Constructible<const I&> X, Constructible<const S&> Y>
 			constexpr operator pair<X, Y>() const {
-				return {this->first, this->second};
+				return pair<X, Y>{this->first, this->second};
 			}
 
 			constexpr bool empty() const {
@@ -75,92 +60,126 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		template <Iterator I, Sentinel<I> S>
-		iterator_range(I, S) -> iterator_range<I, S>;
-
 		template <Range R>
 		iterator_range(R&) -> iterator_range<iterator_t<R>, sentinel_t<R>>;
 
 		template <Iterator I, Sentinel<I> S = I>
-		struct sized_iterator_range
-			: view_interface<sized_iterator_range<I, S>> {
-		private:
-			iterator_range<I, S> rng_; // exposition only
-			difference_type_t<I> size_; // exposition only
-		public:
-			using iterator = I;
-			using sentinel = S;
-			sized_iterator_range() = default;
+		struct sized_iterator_range;
+	} // namespace ext
 
-			constexpr sized_iterator_range(I i, S s, difference_type_t<I> n)
+	namespace detail {
+		template <Iterator I, Sentinel<I> S>
+		struct sized_iterator_range_base
+		: ext::view_interface<ext::sized_iterator_range<I, S>>
+		{
+			sized_iterator_range_base() = default;
+
+			constexpr sized_iterator_range_base(I i, S s, difference_type_t<I> n)
 			: rng_{i, s}, size_{n} {}
 
 			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
+			constexpr sized_iterator_range_base(sized_iterator_range_base<X, Y> r)
+			: sized_iterator_range_base{r.begin(), r.end(), r.size()} {}
+
+			template <SizedRange R>
+			requires Constructible<ext::iterator_range<I, S>, R&>
+			constexpr sized_iterator_range_base(R& r)
+			: sized_iterator_range_base{__stl2::begin(r), __stl2::end(r), __stl2::size(r)} {}
+
+			constexpr difference_type_t<I> size() const noexcept {
+				return size_;
+			}
+		protected:
+			ext::iterator_range<I, S> rng_;
+		private:
+			difference_type_t<I> size_;
+		};
+
+		template <Iterator I, SizedSentinel<I> S>
+		struct sized_iterator_range_base<I, S>
+		: ext::view_interface<ext::sized_iterator_range<I, S>>
+		{
+			sized_iterator_range_base() = default;
+
+			constexpr sized_iterator_range_base(I i, S s, difference_type_t<I> n)
+			: rng_{i, s} {
+				STL2_EXPECT(n == s - i);
+			}
+
+			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
+			constexpr sized_iterator_range_base(sized_iterator_range_base<X, Y> r)
+			: rng_{r.begin(), r.end()} {}
+
+			template <SizedRange R>
+			requires Constructible<ext::iterator_range<I, S>, R&>
+			constexpr sized_iterator_range_base(R& r)
+			: rng_{__stl2::begin(r), __stl2::end(r)} {}
+
+			constexpr difference_type_t<I> size() const {
+				return __stl2::distance(rng_);
+			}
+		protected:
+			ext::iterator_range<I, S> rng_;
+		};
+	} // namespace detail
+
+	namespace ext {
+		template <Iterator I, Sentinel<I> S>
+		struct sized_iterator_range
+		: detail::sized_iterator_range_base<I, S>
+		{
+			using iterator = I;
+			using sentinel = S;
+
+			sized_iterator_range() = default;
+
+			using detail::sized_iterator_range_base<I, S>::sized_iterator_range_base;
+
+			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
 			constexpr sized_iterator_range(pair<X, Y> r, difference_type_t<I> n)
-			: rng_{r.first, r.second}, size_{n} {}
+			: sized_iterator_range{r.first, r.second, n} {}
 
 			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
 			constexpr sized_iterator_range(iterator_range<X, Y> r, difference_type_t<I> n)
-			: rng_{r.begin(), r.end()}, size_{n} {}
-
-			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
-			constexpr sized_iterator_range(sized_iterator_range<X, Y> r)
-			: rng_{r.begin(), r.end()}, size_{r.size()} {}
-
-			template <SizedRange R>
-			requires Constructible<iterator_range<I, S>, R&>
-			constexpr sized_iterator_range(R& r)
-			: rng_{r}, size_(__stl2::size(r)) {}
-
-			template <ConvertibleTo<I> X, ConvertibleTo<S> Y>
-			constexpr sized_iterator_range& operator=(sized_iterator_range<X, Y> r) {
-				rng_.first = r.begin();
-				rng_.second = r.end();
-				size_ = r.size();
-				return *this;
-			}
-
-			template <SizedRange R>
-			requires Assignable<iterator_range<I, S>&, R&>
-			constexpr sized_iterator_range& operator=(R& r)
-			{
-				rng_ = r;
-				size_ = __stl2::size(r);
-				return *this;
-			}
+			: sized_iterator_range{r.begin(), r.end(), n} {}
 
 			template <Constructible<const I&> X, Constructible<const S&> Y>
 			constexpr operator pair<X, Y>() const {
-				return {rng_.first, rng_.second};
+				return pair<X, Y>{this->rng_.begin(), this->rng_.end()};
 			}
 
 			template <Constructible<const I&> X, Constructible<const S&> Y>
 			constexpr operator iterator_range<X, Y>() const {
-				return {rng_.first, rng_.second};
+				return this->rng_;
 			}
 
 			constexpr operator iterator_range<I, S> const &() const & noexcept {
-				return rng_;
+				return this->rng_;
 			}
 
 			constexpr I begin() const {
-				return rng_.first;
+				return this->rng_.begin();
 			}
 
 			constexpr S end() const {
-				return rng_.second;
-			}
-
-			constexpr difference_type_t<I> size() const noexcept {
-				return size_;
+				return this->rng_.end();
 			}
 		};
 
 		template <Iterator I, Sentinel<I> S>
 		sized_iterator_range(I, S, difference_type_t<I>) -> sized_iterator_range<I, S>;
 
+		template <Iterator I, Sentinel<I> S>
+		sized_iterator_range(pair<I, S>, difference_type_t<I>) -> sized_iterator_range<I, S>;
+
+		template <Iterator I, Sentinel<I> S>
+		sized_iterator_range(iterator_range<I, S>, difference_type_t<I>) -> sized_iterator_range<I, S>;
+
+		template <Iterator I, SizedSentinel<I> S>
+		sized_iterator_range(pair<I, S>) -> sized_iterator_range<I, S>;
+
 		template <SizedRange R>
-		explicit sized_iterator_range(R&) -> sized_iterator_range<iterator_t<R>, sentinel_t<R>>;
+		sized_iterator_range(R&) -> sized_iterator_range<iterator_t<R>, sentinel_t<R>>;
 
 		template <std::size_t N, class I, class S>
 		requires N < 2


### PR DESCRIPTION
* Use constructor delegation to simplify
* pair conversion operators use `Constructible` instead of `ConvertibleTo`, so the selected constructor might be `explicit`.
* `sized_iterator_range_base` stores `size_` only if `!SizedSentinel<S, I>`.
* Fixup deduction guides
* Kill assignment operators that are already covered by implicit conversions