### PR TITLE
constexpr algorithms must use constexpr invoke

### DIFF
--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 			value_type_t<iterator_t<Rng>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
-				if (__stl2::invoke(comp, __stl2::invoke(proj, result), __stl2::invoke(proj, tmp))) {
+				if (__invoke::impl(comp, __invoke::impl(proj, result), __invoke::impl(proj, tmp))) {
 					result = (decltype(tmp)&&)tmp;
 				}
 			}
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	constexpr const T& max(const T& a, const T& b, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
-		return !__stl2::invoke(comp, __stl2::invoke(proj, a), __stl2::invoke(proj, b)) ? a : b;
+		return !__invoke::impl(comp, __invoke::impl(proj, a), __invoke::impl(proj, b)) ? a : b;
 	}
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 			value_type_t<iterator_t<Rng>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
-				if (__stl2::invoke(comp, __stl2::invoke(proj, tmp), __stl2::invoke(proj, result))) {
+				if (__invoke::impl(comp, __invoke::impl(proj, tmp), __invoke::impl(proj, result))) {
 					result = (decltype(tmp)&&)tmp;
 				}
 			}
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	constexpr const T& min(const T& a, const T& b, Comp comp = Comp{},
 		Proj proj = Proj{})
 	{
-		return __stl2::invoke(comp, __stl2::invoke(proj, b), __stl2::invoke(proj, a)) ? b : a;
+		return __invoke::impl(comp, __invoke::impl(proj, b), __invoke::impl(proj, a)) ? b : a;
 	}
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 			if (++first != last) {
 				{
 					auto&& tmp = *first;
-					if (__stl2::invoke(comp, __stl2::invoke(proj, tmp), __stl2::invoke(proj, result.first))) {
+					if (__invoke::impl(comp, __invoke::impl(proj, tmp), __invoke::impl(proj, result.first))) {
 						result.first = (decltype(tmp)&&)tmp;
 					} else {
 						result.second = (decltype(tmp)&&)tmp;
@@ -53,27 +53,27 @@ STL2_OPEN_NAMESPACE {
 				while (++first != last) {
 					auto tmp1 = V{*first};
 					if (++first == last) {
-						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.first))) {
+						if (__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.first))) {
 							result.first = std::move(tmp1);
-						} else if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.second))) {
+						} else if (!__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.second))) {
 							result.second = std::move(tmp1);
 						}
 						break;
 					}
 
 					auto&& tmp2 = *first;
-					if (__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, tmp1))) {
-						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, result.first))) {
+					if (__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, tmp1))) {
+						if (__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, result.first))) {
 							result.first = (decltype(tmp2)&&)tmp2;
 						}
-						if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.second))) {
+						if (!__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.second))) {
 							result.second = std::move(tmp1);
 						}
 					} else {
-						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.first))) {
+						if (__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.first))) {
 							result.first = std::move(tmp1);
 						}
-						if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, result.second))) {
+						if (!__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, result.second))) {
 							result.second = (decltype(tmp2)&&)tmp2;
 						}
 					}
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 	constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
 	minmax(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{})
 	{
-		if (__stl2::invoke(comp, __stl2::invoke(proj, b), __stl2::invoke(proj, a))) {
+		if (__invoke::impl(comp, __invoke::impl(proj, b), __invoke::impl(proj, a))) {
 			return {b, a};
 		} else {
 			return {a, b};

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 	I nth_element(I first, I nth, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		I end = __stl2::next(nth, last), end_orig = end;
-		static constexpr difference_type_t<I> limit = 7;
+		constexpr difference_type_t<I> limit = 7;
 		while (true) {
 		restart:
 			if (nth == end) {

--- a/include/stl2/detail/algorithm/reverse.hpp
+++ b/include/stl2/detail/algorithm/reverse.hpp
@@ -107,7 +107,7 @@ STL2_OPEN_NAMESPACE {
 			auto ufirst = ext::uncounted(first);
 			using buf_t = temporary_buffer<value_type_t<decltype(ufirst)>>;
 			// TODO: tune this threshold.
-			static constexpr auto alloc_threshold = difference_type_t<I>(8);
+			constexpr auto alloc_threshold = difference_type_t<I>(8);
 			auto buf = n >= alloc_threshold ? buf_t{n / 2} : buf_t{};
 			auto last = detail::reverse_n_adaptive(ufirst, n, buf);
 			return ext::recounted(first, std::move(last), n);

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -278,7 +278,7 @@ STL2_OPEN_NAMESPACE {
 			// *first is known to be false
 
 			// might want to make this a function of trivial assignment
-			static constexpr difference_type_t<I> alloc_threshold = 4;
+			constexpr difference_type_t<I> alloc_threshold = 4;
 			using buf_t = detail::stable_part::buf_t<I>;
 			auto buf = n >= alloc_threshold ? buf_t{n} : buf_t{};
 			return detail::stable_part::forward(
@@ -310,7 +310,7 @@ STL2_OPEN_NAMESPACE {
 			// *last is known to be true
 
 			// might want to make this a function of trivial assignment
-			static constexpr difference_type_t<I> alloc_threshold = 4;
+			constexpr difference_type_t<I> alloc_threshold = 4;
 			using buf_t = detail::stable_part::buf_t<I>;
 			buf_t buf = n >= alloc_threshold ? buf_t{n} : buf_t{};
 			return detail::stable_part::bidirectional(


### PR DESCRIPTION
a.k.a. `::__stl2::__invoke::impl`

Fixes #124.