### PR TITLE
Add Conan packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
       addons: &gcc6
         apt:
           packages:
-            - g++-6
+            - g++-6 python-pip
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Release ASAN=Off
+    - env: GCC_VERSION=6 CONAN_GCC_VERSIONS=6 BUILD_TYPE=Release ASAN=Off
       os: linux
       addons: *gcc6
 
@@ -30,12 +30,12 @@ matrix:
     #   os: linux
     #   addons: *gcc6
 
-    - env: GCC_VERSION=7 BUILD_TYPE=Debug ASAN=Off
+    - env: GCC_VERSION=7 CONAN_GCC_VERSIONS=7 BUILD_TYPE=Debug ASAN=Off
       os: linux
       addons: &gcc7
         apt:
           packages:
-            - g++-7
+            - g++-7 python-pip
           sources:
             - ubuntu-toolchain-r-test
 
@@ -65,13 +65,24 @@ install:
       export PATH="${DEPS_DIR}/cmake/bin:${PATH}"
     fi
 
+  ############################################################################
+  # Install conan
+  ############################################################################
+  - pip install --user conan conan_package_tools
+  - conan user
+
 before_script:
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir -p build
   - cd build
   - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then CXX_FLAGS="${CXX_FLAGS}"; fi
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DBUILD_TESTS=1 -DBUILD_EXAMPLES=1
   - make VERBOSE=1 -j${JOBS}
 
 script:
   - ctest -j${JOBS} --output-on-failure
+  - conan create .. mmha/stable
+  - conan remote add repo $CONAN_UPLOAD --insert
+  - conan user -p $CONAN_PASSWORD -r repo $CONAN_LOGIN_USERNAME
+  - conan upload cmcstl2/\*@$CONAN_LOGIN_USERNAME/$CONAN_CHANNEL --all -r=repo --confirm
+  #- python .travis/package.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ cmake_minimum_required(VERSION 3.8)
 
 project(cmcstl2 CXX)
 
+option(BUILD_TESTS "Build the unit tests" OFF)
+option(BUILD_EXAMPLES "Build the examples" OFF)
+
 add_library(stl2 INTERFACE)
 target_include_directories(stl2 INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -32,8 +35,12 @@ install(
     FILES ${PROJECT_BINARY_DIR}/cmcstl2-config.cmake
     DESTINATION lib/cmake/cmcstl2)
 
-add_subdirectory(examples)
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
-enable_testing()
-include(CTest)
-add_subdirectory(test)
+if(BUILD_TESTS)
+    enable_testing()
+    include(CTest)
+    add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ target_link_libraries(app PRIVATE stl2)
 ```
 
 ## Conan Package
-| | | |
-|-|-|-|
-| Bintray repository | `conan remote add mmha https://api.bintray.com/conan/mmha/conan` |
+| On Bintray| [ ![Download](https://api.bintray.com/packages/mmha/conan/cmcstl2%3Ammha/images/download.svg) ](https://bintray.com/mmha/conan/cmcstl2%3Ammha/_latestVersion) |
+|-|-|
+| Repository | `conan remote add mmha https://api.bintray.com/conan/mmha/conan` |
 | Package reference  | `conan install cmcstl2/<commit_hash>@mmha/stable` |
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -2,5 +2,41 @@
 An implementation of [ISO/IEC Technical Specification 21425:2017 "Programming languages -- C++ Extensions for ranges"](https://www.iso.org/standard/70910.html) (the "Ranges TS").
 Compilation requires a compiler with support for C++17 and the Concepts TS, which as of this writing means [GCC 6+](https://gcc.gnu.org/) with the `-std=c++1z` and `-fconcepts` command line options.
 
-**Build status**
+## Build status
 - on Travis-CI: [![Travis Build Status](https://travis-ci.org/CaseyCarter/cmcstl2.svg?branch=master)](https://travis-ci.org/CaseyCarter/cmcstl2)
+
+## CMake Package
+
+```cmake
+find_package(cmcstl2 NO_MODULE REQUIRED)
+target_link_libraries(app PRIVATE stl2)
+```
+
+## Conan Package
+| | | |
+|-|-|-|
+| Bintray repository | `conan remote add mmha https://api.bintray.com/conan/mmha/conan` |
+| Package reference  | `conan install cmcstl2/<commit_hash>@mmha/stable` |
+
+### Usage
+To use cmcstl2 in your CMake project, do the following:
+```cmake
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+        message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
+                    "${CMAKE_BINARY_DIR}/conan.cmake")
+    endif()
+    include(${CMAKE_BINARY_DIR}/conan.cmake)
+    conan_cmake_run(REQUIRES cmcstl2/<commit_hash>@mmha/stable
+                    BASIC_SETUP CMAKE_TARGETS
+                    BUILD missing)
+    find_package(cmcstl2 REQUIRED)
+    add_executable(app main.cpp)
+    target_link_libraries(app PRIVATE stl2)
+```
+
+### Build it yourself
+There is a conan recipe in this repository. To build the package by yourself, clone this repository and execute this:
+```
+conan create . johndoe/mychannel
+```

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,3 +29,5 @@ class CMCSTL2Conan(ConanFile):
         self.cpp_info.includedirs = ['include']
         if self.settings.compiler == "gcc":
             self.cpp_info.cppflags = ["-fconcepts"]
+        elif self.settings.compiler == "Visual Studio":
+            self.cpp_info.cppflags = ["/std:c++latest"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,12 +14,13 @@ class CMCSTL2Conan(ConanFile):
     url="https://github.com/CaseyCarter/cmcstl2"
     description="An implementation of C++ Extensions for Ranges"
     license = "https://github.com/CaseyCarter/cmcstl2/blob/master/LICENSE.txt"
-    settings = ["os", "compiler", "arch"]
+    settings = ["compiler", "arch"]
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "include/*", "test/*", "examples/*"]
 
     def build(self):
         cmake = CMake(self)
+        cmake.verbose = True
         cmake.configure(source_folder=".")
         cmake.build()
         cmake.test()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake
+from conans.tools import download, unzip
+from conans.client.runner import ConanRunner
+from io import StringIO
+
+def git_commit_hash():
+    hash_buf = StringIO()
+    ConanRunner()("git rev-parse --short HEAD", output=hash_buf)
+    return hash_buf.getvalue()
+
+class CMCSTL2Conan(ConanFile):
+    name = "cmcstl2"
+    version = git_commit_hash()
+    url="https://github.com/CaseyCarter/cmcstl2"
+    description="An implementation of C++ Extensions for Ranges"
+    license = "https://github.com/CaseyCarter/cmcstl2/blob/master/LICENSE.txt"
+    settings = ["os", "compiler", "arch"]
+    generators = "cmake"
+    exports_sources = ["CMakeLists.txt", "include/*", "test/*", "examples/*"]
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(source_folder=".")
+        cmake.build()
+        cmake.test()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.includedirs = ['include']
+        if self.settings.compiler == "gcc":
+            self.cpp_info.cppflags = ["-fconcepts"]


### PR DESCRIPTION
This changes  the following things:

1. Tests and examples now build optionally. To build them, pass `-DBUILD_TESTS=1` or `-DBUILD_EXAMPLES=1` to CMake respectively
2. Added a `conanfile.py` that retrieves the git commit hash, sets it as the package version and packages cmcstl2 up along with the CMake package. A disadvantage is that there can be no version ranges and forces downstream users to specify the commit they want, but given the instability of the API this is probably fine.
3. Modified the `.travis.yml` such that it automatically packages up cmcstl2 after running the tests and uploads it to Bintray. For this to work you need to create your own Bintray account, and set some environment variables just like in [this](https://github.com/conan-io/conan-package-tools#travis-integration) example. Look at my source branch to see it all in action.
4. Document it all for the user in the `README.md`