### PR TITLE
Fixed files that didn't compile on GCC 8 and added Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,19 @@ matrix:
       os: linux
       addons: *gcc7
 
+    - env: GCC_VERSION=8 BUILD_TYPE=Debug ASAN=Off
+      os: linux
+      addons: &gcc8
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: GCC_VERSION=8 BUILD_TYPE=Release ASAN=Off
+      os: linux
+      addons: *gcc8
+
 before_install:
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
   - which $CXX

--- a/test/algorithm/is_sorted.cpp
+++ b/test/algorithm/is_sorted.cpp
@@ -58,8 +58,6 @@ struct range_call
 
 	template <class B, class E, class...  Args>
 	auto operator()(B &&b, E &&e, Args &&... args)
-	 -> decltype(ranges::is_sorted(ranges::ext::subrange(begin_t{b}, sentinel_t{e}),
-								   std::forward<Args>(args)...))
 	{
 		return ranges::is_sorted(ranges::ext::subrange(begin_t{b}, sentinel_t{e}),
 								 std::forward<Args>(args)...);

--- a/test/algorithm/is_sorted_until.cpp
+++ b/test/algorithm/is_sorted_until.cpp
@@ -59,8 +59,6 @@ struct range_call
 
 	template <class B, class E, class... Args>
 	auto operator()(B&& It, E&& e, Args&&... args)
-	 -> decltype(stl2::is_sorted_until(::as_lvalue(stl2::ext::subrange(begin_t{It}, sentinel_t{e})),
-										 std::forward<Args>(args)...))
 	{
 		return stl2::is_sorted_until(::as_lvalue(stl2::ext::subrange(begin_t{It}, sentinel_t{e})),
 									   std::forward<Args>(args)...);


### PR DESCRIPTION
For whatever reason, the deleted code doesn't work with GCC 8. I suspect a compiler bug, since both `decltype(auto)` and `auto` pass for return types.