### PR TITLE
Patch for istreambuf_iterator == default_sentinel

### DIFF
--- a/include/stl2/detail/iterator/istreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/istreambuf_iterator.hpp
@@ -165,7 +165,7 @@ STL2_OPEN_NAMESPACE {
 				return at_end() == that.at_end();
 			}
 			STL2_CONSTEXPR_EXT bool equal(default_sentinel) const noexcept {
-				return sbuf_ == nullptr;
+				return cursor{}.equal(*this);
 			}
 
 		private:

--- a/test/iterator/istreambuf_iterator.cpp
+++ b/test/iterator/istreambuf_iterator.cpp
@@ -93,6 +93,7 @@ int main() {
 		std::istringstream is(hw);
 		::check_equal(ext::subrange(I{is}, default_sentinel{}),
 									ext::subrange(hw + 0, hw + size(hw) - 1));
+		CHECK(I{is} == default_sentinel{});
 	}
 
 	{
@@ -105,6 +106,7 @@ int main() {
 		auto k = I{j};
 		CHECK(*k++ == '3');
 		CHECK(k == I{});
+		CHECK(k == default_sentinel{});
 	}
 
 	{


### PR DESCRIPTION
Before this patch, the test below fails.

```cpp
auto in = std::istringstream{};
assert(istreambuf_iterator{in} == default_sentinel{});
```

Related to #149.