### PR TITLE
Changed iterator aliases and functional alias

### DIFF
--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -34,9 +34,9 @@ STL2_OPEN_NAMESPACE {
 	copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (__stl2::invoke(pred, __stl2::invoke(proj, v))) {
-				*result = std::forward<reference_t<I>>(v);
+				*result = std::forward<iter_reference_t<I>>(v);
 				++result;
 			}
 		}

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, WeaklyIncrementable O>
 	requires IndirectlyCopyable<I, O>
 	tagged_pair<tag::in(I), tag::out(O)>
-	copy_n(I first_, difference_type_t<I> n, O result)
+	copy_n(I first_, iter_difference_t<I> n, O result)
 	{
 		STL2_EXPECT(n >= 0);
 		auto norig = n;

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -25,10 +25,10 @@ STL2_OPEN_NAMESPACE {
 	requires
 		IndirectRelation<
 			equal_to<>, projected<I, Proj>, const T*>
-	difference_type_t<I>
+	iter_difference_t<I>
 	count(I first, S last, const T& value, Proj proj = Proj{})
 	{
-		difference_type_t<I> n = 0;
+		iter_difference_t<I> n = 0;
 		for (; first != last; ++first) {
 			if (__stl2::invoke(proj, *first) == value) {
 				++n;
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		IndirectRelation<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
-	difference_type_t<iterator_t<Rng>>
+	iter_difference_t<iterator_t<Rng>>
 	count(Rng&& rng, const T& value, Proj proj = Proj{})
 	{
 		return __stl2::count(__stl2::begin(rng), __stl2::end(rng),

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -25,9 +25,9 @@ STL2_OPEN_NAMESPACE {
 	requires
 		IndirectUnaryPredicate<
 			Pred, projected<I, Proj>>
-	difference_type_t<I> count_if(I first, S last, Pred pred, Proj proj = Proj{})
+	iter_difference_t<I> count_if(I first, S last, Pred pred, Proj proj = Proj{})
 	{
-		auto n = difference_type_t<I>{0};
+		auto n = iter_difference_t<I>{0};
 		for (; first != last; ++first) {
 			if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
 				++n;
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		IndirectUnaryPredicate<
 			Pred, projected<iterator_t<Rng>, Proj>>
-	difference_type_t<iterator_t<Rng>> count_if(Rng&& rng, Pred pred, Proj proj = Proj{})
+	iter_difference_t<iterator_t<Rng>> count_if(Rng&& rng, Pred pred, Proj proj = Proj{})
 	{
 		return __stl2::count_if(__stl2::begin(rng), __stl2::end(rng),
 			std::ref(pred), std::ref(proj));

--- a/include/stl2/detail/algorithm/equal_range.hpp
+++ b/include/stl2/detail/algorithm/equal_range.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 		requires
 			IndirectStrictWeakOrder<
 				Comp, const T*, projected<I, Proj>>
-		ext::subrange<I> equal_range_n(I first, difference_type_t<I> dist, const T& value,
+		ext::subrange<I> equal_range_n(I first, iter_difference_t<I> dist, const T& value,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
 			if (0 < dist) {
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 		// is past the equal range (i.e., denotes an element greater
 		// than value), or is in the equal range (denotes an element equal
 		// to value).
-		auto dist = difference_type_t<I>{1};
+		auto dist = iter_difference_t<I>{1};
 		while (true) {
 			auto mid = first;
 			auto d = __stl2::advance(mid, dist, last);

--- a/include/stl2/detail/algorithm/fill_n.hpp
+++ b/include/stl2/detail/algorithm/fill_n.hpp
@@ -20,7 +20,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	template <class T, OutputIterator<const T&> O>
-	O fill_n(O first, difference_type_t<O> n, const T& value) {
+	O fill_n(O first, iter_difference_t<O> n, const T& value) {
 		for (; n > 0; --n, ++first) {
 			*first = value;
 		}

--- a/include/stl2/detail/algorithm/forward_sort.hpp
+++ b/include/stl2/detail/algorithm/forward_sort.hpp
@@ -46,13 +46,13 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		namespace fsort {
 			template <class I>
-			using buf_t = temporary_buffer<value_type_t<I>>;
+			using buf_t = temporary_buffer<iter_value_t<I>>;
 
 			template <class I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			inline I merge_n_with_buffer(I f0, difference_type_t<I> n0,
-				I f1, difference_type_t<I> n1,
+			inline I merge_n_with_buffer(I f0, iter_difference_t<I> n0,
+				I f1, iter_difference_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
 			{
 				STL2_EXPECT(0 <= n0);
@@ -73,13 +73,13 @@ STL2_OPEN_NAMESPACE {
 			template <class I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			inline void merge_n_step_0(I f0, difference_type_t<I> n0,
-				I f1, difference_type_t<I> n1,
+			inline void merge_n_step_0(I f0, iter_difference_t<I> n0,
+				I f1, iter_difference_t<I> n1,
 				Comp& comp, Proj& proj,
-				I& f0_0, difference_type_t<I>& n0_0,
-				I& f0_1, difference_type_t<I>& n0_1,
-				I& f1_0, difference_type_t<I>& n1_0,
-				I& f1_1, difference_type_t<I>& n1_1)
+				I& f0_0, iter_difference_t<I>& n0_0,
+				I& f0_1, iter_difference_t<I>& n0_1,
+				I& f1_0, iter_difference_t<I>& n1_0,
+				I& f1_1, iter_difference_t<I>& n1_1)
 			{
 				STL2_EXPECT(0 <= n0);
 				STL2_EXPECT(0 <= n1);
@@ -98,13 +98,13 @@ STL2_OPEN_NAMESPACE {
 			template <class I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			inline void merge_n_step_1(I f0, difference_type_t<I> n0,
-				I f1, difference_type_t<I> n1,
+			inline void merge_n_step_1(I f0, iter_difference_t<I> n0,
+				I f1, iter_difference_t<I> n1,
 				Comp& comp, Proj& proj,
-				I& f0_0, difference_type_t<I>& n0_0,
-				I& f0_1, difference_type_t<I>& n0_1,
-				I& f1_0, difference_type_t<I>& n1_0,
-				I& f1_1, difference_type_t<I>& n1_1)
+				I& f0_0, iter_difference_t<I>& n0_0,
+				I& f0_1, iter_difference_t<I>& n0_1,
+				I& f1_0, iter_difference_t<I>& n1_0,
+				I& f1_1, iter_difference_t<I>& n1_1)
 			{
 				STL2_EXPECT(0 <= n0);
 				STL2_EXPECT(0 <= n1);
@@ -123,8 +123,8 @@ STL2_OPEN_NAMESPACE {
 			template <class I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			I merge_n_adaptive(I f0, difference_type_t<I> n0,
-				I f1, difference_type_t<I> n1,
+			I merge_n_adaptive(I f0, iter_difference_t<I> n0,
+				I f1, iter_difference_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
 			{
 				STL2_EXPECT(0 <= n0);
@@ -136,7 +136,7 @@ STL2_OPEN_NAMESPACE {
 					return fsort::merge_n_with_buffer(f0, n0, f1, n1, buf, comp, proj);
 				}
 				I f0_0, f0_1, f1_0, f1_1;
-				difference_type_t<I> n0_0, n0_1, n1_0, n1_1;
+				iter_difference_t<I> n0_0, n0_1, n1_0, n1_1;
 
 				if (n0 < n1) {
 					fsort::merge_n_step_0(f0, n0, f1, n1, comp, proj,
@@ -154,7 +154,7 @@ STL2_OPEN_NAMESPACE {
 			template <class I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			I sort_n_adaptive(I first, const difference_type_t<I> n, buf_t<I>& buf,
+			I sort_n_adaptive(I first, const iter_difference_t<I> n, buf_t<I>& buf,
 				Comp& comp, Proj& proj)
 			{
 				STL2_EXPECT(0 <= n);
@@ -171,13 +171,13 @@ STL2_OPEN_NAMESPACE {
 			template <class I, class Comp = less<>, class Proj = identity>
 			requires
 				Sortable<I, Comp, Proj>
-			inline I sort_n(I first, const difference_type_t<I> n,
+			inline I sort_n(I first, const iter_difference_t<I> n,
 				Comp comp = Comp{}, Proj proj = Proj{})
 			{
 				STL2_EXPECT(0 <= n);
 				auto ufirst = ext::uncounted(first);
-				static_assert(Same<value_type_t<I>, value_type_t<decltype(ufirst)>>);
-				using buf_t = temporary_buffer<value_type_t<I>>;
+				static_assert(Same<iter_value_t<I>, iter_value_t<decltype(ufirst)>>);
+				using buf_t = temporary_buffer<iter_value_t<I>>;
 				// TODO: tune this threshold.
 				auto buf = n / 2 >= 16 ? buf_t{n / 2} : buf_t{};
 				auto last = detail::fsort::sort_n_adaptive(std::move(ufirst), n,

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		Invocable<F&> &&
 		Writable<O, result_of_t<F&()>>
-	O generate_n(O first, difference_type_t<O> n, F gen)
+	O generate_n(O first, iter_difference_t<O> n, F gen)
 	{
 		for (; n > 0; ++first, --n) {
 			*first = gen();

--- a/include/stl2/detail/algorithm/heap_sift.hpp
+++ b/include/stl2/detail/algorithm/heap_sift.hpp
@@ -37,14 +37,14 @@ STL2_OPEN_NAMESPACE {
 		requires
 			IndirectStrictWeakOrder<Comp,
 				projected<I, Proj>, projected<I, Proj>>
-		void sift_up_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
+		void sift_up_n(I first, iter_difference_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
 				I last = first + n;
 				n = (n - 2) / 2;
 				I i = first + n;
 				if (__stl2::invoke(comp, __stl2::invoke(proj, *i), __stl2::invoke(proj, *--last))) {
-					value_type_t<I> v = __stl2::iter_move(last);
+					iter_value_t<I> v = __stl2::iter_move(last);
 					do {
 						*last = __stl2::iter_move(i);
 						last = i;
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 		requires
 			IndirectStrictWeakOrder<Comp,
 				projected<I, Proj>, projected<I, Proj>>
-		void sift_down_n(I first, difference_type_t<I> n, I start,
+		void sift_down_n(I first, iter_difference_t<I> n, I start,
 			Comp comp, Proj proj)
 		{
 			// left-child of start is at 2 * start + 1
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 				return;
 			}
 
-			value_type_t<I> top = __stl2::iter_move(start);
+			iter_value_t<I> top = __stl2::iter_move(start);
 			do {
 				// we are not in heap-order, swap the parent with it's largest child
 				*start = __stl2::iter_move(child_i);

--- a/include/stl2/detail/algorithm/inplace_merge.hpp
+++ b/include/stl2/detail/algorithm/inplace_merge.hpp
@@ -49,13 +49,13 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class C, class P>
 			requires
 				Sortable<I, C, P>
-			static void impl(I begin, I middle, I end, difference_type_t<I> len1,
-				difference_type_t<I> len2, temporary_buffer<value_type_t<I>>& buf,
+			static void impl(I begin, I middle, I end, iter_difference_t<I> len1,
+				iter_difference_t<I> len2, temporary_buffer<iter_value_t<I>>& buf,
 				C& pred, P& proj)
 			{
 				STL2_EXPENSIVE_ASSERT(len1 == __stl2::distance(begin, midddle));
 				STL2_EXPENSIVE_ASSERT(len2 == __stl2::distance(middle, end));
-				temporary_vector<value_type_t<I>> vec{buf};
+				temporary_vector<iter_value_t<I>> vec{buf};
 				if (len1 <= len2) {
 					__stl2::move(begin, middle, __stl2::back_inserter(vec));
 					__stl2::merge(
@@ -83,12 +83,12 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class C, class P>
 			requires
 				Sortable<I, __f<C>, __f<P>>
-			void operator()(I begin, I middle, I end, difference_type_t<I> len1, difference_type_t<I> len2,
-				detail::temporary_buffer<value_type_t<I>>& buf, C pred, P proj) const
+			void operator()(I begin, I middle, I end, iter_difference_t<I> len1, iter_difference_t<I> len2,
+				detail::temporary_buffer<iter_value_t<I>>& buf, C pred, P proj) const
 			{
 				// Pre: len1 == distance(begin, midddle)
 				// Pre: len2 == distance(middle, end)
-				using D = difference_type_t<I>;
+				using D = iter_difference_t<I>;
 				while (true) {
 					// if middle == end, we're done
 					if (len2 == 0) {
@@ -178,10 +178,10 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class C = less<>, class P = identity>
 			requires
 				Sortable<I, __f<C>, __f<P>>
-			void operator()(I begin, I middle, I end, difference_type_t<I> len1,
-				difference_type_t<I> len2, C pred = C{}, P proj = P{}) const
+			void operator()(I begin, I middle, I end, iter_difference_t<I> len1,
+				iter_difference_t<I> len2, C pred = C{}, P proj = P{}) const
 			{
-				temporary_buffer<value_type_t<I>> no_buffer;
+				temporary_buffer<iter_value_t<I>> no_buffer;
 				merge_adaptive(std::move(begin), std::move(middle), std::move(end),
 					len1, len2, no_buffer, std::ref(pred), std::ref(proj));
 			}
@@ -201,9 +201,9 @@ STL2_OPEN_NAMESPACE {
 		auto len1 = __stl2::distance(first, middle);
 		auto len2_and_end = __stl2::ext::enumerate(middle, std::move(last));
 		auto buf_size = std::min(len1, len2_and_end.count());
-		detail::temporary_buffer<value_type_t<I>> buf;
-		if (is_trivially_move_assignable<value_type_t<I>>{} && 8 < buf_size) {
-			buf = detail::temporary_buffer<value_type_t<I>>{buf_size};
+		detail::temporary_buffer<iter_value_t<I>> buf;
+		if (is_trivially_move_assignable<iter_value_t<I>>{} && 8 < buf_size) {
+			buf = detail::temporary_buffer<iter_value_t<I>>{buf_size};
 		}
 		detail::merge_adaptive(std::move(first), std::move(middle), len2_and_end.end(),
 			len1, len2_and_end.count(), buf, std::ref(comp), std::ref(proj));

--- a/include/stl2/detail/algorithm/is_heap_until.hpp
+++ b/include/stl2/detail/algorithm/is_heap_until.hpp
@@ -36,11 +36,11 @@ STL2_OPEN_NAMESPACE {
 		requires
 			IndirectStrictWeakOrder<
 				Comp, projected<I, Proj>>
-		I is_heap_until_n(I first, const difference_type_t<I> n,
+		I is_heap_until_n(I first, const iter_difference_t<I> n,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
 			STL2_EXPECT(0 <= n);
-			difference_type_t<I> p = 0, c = 1;
+			iter_difference_t<I> p = 0, c = 1;
 			I pp = first;
 			while (c < n) {
 				I cp = first + c;

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			{
 				// Count number of *i in [f2, l2)
-				difference_type_t<I2> c2 = 0;
+				iter_difference_t<I2> c2 = 0;
 				for (I2 j = first2; j != last2; ++j) {
 					if (__stl2::invoke(pred, __stl2::invoke(proj1, *i), __stl2::invoke(proj2, *j))) {
 						++c2;
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 					return false;
 				}
 				// Count number of *i in [i, l1) (we can start with 1)
-				difference_type_t<I1> c1 = 1;
+				iter_difference_t<I1> c1 = 1;
 				for (I1 j = __stl2::next(i); j != last1; ++j) {
 					if (__stl2::invoke(pred, __stl2::invoke(proj1, *i), __stl2::invoke(proj1, *j))) {
 						++c1;

--- a/include/stl2/detail/algorithm/lower_bound.hpp
+++ b/include/stl2/detail/algorithm/lower_bound.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			ForwardIterator<__f<I>> &&
 			IndirectStrictWeakOrder<
 				Comp, const T*, projected<__f<I>, Proj>>
-		__f<I> lower_bound_n(I&& first, difference_type_t<__f<I>> n,
+		__f<I> lower_bound_n(I&& first, iter_difference_t<__f<I>> n,
 			const T& value, Comp comp = Comp{}, Proj proj = Proj{})
 		{
 			return __stl2::ext::partition_point_n(

--- a/include/stl2/detail/algorithm/make_heap.hpp
+++ b/include/stl2/detail/algorithm/make_heap.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
 			Sortable<I, Comp, Proj>
-		void make_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
+		void make_heap_n(I first, iter_difference_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
 				// start from the first parent, there is no need to consider children

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -26,16 +26,16 @@ STL2_OPEN_NAMESPACE {
 	namespace __max {
 		template <InputRange Rng, class Comp, class Proj>
 		requires
-			Copyable<value_type_t<iterator_t<Rng>>> &&
+			Copyable<iter_value_t<iterator_t<Rng>>> &&
 			IndirectStrictWeakOrder<
 				Comp, projected<iterator_t<Rng>, Proj>>
-		constexpr value_type_t<iterator_t<Rng>>
+		constexpr iter_value_t<iterator_t<Rng>>
 		impl(Rng&& rng, Comp comp, Proj proj)
 		{
 			auto first = __stl2::begin(rng);
 			auto last = __stl2::end(rng);
 			STL2_EXPECT(first != last);
-			value_type_t<iterator_t<Rng>> result = *first;
+			iter_value_t<iterator_t<Rng>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
 				if (__invoke::impl(comp, __invoke::impl(proj, result), __invoke::impl(proj, tmp))) {
@@ -58,10 +58,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		Copyable<value_type_t<iterator_t<Rng>>> &&
+		Copyable<iter_value_t<iterator_t<Rng>>> &&
 		IndirectStrictWeakOrder<
 			Comp, projected<iterator_t<Rng>, Proj>>
-	STL2_CONSTEXPR_EXT value_type_t<iterator_t<Rng>>
+	STL2_CONSTEXPR_EXT iter_value_t<iterator_t<Rng>>
 	max(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __max::impl(rng, std::ref(comp), std::ref(proj));

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -45,13 +45,13 @@ STL2_OPEN_NAMESPACE {
 					std::move(first1), std::move(last1), std::move(result));
 				break;
 			}
-			reference_t<I1>&& v1 = *first1;
-			reference_t<I2>&& v2 = *first2;
+			iter_reference_t<I1>&& v1 = *first1;
+			iter_reference_t<I2>&& v2 = *first2;
 			if (__stl2::invoke(comp, __stl2::invoke(proj1, v1), __stl2::invoke(proj2, v2))) {
-				*result = std::forward<reference_t<I1>>(v1);
+				*result = std::forward<iter_reference_t<I1>>(v1);
 				++first1;
 			} else {
-				*result = std::forward<reference_t<I2>>(v2);
+				*result = std::forward<iter_reference_t<I2>>(v2);
 				++first2;
 			}
 			++result;

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -26,16 +26,16 @@ STL2_OPEN_NAMESPACE {
 	namespace __min {
 		template <InputRange Rng, class Comp = less<>, class Proj = identity>
 		requires
-			Copyable<value_type_t<iterator_t<Rng>>> &&
+			Copyable<iter_value_t<iterator_t<Rng>>> &&
 			IndirectStrictWeakOrder<
 				Comp, projected<iterator_t<Rng>, Proj>>
-		constexpr value_type_t<iterator_t<Rng>>
+		constexpr iter_value_t<iterator_t<Rng>>
 		impl(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 		{
 			auto first = __stl2::begin(rng);
 			auto last = __stl2::end(rng);
 			STL2_EXPECT(first != last);
-			value_type_t<iterator_t<Rng>> result = *first;
+			iter_value_t<iterator_t<Rng>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
 				if (__invoke::impl(comp, __invoke::impl(proj, tmp), __invoke::impl(proj, result))) {
@@ -58,10 +58,10 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		Copyable<value_type_t<iterator_t<Rng>>> &&
+		Copyable<iter_value_t<iterator_t<Rng>>> &&
 		IndirectStrictWeakOrder<
 			Comp, projected<iterator_t<Rng>, Proj>>
-	STL2_CONSTEXPR_EXT value_type_t<iterator_t<Rng>>
+	STL2_CONSTEXPR_EXT iter_value_t<iterator_t<Rng>>
 	min(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __min::impl(rng, std::ref(comp), std::ref(proj));

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -27,14 +27,14 @@ STL2_OPEN_NAMESPACE {
 	namespace __minmax {
 		template <InputRange Rng, class Comp = less<>, class Proj = identity>
 		requires
-			Copyable<value_type_t<iterator_t<Rng>>> &&
+			Copyable<iter_value_t<iterator_t<Rng>>> &&
 			IndirectStrictWeakOrder<
 				Comp, projected<iterator_t<Rng>, Proj>>
-		constexpr tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
-			tag::max(value_type_t<iterator_t<Rng>>)>
+		constexpr tagged_pair<tag::min(iter_value_t<iterator_t<Rng>>),
+			tag::max(iter_value_t<iterator_t<Rng>>)>
 		impl(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 		{
-			using V = value_type_t<iterator_t<Rng>>;
+			using V = iter_value_t<iterator_t<Rng>>;
 			auto first = __stl2::begin(rng);
 			auto last = __stl2::end(rng);
 			STL2_EXPECT(first != last);
@@ -99,11 +99,11 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class Comp = less<>, class Proj = identity>
 	requires
-		Copyable<value_type_t<iterator_t<Rng>>> &&
+		Copyable<iter_value_t<iterator_t<Rng>>> &&
 		IndirectStrictWeakOrder<
 			Comp, projected<iterator_t<Rng>, Proj>>
-	STL2_CONSTEXPR_EXT tagged_pair<tag::min(value_type_t<iterator_t<Rng>>),
-		tag::max(value_type_t<iterator_t<Rng>>)>
+	STL2_CONSTEXPR_EXT tagged_pair<tag::min(iter_value_t<iterator_t<Rng>>),
+		tag::max(iter_value_t<iterator_t<Rng>>)>
 	minmax(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		return __minmax::impl(rng, std::ref(comp), std::ref(proj));

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -86,13 +86,13 @@ STL2_OPEN_NAMESPACE {
 	I nth_element(I first, I nth, S last, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		I end = __stl2::next(nth, last), end_orig = end;
-		constexpr difference_type_t<I> limit = 7;
+		constexpr iter_difference_t<I> limit = 7;
 		while (true) {
 		restart:
 			if (nth == end) {
 				return end_orig;
 			}
-			difference_type_t<I> len = end - first;
+			iter_difference_t<I> len = end - first;
 			switch (len) {
 			case 0:
 			case 1:

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -48,9 +48,9 @@ STL2_OPEN_NAMESPACE {
 			__stl2::make_heap(result_first, r, std::ref(comp), std::ref(proj2));
 			const auto len = __stl2::distance(result_first, r);
 			for(; first != last; ++first) {
-				reference_t<I1>&& x = *first;
+				iter_reference_t<I1>&& x = *first;
 				if(__stl2::invoke(comp, __stl2::invoke(proj1, x), __stl2::invoke(proj2, *result_first))) {
-					*result_first = std::forward<reference_t<I1>>(x);
+					*result_first = std::forward<iter_reference_t<I1>>(x);
 					detail::sift_down_n(result_first, len, result_first,
 						std::ref(comp), std::ref(proj2));
 				}

--- a/include/stl2/detail/algorithm/partition_copy.hpp
+++ b/include/stl2/detail/algorithm/partition_copy.hpp
@@ -36,12 +36,12 @@ STL2_OPEN_NAMESPACE {
 		Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (__stl2::invoke(pred, __stl2::invoke(proj, v))) {
-				*out_true  = std::forward<reference_t<I>>(v);
+				*out_true  = std::forward<iter_reference_t<I>>(v);
 				++out_true;
 			} else {
-				*out_false = std::forward<reference_t<I>>(v);
+				*out_false = std::forward<iter_reference_t<I>>(v);
 				++out_false;
 			}
 		}

--- a/include/stl2/detail/algorithm/partition_point.hpp
+++ b/include/stl2/detail/algorithm/partition_point.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 		requires
 			IndirectUnaryPredicate<
 				Pred, projected<I, Proj>>
-		I partition_point_n(I first, difference_type_t<I> n,
+		I partition_point_n(I first, iter_difference_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
 			STL2_EXPECT(0 <= n);
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		// Probe exponentially for either end-of-range or an iterator
 		// that is past the partition point (i.e., does not satisfy pred).
-		auto n = difference_type_t<I>{1};
+		auto n = iter_difference_t<I>{1};
 		while (true) {
 			auto m = first;
 			auto d = __stl2::advance(m, n, last);

--- a/include/stl2/detail/algorithm/pop_heap.hpp
+++ b/include/stl2/detail/algorithm/pop_heap.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		template <RandomAccessIterator I, class Proj, class Comp>
 		requires
 			Sortable<I, Comp, Proj>
-		void pop_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
+		void pop_heap_n(I first, iter_difference_t<I> n, Comp comp, Proj proj)
 		{
 			if (n > 1) {
 				__stl2::iter_swap(first, first + (n - 1));

--- a/include/stl2/detail/algorithm/random_access_sort.hpp
+++ b/include/stl2/detail/algorithm/random_access_sort.hpp
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 			I choose_pivot(I first, I last, Comp& comp, Proj& proj)
 			{
 				STL2_EXPECT(first != last);
-				I mid = first + difference_type_t<I>(last - first) / 2;
+				I mid = first + iter_difference_t<I>(last - first) / 2;
 				--last;
 				// Find the median:
 				return [&](auto&& a, auto&& b, auto&& c) {
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 			template <BidirectionalIterator I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			void unguarded_linear_insert(I last, value_type_t<I> val, Comp& comp, Proj& proj)
+			void unguarded_linear_insert(I last, iter_value_t<I> val, Comp& comp, Proj& proj)
 			{
 				I next = __stl2::prev(last);
 				while (__stl2::invoke(comp, __stl2::invoke(proj, val), __stl2::invoke(proj, *next))) {
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 				Sortable<I, Comp, Proj>
 			void linear_insert(I first, I last, Comp& comp, Proj& proj)
 			{
-				value_type_t<I> val = __stl2::iter_move(last);
+				iter_value_t<I> val = __stl2::iter_move(last);
 				if (__stl2::invoke(comp, __stl2::invoke(proj, val), __stl2::invoke(proj, *first))) {
 					__stl2::move_backward(first, last, last + 1);
 					*first = std::move(val);
@@ -135,7 +135,7 @@ STL2_OPEN_NAMESPACE {
 			template <RandomAccessIterator I, class Comp, class Proj>
 			requires
 				Sortable<I, Comp, Proj>
-			void introsort_loop(I first, I last, difference_type_t<I> depth_limit,
+			void introsort_loop(I first, I last, iter_difference_t<I> depth_limit,
 				Comp& comp, Proj& proj)
 			{
 				while (__stl2::distance(first, last) > introsort_threshold) {

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -32,9 +32,9 @@ STL2_OPEN_NAMESPACE {
 	remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (__stl2::invoke(proj, v) != value) {
-				*result = std::forward<reference_t<I>>(v);
+				*result = std::forward<iter_reference_t<I>>(v);
 				++result;
 			}
 		}

--- a/include/stl2/detail/algorithm/remove_copy_if.hpp
+++ b/include/stl2/detail/algorithm/remove_copy_if.hpp
@@ -33,9 +33,9 @@ STL2_OPEN_NAMESPACE {
 	remove_copy_if(I first, S last, O result, Pred pred, Proj proj = Proj{})
 	{
 		for (; first != last; ++first) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (!__stl2::invoke(pred, __stl2::invoke(proj, v))) {
-				*result = std::forward<reference_t<I>>(v);
+				*result = std::forward<iter_reference_t<I>>(v);
 				++result;
 			}
 		}

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -31,11 +31,11 @@ STL2_OPEN_NAMESPACE {
 		const T2& new_value, Proj proj = Proj{})
 	{
 		for (; first != last; ++first, ++result) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (__stl2::invoke(proj, v) == old_value) {
 				*result = new_value;
 			} else {
-				*result = std::forward<reference_t<I>>(v);
+				*result = std::forward<iter_reference_t<I>>(v);
 			}
 		}
 		return {std::move(first), std::move(result)};

--- a/include/stl2/detail/algorithm/replace_copy_if.hpp
+++ b/include/stl2/detail/algorithm/replace_copy_if.hpp
@@ -31,11 +31,11 @@ STL2_OPEN_NAMESPACE {
 		const T& new_value, Proj proj = Proj{})
 	{
 		for (; first != last; ++first, ++result) {
-			reference_t<I>&& v = *first;
+			iter_reference_t<I>&& v = *first;
 			if (__stl2::invoke(pred, __stl2::invoke(proj, v))) {
 				*result = new_value;
 			} else {
-				*result = std::forward<reference_t<I>>(v);
+				*result = std::forward<iter_reference_t<I>>(v);
 			}
 		}
 		return {std::move(first), std::move(result)};

--- a/include/stl2/detail/algorithm/reverse.hpp
+++ b/include/stl2/detail/algorithm/reverse.hpp
@@ -47,8 +47,8 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		requires
 			Permutable<I>
-		I reverse_n_with_half_buffer(I first, const difference_type_t<I> n,
-			temporary_buffer<value_type_t<I>>& buf)
+		I reverse_n_with_half_buffer(I first, const iter_difference_t<I> n,
+			temporary_buffer<iter_value_t<I>>& buf)
 		{
 			// Precondition: $\property{mutable\_counted\_range}(first, n)$
 			STL2_EXPECT(n / 2 <= buf.size());
@@ -76,11 +76,11 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		requires
 			Permutable<I>
-		I reverse_n_adaptive(I first, const difference_type_t<I> n,
-			temporary_buffer<value_type_t<I>>& buf)
+		I reverse_n_adaptive(I first, const iter_difference_t<I> n,
+			temporary_buffer<iter_value_t<I>>& buf)
 		{
 			// Precondition: $\property{mutable\_counted\_range}(first, n)$
-			if (n < difference_type_t<I>(2)) {
+			if (n < iter_difference_t<I>(2)) {
 				return __stl2::next(std::move(first), n);
 			}
 
@@ -102,12 +102,12 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		requires
 			Permutable<I>
-		I reverse_n(I first, difference_type_t<I> n)
+		I reverse_n(I first, iter_difference_t<I> n)
 		{
 			auto ufirst = ext::uncounted(first);
-			using buf_t = temporary_buffer<value_type_t<decltype(ufirst)>>;
+			using buf_t = temporary_buffer<iter_value_t<decltype(ufirst)>>;
 			// TODO: tune this threshold.
-			constexpr auto alloc_threshold = difference_type_t<I>(8);
+			constexpr auto alloc_threshold = iter_difference_t<I>(8);
 			auto buf = n >= alloc_threshold ? buf_t{n / 2} : buf_t{};
 			auto last = detail::reverse_n_adaptive(ufirst, n, buf);
 			return ext::recounted(first, std::move(last), n);

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		Permutable<I>
 	ext::subrange<I> __rotate_left(I first, I last)
 	{
-		value_type_t<I> tmp = __stl2::iter_move(first);
+		iter_value_t<I> tmp = __stl2::iter_move(first);
 		I lm1 = __stl2::move(__stl2::next(first), last, first).second;
 		*lm1 = std::move(tmp);
 		return {std::move(lm1), std::move(last)};
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	ext::subrange<I> __rotate_right(I first, I last)
 	{
 		I lm1 = __stl2::prev(last);
-		value_type_t<I> tmp = __stl2::iter_move(lm1);
+		iter_value_t<I> tmp = __stl2::iter_move(lm1);
 		I fp1 = __stl2::move_backward(first, std::move(lm1), last).second;
 		*first = std::move(tmp);
 		return {std::move(fp1), std::move(last)};
@@ -107,7 +107,7 @@ STL2_OPEN_NAMESPACE {
 		Permutable<I>
 	ext::subrange<I> __rotate_gcd(I first, I middle, I last)
 	{
-		using D = difference_type_t<I>;
+		using D = iter_difference_t<I>;
 		D const m1 = middle - first;
 		D const m2 = last - middle;
 		if (m1 == m2) {
@@ -116,7 +116,7 @@ STL2_OPEN_NAMESPACE {
 		}
 		auto const g = __stl2::__gcd(m1, m2);
 		for (I p = first + g; p != first;) {
-			value_type_t<I> t = __stl2::iter_move(--p);
+			iter_value_t<I> t = __stl2::iter_move(--p);
 			I p1 = p;
 			I p2 = p1 + m1;
 			do {
@@ -145,7 +145,7 @@ STL2_OPEN_NAMESPACE {
 	Permutable{I}
 	ext::subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<value_type_t<I>>()) {
+		if (is_trivially_move_assignable<iter_value_t<I>>()) {
 			if (__stl2::next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}
@@ -158,7 +158,7 @@ STL2_OPEN_NAMESPACE {
 	requires Permutable<I>
 	ext::subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<value_type_t<I>>()) {
+		if (is_trivially_move_assignable<iter_value_t<I>>()) {
 			if (__stl2::next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}
@@ -174,7 +174,7 @@ STL2_OPEN_NAMESPACE {
 	requires Permutable<I>
 	ext::subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<value_type_t<I>>()) {
+		if (is_trivially_move_assignable<iter_value_t<I>>()) {
 			if (__stl2::next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}

--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -28,16 +28,16 @@ STL2_OPEN_NAMESPACE {
 			InputIterator<I> && Sentinel<S, I> && WeaklyIncrementable<O> &&
 			IndirectlyCopyable<I, O> &&
 			UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-			ConvertibleTo<result_of_t<Gen&()>, difference_type_t<I>>;
+			ConvertibleTo<result_of_t<Gen&()>, iter_difference_t<I>>;
 
 		template <class I, class S, class O, class Gen>
 		requires
 			constraint<I, S, O, Gen>
 		tagged_pair<tag::in(I), tag::out(O)>
-		sized_impl(I first, S last, difference_type_t<I> pop_size,
-			O out, difference_type_t<I> n, Gen& gen)
+		sized_impl(I first, S last, iter_difference_t<I> pop_size,
+			O out, iter_difference_t<I> n, Gen& gen)
 		{
-			uniform_int_distribution<difference_type_t<I>> dist;
+			uniform_int_distribution<iter_difference_t<I>> dist;
 			using param_t = typename decltype(dist)::param_type;
 			if (n > pop_size) {
 				n = pop_size;
@@ -59,7 +59,7 @@ STL2_OPEN_NAMESPACE {
 		(ForwardIterator<I> || SizedSentinel<S, I>) &&
 		__sample::constraint<I, S, O, Gen>
 	tagged_pair<tag::in(I), tag::out(O)>
-	inline sample(I first, S last, O out, difference_type_t<I> n,
+	inline sample(I first, S last, O out, iter_difference_t<I> n,
 		Gen&& gen = detail::get_random_engine())
 	{
 		auto k = __stl2::distance(first, last);
@@ -73,19 +73,19 @@ STL2_OPEN_NAMESPACE {
 		!(ForwardIterator<I> || SizedSentinel<S, I>) &&
 		__sample::constraint<I, S, O, Gen>
 	tagged_pair<tag::in(I), tag::out(O)>
-	sample(I first, S last, O out, difference_type_t<I> n,
+	sample(I first, S last, O out, iter_difference_t<I> n,
 		Gen&& gen = detail::get_random_engine())
 	{
 		if (n <= 0) {
 			goto done;
 		}
-		for (difference_type_t<I> i = 0; i < n; (void)++i, ++first) {
+		for (iter_difference_t<I> i = 0; i < n; (void)++i, ++first) {
 			if (first == last) {
 				goto done;
 			}
 			out[i] = *first;
 		}
-		uniform_int_distribution<difference_type_t<I>> dist;
+		uniform_int_distribution<iter_difference_t<I>> dist;
 		using param_t = typename decltype(dist)::param_type;
 		for (auto pop_size = n; first != last; (void)++first, ++pop_size) {
 			auto const i = dist(gen, param_t{0, pop_size});
@@ -134,7 +134,7 @@ STL2_OPEN_NAMESPACE {
 		!(ForwardRange<Rng> || SizedRange<Rng>) &&
 		__sample::constraint<iterator_t<Rng>, sentinel_t<Rng>, O, Gen>
 	inline tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
-	sample(Rng&& rng, O out, difference_type_t<iterator_t<Rng>> n,
+	sample(Rng&& rng, O out, iter_difference_t<iterator_t<Rng>> n,
 		Gen&& gen = detail::get_random_engine())
 	{
 		return __stl2::sample(__stl2::begin(rng), __stl2::end(rng),
@@ -146,7 +146,7 @@ STL2_OPEN_NAMESPACE {
 		(ForwardRange<Rng> || SizedRange<Rng>) &&
 		__sample::constraint<iterator_t<Rng>, sentinel_t<Rng>, O, Gen>
 	inline tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
-	sample(Rng&& rng, O out, difference_type_t<iterator_t<Rng>> n,
+	sample(Rng&& rng, O out, iter_difference_t<iterator_t<Rng>> n,
 		Gen&& gen = detail::get_random_engine())
 	{
 		return __sample::sized_impl(__stl2::begin(rng), __stl2::end(rng),

--- a/include/stl2/detail/algorithm/search.hpp
+++ b/include/stl2/detail/algorithm/search.hpp
@@ -77,8 +77,8 @@ STL2_OPEN_NAMESPACE {
 			IndirectlyComparable<
 				I1, I2, Pred, Proj1, Proj2>
 		ext::subrange<I1> sized(
-			const I1 first1_, S1 last1, const difference_type_t<I1> d1_,
-			I2 first2, S2 last2, const difference_type_t<I2> d2,
+			const I1 first1_, S1 last1, const iter_difference_t<I1> d1_,
+			I2 first2, S2 last2, const iter_difference_t<I2> d2,
 			Pred pred, Proj1 proj1, Proj2 proj2)
 		{
 			if (d2 == 0) {

--- a/include/stl2/detail/algorithm/search_n.hpp
+++ b/include/stl2/detail/algorithm/search_n.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 		template <ForwardIterator I, Sentinel<I> S, class T, class Pred, class Proj>
 		requires
 			IndirectlyComparable<I, const T*, Pred, Proj>
-		I unsized(I first, S last, difference_type_t<I> count,
+		I unsized(I first, S last, iter_difference_t<I> count,
 			const T& value, Pred pred, Proj proj)
 		{
 			if (count <= 0) {
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 			for (; first != last; ++first) {
 				if (__stl2::invoke(pred, __stl2::invoke(proj, *first), value)) {
 					auto saved = first;
-					difference_type_t<I> n = 0;
+					iter_difference_t<I> n = 0;
 					do {
 						if (++n == count) {
 							return saved;
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 		template <ForwardIterator I, Sentinel<I> S, class T, class Pred, class Proj>
 		requires
 			IndirectlyComparable<I, const T*, Pred, Proj>
-		I sized(I first_, S last, difference_type_t<I> d_,
-			difference_type_t<I> count,
+		I sized(I first_, S last, iter_difference_t<I> d_,
+			iter_difference_t<I> count,
 			const T& value, Pred pred, Proj proj)
 		{
 			if (count <= 0) {
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 				if (__stl2::invoke(pred, __stl2::invoke(proj, *first), value)) {
 					// *first matches val, now match elements after here
 					auto saved = first;
-					difference_type_t<I> n = 0;
+					iter_difference_t<I> n = 0;
 					do {
 						if (++n == count) {
 							// Pattern exhausted, saved is the answer
@@ -101,7 +101,7 @@ STL2_OPEN_NAMESPACE {
 		class Pred = equal_to<>, class Proj = identity>
 	requires
 		IndirectlyComparable<I, const T*, Pred, Proj>
-	I search_n(I first, S last, difference_type_t<I> count,
+	I search_n(I first, S last, iter_difference_t<I> count,
 						 const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		return __search_n::unsized(std::move(first), std::move(last),
@@ -113,7 +113,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		SizedSentinel<S, I> &&
 		IndirectlyComparable<I, const T*, Pred, Proj>
-	I search_n(I first, S last, difference_type_t<I> count,
+	I search_n(I first, S last, iter_difference_t<I> count,
 						 const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		auto n = __stl2::distance(first, last);
@@ -126,7 +126,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyComparable<
 			iterator_t<Rng>, const T*, Pred, Proj>
 	safe_iterator_t<Rng>
-	search_n(Rng&& rng, difference_type_t<iterator_t<Rng>> count,
+	search_n(Rng&& rng, iter_difference_t<iterator_t<Rng>> count,
 		const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		return __search_n::unsized(
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyComparable<
 			iterator_t<Rng>, const T*, Pred, Proj>
 	safe_iterator_t<Rng>
-	search_n(Rng&& rng, difference_type_t<iterator_t<Rng>> count,
+	search_n(Rng&& rng, iter_difference_t<iterator_t<Rng>> count,
 		const T& value, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		return __search_n::sized(

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -34,12 +34,12 @@ STL2_OPEN_NAMESPACE {
 		Comp comp = Comp{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	{
 		while (first1 != last1 && first2 != last2) {
-			reference_t<I1>&& v1 = *first1;
-			reference_t<I2>&& v2 = *first2;
+			iter_reference_t<I1>&& v1 = *first1;
+			iter_reference_t<I2>&& v2 = *first2;
 			auto&& p1 = __stl2::invoke(proj1, v1);
 			auto&& p2 = __stl2::invoke(proj2, v2);
 			if (__stl2::invoke(comp, p1, p2)) {
-				*result = std::forward<reference_t<I1>>(v1);
+				*result = std::forward<iter_reference_t<I1>>(v1);
 				++result;
 				++first1;
 			} else {

--- a/include/stl2/detail/algorithm/set_intersection.hpp
+++ b/include/stl2/detail/algorithm/set_intersection.hpp
@@ -33,8 +33,8 @@ STL2_OPEN_NAMESPACE {
 		Proj2 proj2 = Proj2{})
 	{
 		while (first1 != last1 && first2 != last2) {
-			reference_t<I1>&& v1 = *first1;
-			reference_t<I2>&& v2 = *first2;
+			iter_reference_t<I1>&& v1 = *first1;
+			iter_reference_t<I2>&& v2 = *first2;
 			auto&& p1 = __stl2::invoke(proj1, v1);
 			auto&& p2 = __stl2::invoke(proj2, v2);
 			if (__stl2::invoke(comp, p1, p2)) {
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 			} else if (__stl2::invoke(comp, p2, p1)) {
 				++first2;
 			} else {
-				*result = std::forward<reference_t<I1>>(v1);
+				*result = std::forward<iter_reference_t<I1>>(v1);
 				++result;
 				++first1;
 				++first2;

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -47,17 +47,17 @@ STL2_OPEN_NAMESPACE {
 					__stl2::copy(std::move(first1), std::move(last1), std::move(result));
 				break;
 			}
-			reference_t<I1>&& v1 = *first1;
-			reference_t<I2>&& v2 = *first2;
+			iter_reference_t<I1>&& v1 = *first1;
+			iter_reference_t<I2>&& v2 = *first2;
 			auto&& p1 = __stl2::invoke(proj1, v1);
 			auto&& p2 = __stl2::invoke(proj2, v2);
 			if (__stl2::invoke(comp, p1, p2)) {
-				*result = std::forward<reference_t<I1>>(v1);
+				*result = std::forward<iter_reference_t<I1>>(v1);
 				++result;
 				++first1;
 			} else {
 				if (__stl2::invoke(comp, p2, p1)) {
-					*result = std::forward<reference_t<I2>>(v2);
+					*result = std::forward<iter_reference_t<I2>>(v2);
 					++result;
 				} else {
 					++first1;

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -43,18 +43,18 @@ STL2_OPEN_NAMESPACE {
 				auto res = __stl2::copy(std::move(first1), std::move(last1), std::move(result));
 				return {std::move(res.in()), std::move(first2), std::move(res.out())};
 			}
-			reference_t<I1>&& v1 = *first1;
-			reference_t<I2>&& v2 = *first2;
+			iter_reference_t<I1>&& v1 = *first1;
+			iter_reference_t<I2>&& v2 = *first2;
 			auto&& p1 = __stl2::invoke(proj1, v1);
 			auto&& p2 = __stl2::invoke(proj2, v2);
 			if (__stl2::invoke(comp, p1, p2)) {
-				*result = std::forward<reference_t<I1>>(v1);
+				*result = std::forward<iter_reference_t<I1>>(v1);
 				++first1;
 			} else {
 				if (!__stl2::invoke(comp, p2, p1)) {
 					++first1;
 				}
-				*result = std::forward<reference_t<I2>>(v2);
+				*result = std::forward<iter_reference_t<I2>>(v2);
 				++first2;
 			}
 			++result;

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -25,7 +25,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I, Sentinel<I> S,
-		class Gen = detail::default_random_engine&, class D = difference_type_t<I>>
+		class Gen = detail::default_random_engine&, class D = iter_difference_t<I>>
 	requires
 		Permutable<I> &&
 		UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template <RandomAccessRange Rng, class Gen = detail::default_random_engine&,
-		class D = difference_type_t<iterator_t<Rng>>>
+		class D = iter_difference_t<iterator_t<Rng>>>
 	requires
 		Permutable<iterator_t<Rng>> &&
 		UniformRandomNumberGenerator<remove_reference_t<Gen>> &&

--- a/include/stl2/detail/algorithm/sort_heap.hpp
+++ b/include/stl2/detail/algorithm/sort_heap.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		template <RandomAccessIterator I, class Comp, class Proj>
 		requires
 			Sortable<I, Comp, Proj>
-		void sort_heap_n(I first, difference_type_t<I> n, Comp comp, Proj proj)
+		void sort_heap_n(I first, iter_difference_t<I> n, Comp comp, Proj proj)
 		{
 			if (n < 2) {
 				return;

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -31,11 +31,11 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		namespace stable_part {
 			Readable{I}
-			using buf_t = detail::temporary_buffer<value_type_t<I>>;
+			using buf_t = detail::temporary_buffer<iter_value_t<I>>;
 
 			template <ForwardIterator I, class Proj,
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			void skip_true(I& first, difference_type_t<I>& n, Pred& pred, Proj& proj)
+			void skip_true(I& first, iter_difference_t<I>& n, Pred& pred, Proj& proj)
 			{
 				// advance "first" past values that satisfy the predicate.
 				// Ensures: n == 0 || !__stl2::invoke(pred, __stl2::invoke(proj, *first))
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 			requires
 				Permutable<I>
 			ext::subrange<I>
-			forward_buffer(I first, I next, difference_type_t<I> n,
+			forward_buffer(I first, I next, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
 				// Precondition: !__stl2::invoke(pred, __stl2::invoke(proj, *first)))
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 			requires
 				Permutable<I>
 			ext::subrange<I>
-			forward_reduce(I first, difference_type_t<I> n, buf_t<I>& buf,
+			forward_reduce(I first, iter_difference_t<I> n, buf_t<I>& buf,
 				Pred& pred, Proj& proj);
 
 			template <ForwardIterator I, class Proj,
@@ -85,14 +85,14 @@ STL2_OPEN_NAMESPACE {
 			requires
 				Permutable<I>
 			ext::subrange<I>
-			forward(I first, difference_type_t<I> n, buf_t<I>& buf, Pred& pred,
+			forward(I first, iter_difference_t<I> n, buf_t<I>& buf, Pred& pred,
 				Proj& proj)
 			{
 				// Precondition: !__stl2::invoke(pred, __stl2::invoke(proj, *first)))
 				STL2_EXPECT(n > 0);
 
 				auto middle = __stl2::next(first);
-				if (n == difference_type_t<I>(1)) {
+				if (n == iter_difference_t<I>(1)) {
 					return {std::move(first), std::move(middle)};
 				}
 				// n >= 2
@@ -116,13 +116,13 @@ STL2_OPEN_NAMESPACE {
 			requires
 				Permutable<I>
 			ext::subrange<I>
-			forward_reduce(I first, difference_type_t<I> n, buf_t<I>& buf,
+			forward_reduce(I first, iter_difference_t<I> n, buf_t<I>& buf,
 				Pred& pred, Proj& proj)
 			{
 				// Establish preconditions of stable_part::forward by reducing the
 				// input range.
 				stable_part::skip_true(first, n, pred, proj);
-				if (n < difference_type_t<I>(2)) {
+				if (n < iter_difference_t<I>(2)) {
 					auto last = __stl2::next(first, n);
 					return {std::move(first), std::move(last)};
 				}
@@ -131,7 +131,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <BidirectionalIterator I, class Proj,
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			void skip_false(I& last, difference_type_t<I>& n, Pred& pred, Proj& proj)
+			void skip_false(I& last, iter_difference_t<I>& n, Pred& pred, Proj& proj)
 			{
 				// Move last backward past values that do not satisfy pred.
 				// Precondition: __stl2::invoke(pred, __stl2::invoke(proj, *(last - n)))
@@ -147,7 +147,7 @@ STL2_OPEN_NAMESPACE {
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional_buffer(I first, I last, difference_type_t<I> n,
+			I bidirectional_buffer(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
 				// Precondition: !__stl2::invoke(pred, __stl2::invoke(proj, *first))
@@ -178,29 +178,29 @@ STL2_OPEN_NAMESPACE {
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional_reduce_front(I first, I last, difference_type_t<I> n,
+			I bidirectional_reduce_front(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj);
 
 			template <BidirectionalIterator I, class Proj,
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional_reduce_back(I first, I last, difference_type_t<I> n,
+			I bidirectional_reduce_back(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj);
 
 			template <BidirectionalIterator I, class Proj,
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional(I first, I last, difference_type_t<I> n,
+			I bidirectional(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
 				// Precondition: !__stl2::invoke(pred, __stl2::invoke(proj, *first))
 				// Precondition: __stl2::invoke(pred, __stl2::invoke(proj, *last))
 				// Precondition: n == distance(first, last)
-				STL2_EXPECT(n >= difference_type_t<I>(1));
+				STL2_EXPECT(n >= iter_difference_t<I>(1));
 
-				if (n == difference_type_t<I>(1)) {
+				if (n == iter_difference_t<I>(1)) {
 					__stl2::iter_swap(first, last);
 					return last;
 				}
@@ -226,15 +226,15 @@ STL2_OPEN_NAMESPACE {
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional_reduce_front(I first, I last, difference_type_t<I> n,
+			I bidirectional_reduce_front(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
 				// Precondition: __stl2::invoke(pred, __stl2::invoke(proj, *last))
 				// Precondition: n == distance(first, last)
-				STL2_EXPECT(n >= difference_type_t<I>(0));
+				STL2_EXPECT(n >= iter_difference_t<I>(0));
 
 				stable_part::skip_true(first, n, pred, proj);
-				if (n == difference_type_t<I>(0)) {
+				if (n == iter_difference_t<I>(0)) {
 					return std::move(++last);
 				}
 				return stable_part::bidirectional(first, last, n, buf, pred, proj);
@@ -244,15 +244,15 @@ STL2_OPEN_NAMESPACE {
 				IndirectUnaryPredicate<projected<I, Proj>> Pred>
 			requires
 				Permutable<I>
-			I bidirectional_reduce_back(I first, I last, difference_type_t<I> n,
+			I bidirectional_reduce_back(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
 				// Precondition: !__stl2::invoke(pred, __stl2::invoke(proj, *first))
 				// Precondition: n == __stl2::distance(first, last)
-				STL2_EXPECT(n >= difference_type_t<I>(1));
+				STL2_EXPECT(n >= iter_difference_t<I>(1));
 
 				stable_part::skip_false(last, n, pred, proj);
-				if (n == difference_type_t<I>(0)) {
+				if (n == iter_difference_t<I>(0)) {
 					return first;
 				}
 				return stable_part::bidirectional(first, last, n, buf, pred, proj);
@@ -266,19 +266,19 @@ STL2_OPEN_NAMESPACE {
 			Permutable<I> &&
 			IndirectUnaryPredicate<
 				Pred, projected<I, Proj>>
-		I stable_partition_n(I first, difference_type_t<I> n,
+		I stable_partition_n(I first, iter_difference_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
 			// Either prove all true or find first false
 			detail::stable_part::skip_true(first, n, pred, proj);
-			if (n < difference_type_t<I>(2)) {
+			if (n < iter_difference_t<I>(2)) {
 				return first;
 			}
 			// We now have a reduced range [first, first + n)
 			// *first is known to be false
 
 			// might want to make this a function of trivial assignment
-			constexpr difference_type_t<I> alloc_threshold = 4;
+			constexpr iter_difference_t<I> alloc_threshold = 4;
 			using buf_t = detail::stable_part::buf_t<I>;
 			auto buf = n >= alloc_threshold ? buf_t{n} : buf_t{};
 			return detail::stable_part::forward(
@@ -290,19 +290,19 @@ STL2_OPEN_NAMESPACE {
 			Permutable<I> &&
 			IndirectUnaryPredicate<
 				Pred, projected<I, Proj>>
-		I stable_partition_n(I first, I last, difference_type_t<I> n,
+		I stable_partition_n(I first, I last, iter_difference_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
 			// Precondition: n == distance(first, last);
 			// Either prove all true or find first false
 			detail::stable_part::skip_true(first, n, pred, proj);
-			if (n == difference_type_t<I>(0)) {
+			if (n == iter_difference_t<I>(0)) {
 				return first;
 			}
 
 			// Either prove (first, last) is all false or find last true
 			detail::stable_part::skip_false(last, n, pred, proj);
-			if (n == difference_type_t<I>(0)) {
+			if (n == iter_difference_t<I>(0)) {
 				return first;
 			}
 			// We now have a reduced range [first, last]
@@ -310,7 +310,7 @@ STL2_OPEN_NAMESPACE {
 			// *last is known to be true
 
 			// might want to make this a function of trivial assignment
-			constexpr difference_type_t<I> alloc_threshold = 4;
+			constexpr iter_difference_t<I> alloc_threshold = 4;
 			using buf_t = detail::stable_part::buf_t<I>;
 			buf_t buf = n >= alloc_threshold ? buf_t{n} : buf_t{};
 			return detail::stable_part::bidirectional(
@@ -322,7 +322,7 @@ STL2_OPEN_NAMESPACE {
 			Permutable<I> &&
 			IndirectUnaryPredicate<
 				Pred, projected<I, Proj>>
-		I stable_partition_n(I first, difference_type_t<I> n,
+		I stable_partition_n(I first, iter_difference_t<I> n,
 			Pred pred, Proj proj = Proj{})
 		{
 			auto bound = __stl2::next(first, n);

--- a/include/stl2/detail/algorithm/stable_sort.hpp
+++ b/include/stl2/detail/algorithm/stable_sort.hpp
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		namespace ssort {
 			template <class I>
-			using buf_t = temporary_buffer<value_type_t<I>>;
+			using buf_t = temporary_buffer<iter_value_t<I>>;
 
 			constexpr int merge_sort_chunk_size = 7;
 
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 				if (last - first < 15) {
 					rsort::insertion_sort(first, last, pred, proj);
 				} else {
-					I middle = first + difference_type_t<I>(last - first) / 2;
+					I middle = first + iter_difference_t<I>(last - first) / 2;
 					ssort::inplace_stable_sort(first, middle, pred, proj);
 					ssort::inplace_stable_sort(middle, last, pred, proj);
 					detail::inplace_merge_no_buffer(first, middle, last,
@@ -77,9 +77,9 @@ STL2_OPEN_NAMESPACE {
 			requires
 				Sortable<I, C, P>
 			void merge_sort_loop(I first, I last, O result,
-				difference_type_t<I> step_size, C &pred, P &proj)
+				iter_difference_t<I> step_size, C &pred, P &proj)
 			{
-				auto two_step = difference_type_t<I>(2 * step_size);
+				auto two_step = iter_difference_t<I>(2 * step_size);
 				while (last - first >= two_step) {
 					result = __stl2::merge(
 						__stl2::make_move_iterator(first),
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 						std::ref(proj), std::ref(proj)).out();
 					first += two_step;
 				}
-				step_size = __stl2::min(difference_type_t<I>(last - first), step_size);
+				step_size = __stl2::min(iter_difference_t<I>(last - first), step_size);
 				__stl2::merge(
 					__stl2::make_move_iterator(first),
 					__stl2::make_move_iterator(first + step_size),
@@ -103,7 +103,7 @@ STL2_OPEN_NAMESPACE {
 			template <RandomAccessIterator I, class C, class P>
 			requires
 				Sortable<I, C, P>
-			void chunk_insertion_sort(I first, I last, difference_type_t<I> chunk_size,
+			void chunk_insertion_sort(I first, I last, iter_difference_t<I> chunk_size,
 				C &comp, P &proj)
 			{
 				while (last - first >= chunk_size) {
@@ -118,13 +118,13 @@ STL2_OPEN_NAMESPACE {
 				Sortable<I, C, P>
 			void merge_sort_with_buffer(I first, I last, buf_t<I>& buf, C &comp, P &proj)
 			{
-				auto len = difference_type_t<I>(last - first);
-				auto step_size = difference_type_t<I>(merge_sort_chunk_size);
+				auto len = iter_difference_t<I>(last - first);
+				auto step_size = iter_difference_t<I>(merge_sort_chunk_size);
 				ssort::chunk_insertion_sort(first, last, step_size, comp, proj);
 				if (step_size >= len) {
 					return;
 				}
-				temporary_vector<value_type_t<I>> vec{buf};
+				temporary_vector<iter_value_t<I>> vec{buf};
 				ssort::merge_sort_loop(first, last, __stl2::back_inserter(vec), step_size, comp, proj);
 				step_size *= 2;
 				while (true) {
@@ -143,7 +143,7 @@ STL2_OPEN_NAMESPACE {
 				Sortable<I, C, P>
 			void stable_sort_adaptive(I first, I last, buf_t<I>& buf, C &comp, P &proj)
 			{
-				auto len = difference_type_t<I>((last - first + 1) / 2);
+				auto len = iter_difference_t<I>((last - first + 1) / 2);
 				auto middle = first + len;
 				if (len > buf.size()) {
 					ssort::stable_sort_adaptive(first, middle, buf, comp, proj);
@@ -179,7 +179,7 @@ STL2_OPEN_NAMESPACE {
 	I stable_sort(I first, S&& last_, Comp comp = Comp{}, Proj proj = Proj{})
 	{
 		auto last = __stl2::next(first, std::forward<S>(last_));
-		auto len = difference_type_t<I>(last - first);
+		auto len = iter_difference_t<I>(last - first);
 		using buf_t = detail::ssort::buf_t<I>;
 		auto buf = len > 256 ? buf_t{len} : buf_t{};
 		if (!buf.size_) {

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 		CopyConstructible F, class Proj = identity>
 	requires
 		Writable<O,
-			indirect_result_of_t<F&(projected<I, Proj>)>>
+			indirect_invoke_result_t<F&, projected<I, Proj>>>
 	tagged_pair<tag::in(I), tag::out(O)>
 	transform(I first, S last, O result, F op, Proj proj = Proj{})
 	{
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange R, WeaklyIncrementable O, CopyConstructible F, class Proj = identity>
 	requires
 		Writable<O,
-			indirect_result_of_t<F&(projected<iterator_t<R>, Proj>)>>
+			indirect_invoke_result_t<F&, projected<iterator_t<R>, Proj>>>
 	tagged_pair<tag::in(safe_iterator_t<R>), tag::out(O)>
 	transform(R&& r, O result, F op, Proj proj = Proj{})
 	{
@@ -59,9 +59,9 @@ STL2_OPEN_NAMESPACE {
 	requires
 		InputIterator<std::decay_t<I2>> && !Range<I2> &&
 		Writable<O,
-			indirect_result_of_t<F&(
+			indirect_invoke_result_t<F&,
 				projected<I1, Proj1>,
-				projected<std::decay_t<I2>, Proj2>)>>
+				projected<std::decay_t<I2>, Proj2>>>
 	{
 		auto first2 = std::forward<I2>(first2_);
 		for (; first1 != last1; ++first1, ++first2, ++result) {
@@ -80,9 +80,9 @@ STL2_OPEN_NAMESPACE {
 	requires
 		InputIterator<std::decay_t<I>> && !Range<I> &&
 		Writable<O,
-			indirect_result_of_t<F&(
+			indirect_invoke_result_t<F&,
 				projected<iterator_t<Rng>, Proj1>,
-				projected<std::decay_t<I>, Proj2>)>>
+				projected<std::decay_t<I>, Proj2>>>
 	{
 		auto first2 = std::forward<I>(first2_);
 		return __stl2::transform(
@@ -98,9 +98,9 @@ STL2_OPEN_NAMESPACE {
 		class Proj1 = identity, class Proj2 = identity>
 	requires
 		Writable<O,
-			indirect_result_of_t<F&(
+			indirect_invoke_result_t<F&,
 				projected<I1, Proj1>,
-				projected<I2, Proj2>)>>
+				projected<I2, Proj2>>>
 	tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
 	transform(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 		F op, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -115,9 +115,9 @@ STL2_OPEN_NAMESPACE {
 		class Proj1 = identity, class Proj2 = identity>
 	requires
 		Writable<O,
-			indirect_result_of_t<F&(
+			indirect_invoke_result_t<F&,
 				projected<iterator_t<Rng1>, Proj1>,
-				projected<iterator_t<Rng2>, Proj2>)>>
+				projected<iterator_t<Rng2>, Proj2>>>
 	tagged_tuple<
 		tag::in1(safe_iterator_t<Rng1>),
 		tag::in2(safe_iterator_t<Rng2>),

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -29,15 +29,15 @@ STL2_OPEN_NAMESPACE {
 	__unique_copy(ext::priority_tag<0>, I first, S last, O result, R comp, Proj proj)
 	{
 		if (first != last) {
-			value_type_t<I> saved = *first;
+			iter_value_t<I> saved = *first;
 			*result = saved;
 			++result;
 			while (++first != last) {
-				reference_t<I>&& v = *first;
+				iter_reference_t<I>&& v = *first;
 				if (!__stl2::invoke(comp,
-					__stl2::invoke(proj, std::forward<reference_t<I>>(v)),
+					__stl2::invoke(proj, std::forward<iter_reference_t<I>>(v)),
 					__stl2::invoke(proj, saved))) {
-					saved = std::forward<reference_t<I>>(v);
+					saved = std::forward<iter_reference_t<I>>(v);
 					*result = saved;
 					++result;
 				}
@@ -47,18 +47,18 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template <class I, class S, InputIterator O, class R, class Proj>
-	requires Same<value_type_t<I>, value_type_t<O>>
+	requires Same<iter_value_t<I>, iter_value_t<O>>
 	tagged_pair<tag::in(I), tag::out(O)>
 	__unique_copy(ext::priority_tag<1>, I first, S last, O result, R comp, Proj proj)
 	{
 		if (first != last) {
 			*result = *first;
 			while (++first != last) {
-				reference_t<I>&& v = *first;
+				iter_reference_t<I>&& v = *first;
 				if (!__stl2::invoke(comp,
-					__stl2::invoke(proj, std::forward<reference_t<I>>(v)),
+					__stl2::invoke(proj, std::forward<iter_reference_t<I>>(v)),
 					__stl2::invoke(proj, *result))) {
-					*++result = std::forward<reference_t<I>>(v);
+					*++result = std::forward<iter_reference_t<I>>(v);
 				}
 			}
 			++result;
@@ -75,11 +75,11 @@ STL2_OPEN_NAMESPACE {
 			++result;
 			auto m = first;
 			while (++first != last) {
-				reference_t<I>&& v = *first;
+				iter_reference_t<I>&& v = *first;
 				if (!__stl2::invoke(comp,
-					__stl2::invoke(proj, std::forward<reference_t<I>>(v)),
+					__stl2::invoke(proj, std::forward<iter_reference_t<I>>(v)),
 					__stl2::invoke(proj, *m))) {
-					*result = std::forward<reference_t<I>>(v);
+					*result = std::forward<iter_reference_t<I>>(v);
 					++result;
 					m = first;
 				}
@@ -94,7 +94,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyCopyable<I, O> &&
 		IndirectRelation<R, projected<I, Proj>> &&
 		(ForwardIterator<I> ||
-		 InputIterator<O> && Same<value_type_t<I>, value_type_t<O>> ||
+		 InputIterator<O> && Same<iter_value_t<I>, iter_value_t<O>> ||
 		 IndirectlyCopyableStorable<I, O>)
 	tagged_pair<tag::in(I), tag::out(O)>
 	unique_copy(I first, S last, O result, R comp = R{},
@@ -114,7 +114,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyCopyable<iterator_t<Rng>, O> &&
 		IndirectRelation<R, projected<iterator_t<Rng>, Proj>> &&
 		(ForwardIterator<iterator_t<Rng>> ||
-		 InputIterator<O> && Same<value_type_t<iterator_t<Rng>>, value_type_t<O>> ||
+		 InputIterator<O> && Same<iter_value_t<iterator_t<Rng>>, iter_value_t<O>> ||
 		 IndirectlyCopyableStorable<iterator_t<Rng>, O>)
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
 	unique_copy(Rng&& rng, O result, R comp = R{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/upper_bound.hpp
+++ b/include/stl2/detail/algorithm/upper_bound.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			ForwardIterator<__f<I>> &&
 			IndirectStrictWeakOrder<
 				Comp, const T*, projected<__f<I>, Proj>>
-		__f<I> upper_bound_n(I&& first, difference_type_t<__f<I>> n, const T& value,
+		__f<I> upper_bound_n(I&& first, iter_difference_t<__f<I>> n, const T& value,
 			Comp comp = Comp{}, Proj proj = Proj{})
 		{
 			return ext::partition_point_n(std::forward<I>(first), n,

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 	using __iter_args_lists =
 		meta::push_back<
 			meta::cartesian_product<
-				meta::list<meta::list<value_type_t<Is>&, reference_t<Is>>...>>,
+				meta::list<meta::list<iter_value_t<Is>&, iter_reference_t<Is>>...>>,
 			meta::list<iter_common_reference_t<Is>...>>;
 
 	template <typename MapFn, typename ReduceFn>
@@ -61,8 +61,8 @@ STL2_OPEN_NAMESPACE {
 			CopyConstructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
-			Invocable<F&, value_type_t<Is>&...> &&
-			Invocable<F&, reference_t<Is>...> &&
+			Invocable<F&, iter_value_t<Is>&...> &&
+			Invocable<F&, iter_reference_t<Is>...> &&
 			Invocable<F&, iter_common_reference_t<Is>...> &&
 			// redundantly checks the above 3 requirements
 			meta::_v<meta::invoke<
@@ -77,19 +77,16 @@ STL2_OPEN_NAMESPACE {
 		ext::IndirectInvocable<F, I>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// indirect_result_of [indirectcallables.indirectfunc]
+	// indirect_invoke_result [indirectcallables.indirectfunc]
 	//
-	template <class>
-	struct indirect_result_of {};
+	template <class F, class... Is>
+	requires Invocable<F, iter_reference_t<Is>...>
+	struct indirect_invoke_result
+	: invoke_result<F, iter_reference_t<Is>&&...> {};
 
 	template <class F, class... Is>
-	requires Invocable<F, reference_t<Is>...>
-	struct indirect_result_of<F(Is...)>
-	: result_of<F(reference_t<Is>&&...)> {};
-
-	template <class T>
-	using indirect_result_of_t =
-		meta::_t<indirect_result_of<T>>;
+	using indirect_invoke_result_t =
+		meta::_t<indirect_invoke_result<F, Is...>>;
 
 	namespace ext {
 		template <class F, class... Is>
@@ -111,8 +108,8 @@ STL2_OPEN_NAMESPACE {
 			CopyConstructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
-			Predicate<F&, value_type_t<Is>&...> &&
-			Predicate<F&, reference_t<Is>...> &&
+			Predicate<F&, iter_value_t<Is>&...> &&
+			Predicate<F&, iter_reference_t<Is>...> &&
 			Predicate<F&, iter_common_reference_t<Is>...> &&
 			// redundantly checks the above 3 requirements
 			meta::_v<meta::invoke<
@@ -131,10 +128,10 @@ STL2_OPEN_NAMESPACE {
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&
-		Relation<F&, value_type_t<I1>&, value_type_t<I2>&> &&
-		Relation<F&, value_type_t<I1>&, reference_t<I2>> &&
-		Relation<F&, reference_t<I1>, value_type_t<I2>&> &&
-		Relation<F&, reference_t<I1>, reference_t<I2>> &&
+		Relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		Relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		Relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		Relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
 		Relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template <class F, class I1, class I2 = I1>
@@ -142,10 +139,10 @@ STL2_OPEN_NAMESPACE {
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&
-		StrictWeakOrder<F&, value_type_t<I1>&, value_type_t<I2>&> &&
-		StrictWeakOrder<F&, value_type_t<I1>&, reference_t<I2>> &&
-		StrictWeakOrder<F&, reference_t<I1>, value_type_t<I2>&> &&
-		StrictWeakOrder<F&, reference_t<I1>, reference_t<I2>> &&
+		StrictWeakOrder<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		StrictWeakOrder<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		StrictWeakOrder<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		StrictWeakOrder<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
 		StrictWeakOrder<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	///////////////////////////////////////////////////////////////////////////
@@ -153,13 +150,13 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <Readable I, IndirectRegularUnaryInvocable<I> Proj>
 	struct projected {
-		using value_type = __uncvref<indirect_result_of_t<Proj&(I)>>;
-		indirect_result_of_t<Proj&(I)> operator*() const;
+		using value_type = __uncvref<indirect_invoke_result_t<Proj&, I>>;
+		indirect_invoke_result_t<Proj&, I> operator*() const;
 	};
 
 	template <WeaklyIncrementable I, class Proj>
-	struct difference_type<projected<I, Proj>> :
-		difference_type<I> {};
+	struct incrementable_traits<projected<I, Proj>> :
+		incrementable_traits<I> {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -80,13 +80,8 @@ STL2_OPEN_NAMESPACE {
 	// indirect_invoke_result [indirectcallables.indirectfunc]
 	//
 	template <class F, class... Is>
-	requires Invocable<F, iter_reference_t<Is>...>
-	struct indirect_invoke_result
-	: invoke_result<F, iter_reference_t<Is>&&...> {};
-
-	template <class F, class... Is>
 	using indirect_invoke_result_t =
-		meta::_t<indirect_invoke_result<F, Is...>>;
+		invoke_result_t<F, iter_reference_t<Is>&&...>;
 
 	namespace ext {
 		template <class F, class... Is>

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -868,7 +868,7 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template <class C>
-	struct difference_type<basic_iterator<C>> {
+	struct incrementable_traits<basic_iterator<C>> {
 		using type = cursor::difference_type_t<C>;
 	};
 
@@ -878,7 +878,7 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template <cursor::Input C>
-	struct value_type<basic_iterator<C>> {
+	struct readable_traits<basic_iterator<C>> {
 		using type = cursor::value_type_t<C>;
 	};
 

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		requires
 			Readable<const I> &&
-			_Is<reference_t<const I>, std::is_reference>
+			_Is<iter_reference_t<const I>, std::is_reference>
 		constexpr auto operator_arrow_(const I& i, ext::priority_tag<1>)
 		noexcept(noexcept(*i)) {
 			auto&& tmp = *i;
@@ -71,15 +71,15 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		requires
 			Readable<const I> &&
-			!std::is_reference<reference_t<I>>::value &&
-			Constructible<value_type_t<I>, reference_t<I>>
+			!std::is_reference<iter_reference_t<I>>::value &&
+			Constructible<iter_value_t<I>, iter_reference_t<I>>
 		constexpr auto operator_arrow_(const I& i, ext::priority_tag<0>)
 		noexcept(
 			std::is_nothrow_move_constructible<
-				operator_arrow_proxy<value_type_t<I>>>::value &&
+				operator_arrow_proxy<iter_value_t<I>>>::value &&
 			std::is_nothrow_constructible<
-				operator_arrow_proxy<value_type_t<I>>, reference_t<I>>::value) {
-			return operator_arrow_proxy<value_type_t<I>>{*i};
+				operator_arrow_proxy<iter_value_t<I>>, iter_reference_t<I>>::value) {
+			return operator_arrow_proxy<iter_value_t<I>>{*i};
 		}
 
 		template <class I>
@@ -148,12 +148,12 @@ STL2_OPEN_NAMESPACE {
 		template <class I2, SizedSentinel<I2> I1,
 			SizedSentinel<I2> S1, SizedSentinel<I1> S2>
 		struct difference_visitor {
-			constexpr difference_type_t<I2> operator()(
+			constexpr iter_difference_t<I2> operator()(
 				const auto& lhs, const auto& rhs) const
 			STL2_NOEXCEPT_RETURN(
-				static_cast<difference_type_t<I2>>(lhs - rhs)
+				static_cast<iter_difference_t<I2>>(lhs - rhs)
 			)
-			constexpr difference_type_t<I2> operator()(
+			constexpr iter_difference_t<I2> operator()(
 				const S1&, const S2&) const noexcept
 			{
 				return 0;
@@ -170,7 +170,7 @@ STL2_OPEN_NAMESPACE {
 		friend __common_iterator::access;
 		std::variant<I, S> v_;
 	public:
-		using difference_type = difference_type_t<I>;
+		using difference_type = iter_difference_t<I>;
 
 		constexpr common_iterator() = default;
 
@@ -239,7 +239,7 @@ STL2_OPEN_NAMESPACE {
 			return tmp;
 		}
 
-		friend rvalue_reference_t<I> iter_move(
+		friend iter_rvalue_reference_t<I> iter_move(
 			const common_iterator& i)
 			noexcept(noexcept(__stl2::iter_move(std::declval<const I&>())))
 			requires InputIterator<I> {
@@ -260,8 +260,8 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template <Readable I, class S>
-	struct value_type<common_iterator<I, S>> {
-		using type = value_type_t<I>;
+	struct readable_traits<common_iterator<I, S>> {
+		using type = iter_value_t<I>;
 	};
 	template <InputIterator I, class S>
 	struct iterator_category<common_iterator<I, S>> {
@@ -290,7 +290,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <class I2, SizedSentinel<I2> I1, SizedSentinel<I2> S1,
 		SizedSentinel<I1> S2>
-	difference_type_t<I2> operator-(
+	iter_difference_t<I2> operator-(
 		const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y)
 	STL2_NOEXCEPT_RETURN(
 		std::visit(__common_iterator::difference_visitor<I1, I2, S1, S2>{},

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -27,22 +27,22 @@ STL2_OPEN_NAMESPACE {
 	class counted_iterator {
 		Iterator{O} friend class counted_iterator;
 		Iterator{O} friend constexpr
-		void advance(counted_iterator<O>& i, difference_type_t<O> n);
+		void advance(counted_iterator<O>& i, iter_difference_t<O> n);
 
-		ext::compressed_pair<I, difference_type_t<I>> data_{};
+		ext::compressed_pair<I, iter_difference_t<I>> data_{};
 
 		constexpr I& current() noexcept { return data_.first(); };
 		constexpr const I& current() const noexcept { return data_.first(); };
-		constexpr difference_type_t<I>& cnt() noexcept { return data_.second(); }
-		constexpr const difference_type_t<I>& cnt() const noexcept {
+		constexpr iter_difference_t<I>& cnt() noexcept { return data_.second(); }
+		constexpr const iter_difference_t<I>& cnt() const noexcept {
 			return data_.second();
 		}
 	public:
 		using iterator_type = I;
-		using difference_type = difference_type_t<I>;
+		using difference_type = iter_difference_t<I>;
 
 		constexpr counted_iterator() = default;
-		constexpr counted_iterator(I x, difference_type_t<I> n)
+		constexpr counted_iterator(I x, iter_difference_t<I> n)
 		: data_{std::move(x), n} {
 			STL2_EXPECT(n >= 0);
 		}
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr I base() const {
 			return current();
 		}
-		constexpr difference_type_t<I> count() const {
+		constexpr iter_difference_t<I> count() const {
 			return cnt();
 		}
 		constexpr decltype(auto) operator*() noexcept(noexcept(*std::declval<I&>())) {
@@ -126,7 +126,7 @@ STL2_OPEN_NAMESPACE {
 			return current()[n];
 		}
 
-		friend constexpr rvalue_reference_t<I>
+		friend constexpr iter_rvalue_reference_t<I>
 		iter_move(const counted_iterator& i)
 			noexcept(noexcept(__stl2::iter_move(i.current())))
 			requires InputIterator<I> {
@@ -141,8 +141,8 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template <Readable I>
-	struct value_type<counted_iterator<I>> {
-		using type = value_type_t<I>;
+	struct readable_traits<counted_iterator<I>> {
+		using type = iter_value_t<I>;
 	};
 	template <InputIterator I>
 	struct iterator_category<counted_iterator<I>> {
@@ -203,35 +203,35 @@ STL2_OPEN_NAMESPACE {
 	}
 	template <class I1, class I2>
 		requires Common<I1, I2>
-	constexpr difference_type_t<I2> operator-(
+	constexpr iter_difference_t<I2> operator-(
 		const counted_iterator<I1>& x, const counted_iterator<I2>& y) noexcept {
 		return y.count() - x.count();
 	}
 	template <class I>
-	constexpr difference_type_t<I> operator-(
+	constexpr iter_difference_t<I> operator-(
 		const counted_iterator<I>& x, default_sentinel) noexcept {
 		return -x.count();
 	}
 	template <class I>
-	constexpr difference_type_t<I> operator-(
+	constexpr iter_difference_t<I> operator-(
 		default_sentinel, const counted_iterator<I>& y) noexcept {
 		return y.count();
 	}
 	template <RandomAccessIterator I>
 	constexpr counted_iterator<I>
-	operator+(difference_type_t<I> n, const counted_iterator<I>& x) noexcept {
+	operator+(iter_difference_t<I> n, const counted_iterator<I>& x) noexcept {
 		STL2_EXPECT(n <= x.count());
 		return x + n;
 	}
 
 	template <Iterator I>
-	constexpr auto make_counted_iterator(I i, difference_type_t<I> n)
+	constexpr auto make_counted_iterator(I i, iter_difference_t<I> n)
 	STL2_NOEXCEPT_RETURN(
 		counted_iterator<I>{std::move(i), n}
 	)
 
 	Iterator{I}
-	constexpr void advance(counted_iterator<I>& i, difference_type_t<I> n)
+	constexpr void advance(counted_iterator<I>& i, iter_difference_t<I> n)
 	noexcept(noexcept(__stl2::advance(std::declval<I&>(), n)))
 	{
 		STL2_EXPECT(n <= i.count());
@@ -240,7 +240,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	RandomAccessIterator{I}
-	constexpr void advance(counted_iterator<I>& i, difference_type_t<I> n)
+	constexpr void advance(counted_iterator<I>& i, iter_difference_t<I> n)
 	STL2_NOEXCEPT_RETURN(
 		(STL2_EXPECT(n <= i.count()), i += n, void())
 	)
@@ -259,7 +259,7 @@ STL2_OPEN_NAMESPACE {
 		)
 
 		Iterator{I}
-		constexpr auto recounted(const I&, const I& i, difference_type_t<I> = 0)
+		constexpr auto recounted(const I&, const I& i, iter_difference_t<I> = 0)
 		noexcept(is_nothrow_copy_constructible<I>::value)
 		{
 			return i;
@@ -273,7 +273,7 @@ STL2_OPEN_NAMESPACE {
 
 		template <class I>
 		constexpr auto recounted(
-			const counted_iterator<I>& o, I i, difference_type_t<I> n)
+			const counted_iterator<I>& o, I i, iter_difference_t<I> n)
 		noexcept(noexcept(counted_iterator<I>{std::move(i), o.count() - n}))
 		{
 			STL2_EXPENSIVE_ASSERT(!ForwardIterator<I> ||

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -22,7 +22,7 @@
 
 STL2_OPEN_NAMESPACE {
 	////////////////////////////////////////////////////////////////////////////
-	// difference_type_t [iterator.assoc]
+	// iter_difference_t [iterator.assoc]
 	// Not to spec:
 	// * Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78173; it is
 	//   necessary to guard the requires clause of the "fallback" specialization
@@ -34,19 +34,19 @@ STL2_OPEN_NAMESPACE {
 			requires { typename T::difference_type; };
 	}
 
-	template <class> struct difference_type {};
+	template <class> struct incrementable_traits {};
 
 	template <ext::Object T>
-	struct difference_type<T*> {
+	struct incrementable_traits<T*> {
 		using type = std::ptrdiff_t;
 	};
 
 	template <class T>
-	struct difference_type<const T>
-	: difference_type<std::decay_t<T>> {};
+	struct incrementable_traits<const T>
+	: incrementable_traits<std::decay_t<T>> {};
 
 	detail::MemberDifferenceType{T}
-	struct difference_type<T> {
+	struct incrementable_traits<T> {
 		using type = typename T::difference_type;
 	};
 
@@ -59,11 +59,11 @@ STL2_OPEN_NAMESPACE {
 				requires Integral<decltype(a - b)>;
 			 	// { a - b } -> Integral;
 			}
-	struct difference_type<T>
+	struct incrementable_traits<T>
 	: make_signed<decltype(declval<const T>() - declval<const T>())> {};
 
 	template <class T>
-	using difference_type_t = meta::_t<difference_type<T>>;
+	using iter_difference_t = meta::_t<incrementable_traits<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// WeaklyIncrementable [weaklyincrementable.iterators]
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 	concept bool WeaklyIncrementable =
 		Semiregular<I> &&
 		requires(I& i) {
-			typename difference_type_t<I>;
+			typename iter_difference_t<I>;
 			{ ++i } -> Same<I&>&&;
 			i++;
 		};
@@ -114,13 +114,13 @@ STL2_OPEN_NAMESPACE {
 		template <class I>
 		concept bool RandomAccessIncrementable =
 			Decrementable<I> &&
-			requires(I& i, const I& ci, const difference_type_t<I> n) {
+			requires(I& i, const I& ci, const iter_difference_t<I> n) {
 				{ i += n } -> Same<I&>&&;
 				{ i -= n } -> Same<I&>&&;
 				{ ci + n } -> Same<I>&&;
 				{ n + ci } -> Same<I>&&;
 				{ ci - n } -> Same<I>&&;
-				{ ci - ci } -> difference_type_t<I>;
+				{ ci - ci } -> iter_difference_t<I>;
 			};
 			// FIXME: Axioms
 	}

--- a/include/stl2/detail/iterator/insert_iterators.hpp
+++ b/include/stl2/detail/iterator/insert_iterators.hpp
@@ -133,15 +133,15 @@ STL2_OPEN_NAMESPACE {
 		insert_iterator() = default;
 		insert_iterator(Container& x, iterator_t<Container> i)
 		: container(std::addressof(x)), iter(std::move(i)) {}
-		insert_iterator& operator=(const value_type_t<Container>& value)
-		requires detail::InsertableInto<const value_type_t<Container>&, Container>
+		insert_iterator& operator=(const iter_value_t<Container>& value)
+		requires detail::InsertableInto<const iter_value_t<Container>&, Container>
 		{
 			iter = container->insert(iter, value);
 			++iter;
 			return *this;
 		}
-		insert_iterator& operator=(value_type_t<Container>&& value)
-		requires detail::InsertableInto<value_type_t<Container>&&, Container>
+		insert_iterator& operator=(iter_value_t<Container>&& value)
+		requires detail::InsertableInto<iter_value_t<Container>&&, Container>
 		{
 			iter = container->insert(iter, std::move(value));
 			++iter;

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -43,8 +43,8 @@ STL2_OPEN_NAMESPACE {
 			friend access;
 			I current_{};
 		public:
-			using difference_type = difference_type_t<I>;
-			using value_type = value_type_t<I>;
+			using difference_type = iter_difference_t<I>;
+			using value_type = iter_value_t<I>;
 			using single_pass = meta::bool_<!ForwardIterator<I>>;
 
 			class mixin : protected basic_mixin<cursor> {
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 				using difference_type = cursor::difference_type;
 				using value_type = cursor::value_type;
 				using iterator_category = input_iterator_tag;
-				using reference = rvalue_reference_t<I>;
+				using reference = iter_rvalue_reference_t<I>;
 
 				constexpr mixin() = default;
 				constexpr explicit mixin(I&& i)
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 			: current_{access::current(u)}
 			{}
 
-			constexpr rvalue_reference_t<I> read() const
+			constexpr iter_rvalue_reference_t<I> read() const
 			STL2_NOEXCEPT_RETURN(
 				__stl2::iter_move(current_)
 			)
@@ -106,7 +106,7 @@ STL2_OPEN_NAMESPACE {
 			using __postinc_t = std::decay_t<decltype(current_++)>;
 			Readable{R}
 			struct __proxy {
-				using value_type = __stl2::value_type_t<R>;
+				using value_type = __stl2::iter_value_t<R>;
 				R __tmp;
 				constexpr decltype(auto) operator*()
 				STL2_NOEXCEPT_RETURN(
@@ -134,7 +134,7 @@ STL2_OPEN_NAMESPACE {
 				--current_;
 			}
 
-			constexpr void advance(difference_type_t<I> n)
+			constexpr void advance(iter_difference_t<I> n)
 			noexcept(noexcept(current_ += n))
 			requires RandomAccessIterator<I>
 			{
@@ -153,13 +153,13 @@ STL2_OPEN_NAMESPACE {
 				current_ == access::sentinel(that)
 			)
 
-			constexpr difference_type_t<I>
+			constexpr iter_difference_t<I>
 			distance_to(const cursor<SizedSentinel<I> >& that) const
 			STL2_NOEXCEPT_RETURN(
 				access::current(that) - current_
 			)
 
-			constexpr difference_type_t<I>
+			constexpr iter_difference_t<I>
 			distance_to(const move_sentinel<SizedSentinel<I> >& that) const
 			STL2_NOEXCEPT_RETURN(
 				access::sentinel(that) - current_

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 		requires
 			Iterator<I>
 			// Pre: 0 <= n && [i,i+n)
-		constexpr void impl(I& i, difference_type_t<I> n)
+		constexpr void impl(I& i, iter_difference_t<I> n)
 		noexcept(noexcept(++std::declval<I&>()))
 		{
 			STL2_EXPECT(0 <= n);
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 
 	Iterator{I}
 		// Pre: 0 <= n && [i,i+n)
-	constexpr void advance(I& i, difference_type_t<I> n)
+	constexpr void advance(I& i, iter_difference_t<I> n)
 	noexcept(noexcept(++std::declval<I&>()))
 	{
 		__advance::impl(i, n);
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 
 	BidirectionalIterator{I}
 		// Pre: 0 <= n ? [i,i+n) : [i+n,i)
-	constexpr void advance(I& i, difference_type_t<I> n)
+	constexpr void advance(I& i, iter_difference_t<I> n)
 	noexcept(noexcept(++std::declval<I&>(), --std::declval<I&>()))
 	{
 		if (0 <= n) {
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 
 	RandomAccessIterator{I}
 		// Pre: 0 <= n ? [i,i+n) : [i+n,i)
-	constexpr void advance(I& i, difference_type_t<I> n)
+	constexpr void advance(I& i, iter_difference_t<I> n)
 	STL2_NOEXCEPT_RETURN(
 		(void)(i += n)
 	)
@@ -95,7 +95,7 @@ STL2_OPEN_NAMESPACE {
 	constexpr void advance(I& i, S bound)
 	noexcept(noexcept(__stl2::advance(i, bound - i)))
 	{
-		difference_type_t<I> d = bound - i;
+		iter_difference_t<I> d = bound - i;
 		STL2_EXPECT(0 <= d);
 		__stl2::advance(i, d);
 	}
@@ -105,8 +105,8 @@ STL2_OPEN_NAMESPACE {
 		requires
 			Sentinel<S, I>
 			// Pre: 0 == n || (0 < n && [i,bound))
-		constexpr difference_type_t<I>
-		impl(I& i, difference_type_t<I> n, const S& bound)
+		constexpr iter_difference_t<I>
+		impl(I& i, iter_difference_t<I> n, const S& bound)
 		noexcept(noexcept(++i != bound))
 		{
 			STL2_EXPECT(0 <= n);
@@ -122,8 +122,8 @@ STL2_OPEN_NAMESPACE {
 	requires
 		Sentinel<S, I>
 		// Pre: 0 == n || (0 < n && [i,bound))
-	constexpr difference_type_t<I>
-	advance(I& i, difference_type_t<I> n, S bound)
+	constexpr iter_difference_t<I>
+	advance(I& i, iter_difference_t<I> n, S bound)
 	STL2_NOEXCEPT_RETURN(
 		__advance::impl(i, n, bound)
 	)
@@ -132,14 +132,14 @@ STL2_OPEN_NAMESPACE {
 	requires
 		Sentinel<S, I> && SizedSentinel<S, I>
 		// Pre: 0 <= n && [i,bound)
-	constexpr difference_type_t<I>
-	advance(I& i, difference_type_t<I> n, S bound)
+	constexpr iter_difference_t<I>
+	advance(I& i, iter_difference_t<I> n, S bound)
 	noexcept(noexcept(
 		__stl2::advance(i, std::move(bound)),
 		__stl2::advance(i, bound - i)))
 	{
 		STL2_EXPECT(0 <= n);
-		auto d = difference_type_t<I>{bound - i};
+		auto d = iter_difference_t<I>{bound - i};
 		STL2_EXPECT(0 <= d);
 		if (d <= n) {
 			__stl2::advance(i, std::move(bound));
@@ -153,8 +153,8 @@ STL2_OPEN_NAMESPACE {
 	requires
 		BidirectionalIterator<I>
 		// Pre: 0 == n || (0 < n ? [i,bound) : [bound,i))
-	constexpr difference_type_t<I>
-	advance(I& i, difference_type_t<I> n, I bound)
+	constexpr iter_difference_t<I>
+	advance(I& i, iter_difference_t<I> n, I bound)
 	noexcept(noexcept(
 		__advance::impl(i, n, bound),
 		--i != bound))
@@ -174,13 +174,13 @@ STL2_OPEN_NAMESPACE {
 	requires
 		BidirectionalIterator<I> && SizedSentinel<I, I>
 		// Pre: 0 == n ? ([i,bound) || [bound,i)) : (0 < n ? [i,bound) : [bound,i))
-	constexpr difference_type_t<I>
-	advance(I& i, difference_type_t<I> n, I bound)
+	constexpr iter_difference_t<I>
+	advance(I& i, iter_difference_t<I> n, I bound)
 	noexcept(noexcept(
 		i = std::move(bound),
 		__stl2::advance(i, bound - i)))
 	{
-		auto d = difference_type_t<I>{bound - i};
+		auto d = iter_difference_t<I>{bound - i};
 		STL2_EXPECT(0 <= n ? 0 <= d : 0 >= d);
 		if (0 <= n ? d <= n : d >= n) {
 			i = std::move(bound);
@@ -192,7 +192,7 @@ STL2_OPEN_NAMESPACE {
 
 	// next
 	Iterator{I}
-	constexpr I next(I x, difference_type_t<I> n = 1)
+	constexpr I next(I x, iter_difference_t<I> n = 1)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, n),
 		x
@@ -210,7 +210,7 @@ STL2_OPEN_NAMESPACE {
 	template <class S, class I>
 	requires
 		Sentinel<__f<S>, I>
-	constexpr I next(I x, difference_type_t<I> n, S&& bound)
+	constexpr I next(I x, iter_difference_t<I> n, S&& bound)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, n, std::forward<S>(bound)),
 		x
@@ -218,14 +218,14 @@ STL2_OPEN_NAMESPACE {
 
 	// prev
 	BidirectionalIterator{I}
-	constexpr I prev(I x, difference_type_t<I> n = 1)
+	constexpr I prev(I x, iter_difference_t<I> n = 1)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, -n),
 		x
 	)
 
 	BidirectionalIterator{I}
-	constexpr I prev(I x, difference_type_t<I> n, I bound)
+	constexpr I prev(I x, iter_difference_t<I> n, I bound)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::advance(x, -n, std::move(bound)),
 		x
@@ -233,12 +233,12 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		Sentinel{S, I}
-		constexpr tagged_pair<tag::count(difference_type_t<I>), tag::end(I)>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
 		enumerate(I first, S last)
 		noexcept(noexcept(++first != last) &&
 			std::is_nothrow_move_constructible<I>::value)
 		{
-			difference_type_t<I> n = 0;
+			iter_difference_t<I> n = 0;
 			while (first != last) {
 				++n;
 				++first;
@@ -247,7 +247,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		SizedSentinel{S, I}
-		constexpr tagged_pair<tag::count(difference_type_t<I>), tag::end(I)>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
 		enumerate(I first, S last)
 		noexcept(noexcept(__stl2::next(std::move(first), std::move(last))) &&
 			std::is_nothrow_move_constructible<I>::value)
@@ -260,7 +260,7 @@ STL2_OPEN_NAMESPACE {
 		template <class S, class I>
 		requires
 			Sentinel<S, I> && !SizedSentinel<S, I> && SizedSentinel<I, I>
-		constexpr tagged_pair<tag::count(difference_type_t<I>), tag::end(I)>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
 		enumerate(I first, S last)
 		noexcept(noexcept(__stl2::next(first, std::move(last))) &&
 			std::is_nothrow_move_constructible<I>::value)
@@ -274,14 +274,14 @@ STL2_OPEN_NAMESPACE {
 	// distance
 	Sentinel{S, I}
 		// Pre: [first, last)
-	constexpr difference_type_t<I> distance(I first, S last)
+	constexpr iter_difference_t<I> distance(I first, S last)
 	STL2_NOEXCEPT_RETURN(
 		ext::enumerate(std::move(first), std::move(last)).first
 	)
 
 	SizedSentinel{S, I}
 		// Pre: [first, last)
-	constexpr difference_type_t<I> distance(I first, S last)
+	constexpr iter_difference_t<I> distance(I first, S last)
 	noexcept(noexcept(last - first))
 	{
 		auto d = last - first;
@@ -293,7 +293,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		SizedSentinel<I, I>
 		// Pre: [first, last) || [last, first)
-	constexpr difference_type_t<I> distance(I first, I last)
+	constexpr iter_difference_t<I> distance(I first, I last)
 	STL2_NOEXCEPT_RETURN(
 		last - first
 	)

--- a/include/stl2/detail/iterator/reverse_iterator.hpp
+++ b/include/stl2/detail/iterator/reverse_iterator.hpp
@@ -41,8 +41,8 @@ STL2_OPEN_NAMESPACE {
 			I current_{};
 
 		public:
-			using difference_type = difference_type_t<I>;
-			using value_type = value_type_t<I>;
+			using difference_type = iter_difference_t<I>;
+			using value_type = iter_value_t<I>;
 
 			class mixin : protected basic_mixin<cursor> {
 				using base_t = basic_mixin<cursor>;
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 				using difference_type = cursor::difference_type;
 				using value_type = cursor::value_type;
 				using iterator_category = iterator_category_t<I>;
-				using reference = reference_t<I>;
+				using reference = iter_reference_t<I>;
 				using pointer = I;
 
 				constexpr mixin() = default;
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 			: current_{access::current(u)}
 			{}
 
-			constexpr reference_t<I> read() const
+			constexpr iter_reference_t<I> read() const
 			STL2_NOEXCEPT_RETURN(
 				*__stl2::prev(current_)
 			)
@@ -97,7 +97,7 @@ STL2_OPEN_NAMESPACE {
 				(void)++current_
 			)
 
-			constexpr void advance(difference_type_t<I> n)
+			constexpr void advance(iter_difference_t<I> n)
 			noexcept(noexcept(current_ -= n))
 			requires RandomAccessIterator<I>
 			{
@@ -110,7 +110,7 @@ STL2_OPEN_NAMESPACE {
 				current_ == access::current(that)
 			)
 
-			constexpr difference_type_t<I> distance_to(
+			constexpr iter_difference_t<I> distance_to(
 				const cursor<SizedSentinel<I> >& that) const
 			STL2_NOEXCEPT_RETURN(
 				-(access::current(that) - current_)

--- a/include/stl2/detail/memory/concepts.hpp
+++ b/include/stl2/detail/memory/concepts.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	template <class I>
 	concept bool __NoThrowInputIterator =
 		InputIterator<I> &&
-		_Is<reference_t<I>, std::is_lvalue_reference> &&
-		Same<__uncvref<reference_t<I>>, value_type_t<I>>;
+		_Is<iter_reference_t<I>, std::is_lvalue_reference> &&
+		Same<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
 		// Axiom: no exceptions are thrown from increment, copy, move, assignment,
 		//        indirection through valid iterators.
 

--- a/include/stl2/detail/memory/destroy.hpp
+++ b/include/stl2/detail/memory/destroy.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowInputIterator I, __NoThrowSentinel<I> S>
 	requires
-		Destructible<value_type_t<I>>
+		Destructible<iter_value_t<I>>
 	I destroy(I first, S last) noexcept
 	{
 		for (; first != last; ++first) {
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <__NoThrowInputRange Rng>
 	requires
-		Destructible<value_type_t<iterator_t<Rng>>>
+		Destructible<iter_value_t<iterator_t<Rng>>>
 	safe_iterator_t<Rng> destroy(Rng&& rng) noexcept
 	{
 		return __stl2::destroy(__stl2::begin(rng), __stl2::end(rng));
@@ -63,8 +63,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowInputIterator I>
 	requires
-		Destructible<value_type_t<I>>
-	I destroy_n(I first, difference_type_t<I> n) noexcept
+		Destructible<iter_value_t<I>>
+	I destroy_n(I first, iter_difference_t<I> n) noexcept
 	{
 		return __stl2::destroy(__stl2::make_counted_iterator(std::move(first), n),
 			default_sentinel{}).base();

--- a/include/stl2/detail/memory/uninitialized_copy.hpp
+++ b/include/stl2/detail/memory/uninitialized_copy.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	[[deprecated]] tagged_pair<tag::in(I), tag::out(O)>
 	uninitialized_copy(I first, S last, O result)
 	requires
-		Constructible<value_type_t<O>, reference_t<I>>
+		Constructible<iter_value_t<O>, iter_reference_t<I>>
 	{
 		auto guard = detail::destroy_guard<O>{result};
 		for (; first != last; ++result, (void)++first) {
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 	[[deprecated]] tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
 	uninitialized_copy(Rng&& rng, O result)
 	requires
-		Constructible<value_type_t<O>, reference_t<iterator_t<Rng>>>
+		Constructible<iter_value_t<O>, iter_reference_t<iterator_t<Rng>>>
 	{
 		return __stl2::uninitialized_copy(
 			__stl2::begin(rng), __stl2::end(rng), result);
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputIterator I, Sentinel<I> S1, __NoThrowForwardIterator O, __NoThrowSentinel<O> S2>
 	requires
-		Constructible<value_type_t<O>, reference_t<I>>
+		Constructible<iter_value_t<O>, iter_reference_t<I>>
 	tagged_pair<tag::in(I), tag::out(O)>
 	uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast)
 	{
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputRange IRng, __NoThrowForwardRange ORng>
 	requires
-		Constructible<value_type_t<iterator_t<ORng>>, reference_t<iterator_t<IRng>>>
+		Constructible<iter_value_t<iterator_t<ORng>>, iter_reference_t<iterator_t<IRng>>>
 	tagged_pair<tag::in(safe_iterator_t<IRng>), tag::out(safe_iterator_t<ORng>)>
 	uninitialized_copy(IRng&& irng, ORng&& orng)
 	{
@@ -88,9 +88,9 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputIterator I, __NoThrowForwardIterator O>
 	requires
-		Constructible<value_type_t<O>, reference_t<I>>
+		Constructible<iter_value_t<O>, iter_reference_t<I>>
 	tagged_pair<tag::in(I), tag::out(O)>
-	uninitialized_copy_n(I first, difference_type_t<I> n, O out)
+	uninitialized_copy_n(I first, iter_difference_t<I> n, O out)
 	{
 		auto result = __stl2::uninitialized_copy(
 			__stl2::make_counted_iterator(first, n),

--- a/include/stl2/detail/memory/uninitialized_default_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_default_construct.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardIterator I, Sentinel<I> S>
 	requires
-		DefaultConstructible<value_type_t<I>>
+		DefaultConstructible<iter_value_t<I>>
 	I uninitialized_default_construct(I first, S last)
 	{
 		auto guard = detail::destroy_guard<I>{first};
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardRange Rng>
 	requires
-		DefaultConstructible<value_type_t<iterator_t<Rng>>>
+		DefaultConstructible<iter_value_t<iterator_t<Rng>>>
 	safe_iterator_t<Rng> uninitialized_default_construct(Rng&& rng)
 	{
 		return __stl2::uninitialized_default_construct(
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 	// uninitialized_default_construct_n [Extension]
 	//
 	template <__NoThrowForwardIterator I>
-	requires DefaultConstructible<value_type_t<I>>
-	I uninitialized_default_construct_n(I first, difference_type_t<I> n)
+	requires DefaultConstructible<iter_value_t<I>>
+	I uninitialized_default_construct_n(I first, iter_difference_t<I> n)
 	{
 		return __stl2::uninitialized_default_construct(
 			__stl2::make_counted_iterator(first, n),

--- a/include/stl2/detail/memory/uninitialized_fill.hpp
+++ b/include/stl2/detail/memory/uninitialized_fill.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardIterator I, Sentinel<I> S, typename T>
 	requires
-		Constructible<value_type_t<I>, const T&>
+		Constructible<iter_value_t<I>, const T&>
 	I uninitialized_fill(I first, S last, const T& x)
 	{
 		auto guard = detail::destroy_guard<I>{first};
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardRange Rng, typename T>
 	requires
-		Constructible<value_type_t<iterator_t<Rng>>, const T&>
+		Constructible<iter_value_t<iterator_t<Rng>>, const T&>
 	safe_iterator_t<Rng>
 	uninitialized_fill(Rng&& rng, const T& x)
 	{
@@ -55,8 +55,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardIterator I, typename T>
 	requires
-		Constructible<value_type_t<I>, const T&>
-	I uninitialized_fill_n(I first, const difference_type_t<I> n, const T& x)
+		Constructible<iter_value_t<I>, const T&>
+	I uninitialized_fill_n(I first, const iter_difference_t<I> n, const T& x)
 	{
 		return __stl2::uninitialized_fill(
 			__stl2::make_counted_iterator(std::move(first), n),

--- a/include/stl2/detail/memory/uninitialized_move.hpp
+++ b/include/stl2/detail/memory/uninitialized_move.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, __NoThrowForwardIterator O>
 	[[deprecated]] tagged_pair<tag::in(I), tag::out(O)> uninitialized_move(I first, S last, O result)
 	requires
-		Constructible<value_type_t<O>, rvalue_reference_t<I>>
+		Constructible<iter_value_t<O>, iter_rvalue_reference_t<I>>
 	{
 		auto guard = detail::destroy_guard<O>{result};
 		for (; first != last; (void)++result, ++first) {
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 	[[deprecated]] tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
 	uninitialized_move(Rng&& rng, O result)
 	requires
-		Constructible<value_type_t<O>, rvalue_reference_t<iterator_t<Rng>>>
+		Constructible<iter_value_t<O>, iter_rvalue_reference_t<iterator_t<Rng>>>
 	{
 		return __stl2::uninitialized_move(
 			__stl2::begin(rng), __stl2::end(rng), std::move(result));
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputIterator I, Sentinel<I> S1, __NoThrowForwardIterator O, __NoThrowSentinel<O> S2>
 	requires
-		Constructible<value_type_t<O>, rvalue_reference_t<I>>
+		Constructible<iter_value_t<O>, iter_rvalue_reference_t<I>>
 	tagged_pair<tag::in(I), tag::out(O)> uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast)
 	{
 		auto guard = detail::destroy_guard<O>{ofirst};
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputRange IRng, __NoThrowForwardRange ORng>
 	requires
-		Constructible<value_type_t<iterator_t<ORng>>, rvalue_reference_t<iterator_t<IRng>>>
+		Constructible<iter_value_t<iterator_t<ORng>>, iter_rvalue_reference_t<iterator_t<IRng>>>
 	tagged_pair<tag::in(safe_iterator_t<IRng>), tag::out(safe_iterator_t<ORng>)>
 	uninitialized_move(IRng&& irng, ORng&& orng)
 	{
@@ -86,9 +86,9 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <InputIterator I, __NoThrowForwardIterator O>
 	requires
-		Constructible<value_type_t<O>, rvalue_reference_t<I>>
+		Constructible<iter_value_t<O>, iter_rvalue_reference_t<I>>
 	tagged_pair<tag::in(I), tag::out(O)>
-	uninitialized_move_n(I first, difference_type_t<I> n, O result)
+	uninitialized_move_n(I first, iter_difference_t<I> n, O result)
 	{
 		auto r = __stl2::uninitialized_move(
 			__stl2::make_counted_iterator(first, n),

--- a/include/stl2/detail/memory/uninitialized_value_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_value_construct.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardIterator I, Sentinel<I> S>
 	requires
-		DefaultConstructible<value_type_t<I>>
+		DefaultConstructible<iter_value_t<I>>
 	I uninitialized_value_construct(I first, S last)
 	{
 		auto guard = detail::destroy_guard<I>{first};
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardRange Rng>
 	requires
-		DefaultConstructible<value_type_t<iterator_t<Rng>>>
+		DefaultConstructible<iter_value_t<iterator_t<Rng>>>
 	safe_iterator_t<Rng> uninitialized_value_construct(Rng&& rng)
 	{
 		return __stl2::uninitialized_value_construct(__stl2::begin(rng), __stl2::end(rng));
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template <__NoThrowForwardIterator I>
 	requires
-		DefaultConstructible<value_type_t<I>>
-	I uninitialized_value_construct_n(I first, difference_type_t<I> n)
+		DefaultConstructible<iter_value_t<I>>
+	I uninitialized_value_construct_n(I first, iter_difference_t<I> n)
 	{
 		return __stl2::uninitialized_value_construct(
 			__stl2::make_counted_iterator(first, n),

--- a/include/stl2/detail/randutils.hpp
+++ b/include/stl2/detail/randutils.hpp
@@ -269,7 +269,7 @@ STL2_OPEN_NAMESPACE {
 
 				template <InputIterator I, Sentinel<I> S>
 				requires
-					ConvertibleTo<reference_t<I>, IntRep>
+					ConvertibleTo<iter_reference_t<I>, IntRep>
 				void mix_entropy(I begin, S end)
 				{
 					auto hash_const = INIT_A;
@@ -316,7 +316,7 @@ STL2_OPEN_NAMESPACE {
 
 				template <InputIterator I, Sentinel<I> S>
 				requires
-					ConvertibleTo<reference_t<I>, IntRep>
+					ConvertibleTo<iter_reference_t<I>, IntRep>
 				seed_seq_fe(I begin, S end)
 				{
 					seed(begin, end);
@@ -391,7 +391,7 @@ STL2_OPEN_NAMESPACE {
 
 				template <InputIterator I, Sentinel<I> S>
 				requires
-					ConvertibleTo<reference_t<I>, IntRep>
+					ConvertibleTo<iter_reference_t<I>, IntRep>
 				void seed(I begin, S end)
 				{
 					mix_entropy(begin, end);

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 		!disable_sized_range<__uncvref<R>> &&
 		requires(const remove_reference_t<R>& r) {
 			{ __stl2::size(r) } -> Integral;
-			{ __stl2::size(r) } -> difference_type_t<iterator_t<R>>;
+			{ __stl2::size(r) } -> iter_difference_t<iterator_t<R>>;
 		};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 	template <class T>
 	concept bool _ContainerLike =
 		Range<T> && Range<const T> &&
-		!Same<reference_t<iterator_t<T>>, reference_t<iterator_t<const T>>>;
+		!Same<iter_reference_t<iterator_t<T>>, iter_reference_t<iterator_t<const T>>>;
 
 	template <class T>
 	struct enable_view {};
@@ -159,10 +159,10 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <class R>
 		concept bool ContiguousRange =
-			_Is<reference_t<iterator_t<R>>, is_reference> &&
-			Same<value_type_t<iterator_t<R>>, __uncvref<reference_t<iterator_t<R>>>> &&
+			_Is<iter_reference_t<iterator_t<R>>, is_reference> &&
+			Same<iter_value_t<iterator_t<R>>, __uncvref<iter_reference_t<iterator_t<R>>>> &&
 			requires(R& r) {
-				{ __stl2::data(r) } -> Same<add_pointer_t<reference_t<iterator_t<R>>>>&&;
+				{ __stl2::data(r) } -> Same<add_pointer_t<iter_reference_t<iterator_t<R>>>>&&;
 			};
 	}
 

--- a/include/stl2/detail/range/primitives.hpp
+++ b/include/stl2/detail/range/primitives.hpp
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 		SizedRange{R}
 		constexpr auto enumerate(R&& r)
 		STL2_NOEXCEPT_RETURN(
-			tagged_pair<tag::count(difference_type_t<iterator_t<R>>),
+			tagged_pair<tag::count(iter_difference_t<iterator_t<R>>),
 				tag::end(safe_iterator_t<R>)>{
 				__stl2::size(r),
 				__stl2::next(__stl2::begin(r), __stl2::end(r))
@@ -43,15 +43,15 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	Range{R}
-	constexpr difference_type_t<iterator_t<R>> distance(R&& r)
+	constexpr iter_difference_t<iterator_t<R>> distance(R&& r)
 	STL2_NOEXCEPT_RETURN(
 		__stl2::distance(__stl2::begin(r), __stl2::end(r))
 	)
 
 	SizedRange{R}
-	constexpr difference_type_t<iterator_t<R>> distance(R&& r)
+	constexpr iter_difference_t<iterator_t<R>> distance(R&& r)
 	STL2_NOEXCEPT_RETURN(
-		static_cast<difference_type_t<iterator_t<R>>>(__stl2::size(r))
+		static_cast<iter_difference_t<iterator_t<R>>>(__stl2::size(r))
 	)
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/counted.hpp
+++ b/include/stl2/view/counted.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 				}
 
 				template <Iterator I>
-				constexpr auto operator()(I i, difference_type_t<I> d) const
+				constexpr auto operator()(I i, iter_difference_t<I> d) const
 				{ return ext::subrange{counted_iterator{i, d}, default_sentinel{}}; }
 			};
 		}

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -76,8 +76,8 @@ STL2_OPEN_NAMESPACE {
 				meta::if_c<ForwardIterator<iterator_t<R>>,
 					__stl2::forward_iterator_tag,
 					__stl2::input_iterator_tag>>;
-			using value_type = value_type_t<iterator_t<R>>;
-			using difference_type = difference_type_t<iterator_t<R>>;
+			using value_type = iter_value_t<iterator_t<R>>;
+			using difference_type = iter_difference_t<iterator_t<R>>;
 
 			__iterator() = default;
 
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr iterator_t<R> base() const
 			{ return current_; }
 
-			constexpr reference_t<iterator_t<R>> operator*() const
+			constexpr iter_reference_t<iterator_t<R>> operator*() const
 			{ return *current_; }
 
 			// Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 			requires EqualityComparable<iterator_t<R>>
 			{ return !(x == y); }
 
-			friend constexpr rvalue_reference_t<iterator_t<R>>
+			friend constexpr iter_rvalue_reference_t<iterator_t<R>>
 			iter_move(const __iterator& i)
 			noexcept(noexcept(__stl2::iter_move(i.current_)))
 			{ return __stl2::iter_move(i.current_); }

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 		template <View Rng>
 		requires
 			InputRange<Rng> &&
-			Readable<reference_t<iterator_t<Rng>>>
+			Readable<iter_reference_t<iterator_t<Rng>>>
 		class indirect_view : detail::ebo_box<Rng, indirect_view<Rng>> {
 			using base_t = detail::ebo_box<Rng, indirect_view<Rng>>;
 			using base_t::get;
@@ -54,15 +54,15 @@ STL2_OPEN_NAMESPACE {
 				bool equal(const sentinel<IsConst>& s) const
 				{ return it_ == s.s_; }
 
-				difference_type_t<iterator_t<IsConst>> distance_to(const cursor& that) const
+				iter_difference_t<iterator_t<IsConst>> distance_to(const cursor& that) const
 				requires SizedSentinel<iterator_t<IsConst>, iterator_t<IsConst>>
 				{ return that.it_ - it_; }
-				difference_type_t<iterator_t<IsConst>>
+				iter_difference_t<iterator_t<IsConst>>
 				distance_to(const sentinel<IsConst>& that) const
 				requires SizedSentinel<sentinel_t<IsConst>, iterator_t<IsConst>>
 				{ return that.s_ - it_; }
 
-				void advance(difference_type_t<iterator_t<IsConst>> n)
+				void advance(iter_difference_t<iterator_t<IsConst>> n)
 				requires RandomAccessIterator<iterator_t<IsConst>>
 				{ it_ += n; }
 			};

--- a/include/stl2/view/iota.hpp
+++ b/include/stl2/view/iota.hpp
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 			I value_ {};
 		public:
 			using value_type = I;
-			using difference_type = difference_type_t<I>;
+			using difference_type = iter_difference_t<I>;
 
 			iterator() = default;
 			constexpr explicit iterator(I value)

--- a/include/stl2/view/join.hpp
+++ b/include/stl2/view/join.hpp
@@ -29,14 +29,14 @@ STL2_OPEN_NAMESPACE {
 			using iterator_category = __stl2::input_iterator_tag;
 		};
 		template <ForwardRange Base>
-		requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
-			ForwardRange<reference_t<iterator_t<Base>>>
+		requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
+			ForwardRange<iter_reference_t<iterator_t<Base>>>
 		struct join_view_iterator_base<Base> {
 			using iterator_category = __stl2::forward_iterator_tag;
 		};
 		template <BidirectionalRange Base>
-		requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
-			BidirectionalRange<reference_t<iterator_t<Base>>>
+		requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
+			BidirectionalRange<iter_reference_t<iterator_t<Base>>>
 		struct join_view_iterator_base<Base> {
 			using iterator_category = __stl2::bidirectional_iterator_tag;
 		};
@@ -52,15 +52,15 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template <InputRange Rng>
-		requires View<Rng> && InputRange<reference_t<iterator_t<Rng>>> &&
-			(std::is_reference_v<reference_t<iterator_t<Rng>>> ||
-				View<value_type_t<iterator_t<Rng>>>)
+		requires View<Rng> && InputRange<iter_reference_t<iterator_t<Rng>>> &&
+			(std::is_reference_v<iter_reference_t<iterator_t<Rng>>> ||
+				View<iter_value_t<iterator_t<Rng>>>)
 		class join_view
 		: public view_interface<join_view<Rng>>
-		, detail::join_view_base<reference_t<iterator_t<Rng>>> {
+		, detail::join_view_base<iter_reference_t<iterator_t<Rng>>> {
 		private:
 			Rng base_ {};
-			using InnerRng = reference_t<iterator_t<Rng>>;
+			using InnerRng = iter_reference_t<iterator_t<Rng>>;
 			template <bool Const>
 			struct __iterator;
 			template <bool Const>
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 			template <class ConstRng = const Rng>
 			constexpr const_iterator begin() const
 			requires InputRange<ConstRng> &&
-				std::is_reference_v<reference_t<iterator_t<ConstRng>>>
+				std::is_reference_v<iter_reference_t<iterator_t<ConstRng>>>
 			{ return {*this, __stl2::begin(base_)}; }
 
 			constexpr sentinel end()
@@ -97,7 +97,7 @@ STL2_OPEN_NAMESPACE {
 			template <class ConstRng = const Rng>
 			constexpr const_sentinel end() const
 			requires InputRange<ConstRng> &&
-				std::is_reference_v<reference_t<iterator_t<ConstRng>>>
+				std::is_reference_v<iter_reference_t<iterator_t<ConstRng>>>
 			{ return const_sentinel{*this}; }
 
 			constexpr iterator end()
@@ -111,17 +111,17 @@ STL2_OPEN_NAMESPACE {
 			template <class ConstRng = const Rng>
 			constexpr const_iterator end() const
 			requires ForwardRange<ConstRng> &&
-				std::is_reference_v<reference_t<iterator_t<ConstRng>>> &&
-				ForwardRange<reference_t<iterator_t<ConstRng>>> &&
+				std::is_reference_v<iter_reference_t<iterator_t<ConstRng>>> &&
+				ForwardRange<iter_reference_t<iterator_t<ConstRng>>> &&
 				CommonRange<ConstRng> &&
-				CommonRange<reference_t<iterator_t<ConstRng>>>
+				CommonRange<iter_reference_t<iterator_t<ConstRng>>>
 			{ return {*this, __stl2::end(base_)}; }
 		};
 
 		template <InputRange Rng>
-		requires InputRange<reference_t<iterator_t<Rng>>> &&
-			(std::is_reference_v<reference_t<iterator_t<Rng>>> ||
-				View<value_type_t<iterator_t<Rng>>>)
+		requires InputRange<iter_reference_t<iterator_t<Rng>>> &&
+			(std::is_reference_v<iter_reference_t<iterator_t<Rng>>> ||
+				View<iter_value_t<iterator_t<Rng>>>)
 		explicit join_view(Rng&&) -> join_view<all_view<Rng>>;
 
 		template <class Rng>
@@ -133,7 +133,7 @@ STL2_OPEN_NAMESPACE {
 			using Parent = __maybe_const<Const, join_view>;
 
 			iterator_t<Base> outer_ {};
-			iterator_t<reference_t<iterator_t<Base>>> inner_ {};
+			iterator_t<iter_reference_t<iterator_t<Base>>> inner_ {};
 			Parent* parent_ {};
 
 			friend __iterator<!Const>;
@@ -141,7 +141,7 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr decltype(auto) update_cache_()
 			{
-				if constexpr (!std::is_reference_v<reference_t<iterator_t<Base>>>)
+				if constexpr (!std::is_reference_v<iter_reference_t<iterator_t<Base>>>)
 				{
 					auto&& inner = *outer_;
 					return (parent_->inner_ = view::all(inner));
@@ -152,7 +152,7 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr decltype(auto) inner_rng_()
 			{
-				if constexpr (!std::is_reference_v<reference_t<iterator_t<Base>>>)
+				if constexpr (!std::is_reference_v<iter_reference_t<iterator_t<Base>>>)
 					return (parent_->inner_);
 				else
 					return *outer_;
@@ -167,16 +167,16 @@ STL2_OPEN_NAMESPACE {
 						return;
 				}
 				// needed for symmetric iterator comparison:
-				if constexpr (std::is_reference_v<reference_t<iterator_t<Base>>>)
-					inner_ = iterator_t<reference_t<iterator_t<Base>>>{};
+				if constexpr (std::is_reference_v<iter_reference_t<iterator_t<Base>>>)
+					inner_ = iterator_t<iter_reference_t<iterator_t<Base>>>{};
 			}
 		public:
 			using value_type =
-				value_type_t<iterator_t<reference_t<iterator_t<Base>>>>;
+				iter_value_t<iterator_t<iter_reference_t<iterator_t<Base>>>>;
 			using difference_type =
 				__stl2::common_type_t<
-					difference_type_t<iterator_t<Base>>,
-					difference_type_t<iterator_t<reference_t<iterator_t<Base>>>>>;
+					iter_difference_t<iterator_t<Base>>,
+					iter_difference_t<iterator_t<iter_reference_t<iterator_t<Base>>>>>;
 
 			__iterator() = default;
 
@@ -188,7 +188,7 @@ STL2_OPEN_NAMESPACE {
 				ConvertibleTo<iterator_t<Rng>, iterator_t<Base>> &&
 				ConvertibleTo<
 					iterator_t<InnerRng>,
-					iterator_t<reference_t<iterator_t<Base>>>>
+					iterator_t<iter_reference_t<iterator_t<Base>>>>
 			: outer_(i.outer_), inner_(i.inner_), parent_(i.parent) {}
 
 			constexpr decltype(auto) operator*() const
@@ -208,9 +208,9 @@ STL2_OPEN_NAMESPACE {
 			{ ++*this; }
 
 			constexpr __iterator operator++(int)
-			requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
+			requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
 				ForwardRange<Base> &&
-				ForwardRange<reference_t<iterator_t<Base>>>
+				ForwardRange<iter_reference_t<iterator_t<Base>>>
 			{
 				auto tmp = *this;
 				++*this;
@@ -218,9 +218,9 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			constexpr __iterator& operator--()
-			requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
+			requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
 				BidirectionalRange<Base> &&
-				BidirectionalRange<reference_t<iterator_t<Base>>>
+				BidirectionalRange<iter_reference_t<iterator_t<Base>>>
 			{
 				if (outer_ == __stl2::end(parent_->base_))
 					inner_ = __stl2::end(*--outer_);
@@ -231,9 +231,9 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			constexpr __iterator operator--(int)
-			requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
+			requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
 				BidirectionalRange<Base> &&
-				BidirectionalRange<reference_t<iterator_t<Base>>>
+				BidirectionalRange<iter_reference_t<iterator_t<Base>>>
 			{
 				auto tmp = *this;
 				--*this;
@@ -241,15 +241,15 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			friend constexpr bool operator==(const __iterator& x, const __iterator& y)
-			requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
+			requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
 				EqualityComparable<iterator_t<Base>> &&
-				EqualityComparable<iterator_t<reference_t<iterator_t<Base>>>>
+				EqualityComparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
 			{ return x.outer_ == y.outer_ && x.inner_ == y.inner_; }
 
 			friend constexpr bool operator!=(const __iterator& x, const __iterator& y)
-			requires std::is_reference_v<reference_t<iterator_t<Base>>> &&
+			requires std::is_reference_v<iter_reference_t<iterator_t<Base>>> &&
 				EqualityComparable<iterator_t<Base>> &&
-				EqualityComparable<iterator_t<reference_t<iterator_t<Base>>>>
+				EqualityComparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
 			{ return !(x == y); }
 
 			friend constexpr decltype(auto) iter_move(const __iterator& i)
@@ -300,9 +300,9 @@ STL2_OPEN_NAMESPACE {
 			struct fn : detail::__pipeable<fn>
 			{
 				template <InputRange Rng>
-				requires ext::ViewableRange<Rng> && InputRange<reference_t<iterator_t<Rng>>> &&
-					(std::is_reference_v<reference_t<iterator_t<Rng>>> ||
-						View<value_type_t<iterator_t<Rng>>>)
+				requires ext::ViewableRange<Rng> && InputRange<iter_reference_t<iterator_t<Rng>>> &&
+					(std::is_reference_v<iter_reference_t<iterator_t<Rng>>> ||
+						View<iter_value_t<iterator_t<Rng>>>)
 				constexpr auto operator()(Rng&& rng) const
 				{ return ext::join_view{std::forward<Rng>(rng)}; }
 			};

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 			template <InputRange O>
 			requires
 				_ConstructibleFromRange<Rng, O> &&
-				Constructible<Pattern, single_view<value_type_t<iterator_t<O>>>>
-			constexpr split_view(O&& o, value_type_t<iterator_t<O>> e)
+				Constructible<Pattern, single_view<iter_value_t<iterator_t<O>>>>
+			constexpr split_view(O&& o, iter_value_t<iterator_t<O>> e)
 			: base_(view::all(std::forward<O>(o)))
 			, pattern_(single_view{std::move(e)}) {}
 
@@ -101,8 +101,8 @@ STL2_OPEN_NAMESPACE {
 		split_view(Rng&&, Pattern&&) -> split_view<all_view<Rng>, all_view<Pattern>>;
 
 		template <InputRange Rng>
-		split_view(Rng&&, value_type_t<iterator_t<Rng>>)
-			-> split_view<all_view<Rng>, single_view<value_type_t<iterator_t<Rng>>>>;
+		split_view(Rng&&, iter_value_t<iterator_t<Rng>>)
+			-> split_view<all_view<Rng>, single_view<iter_value_t<iterator_t<Rng>>>>;
 
 		template <class, bool>
 		struct __split_view_outer_base {};
@@ -137,7 +137,7 @@ STL2_OPEN_NAMESPACE {
 		public:
 			using iterator_category = meta::if_c<ForwardRange<Base>,
 				__stl2::forward_iterator_tag, __stl2::input_iterator_tag>;
-			using difference_type = difference_type_t<iterator_t<Base>>;
+			using difference_type = iter_difference_t<iterator_t<Base>>;
 			struct value_type;
 
 			__outer_iterator() = default;
@@ -235,8 +235,8 @@ STL2_OPEN_NAMESPACE {
 			bool zero_ = false;
 		public:
 			using iterator_category = iterator_category_t<__outer_iterator<Const>>;
-			using difference_type = difference_type_t<iterator_t<Base>>;
-			using value_type = value_type_t<iterator_t<Base>>;
+			using difference_type = iter_difference_t<iterator_t<Base>>;
+			using value_type = iter_value_t<iterator_t<Base>>;
 
 			__inner_iterator() = default;
 			constexpr explicit __inner_iterator(__outer_iterator<Const> i)

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 				K == subrange_kind::sized && !SizedSentinel<S, I>;
 
 			meta::if_c<StoreSize,
-				std::tuple<I, S, difference_type_t<I>>,
+				std::tuple<I, S, iter_difference_t<I>>,
 				std::tuple<I, S>> data_;
 
 			constexpr I& first_() noexcept {
@@ -80,10 +80,10 @@ STL2_OPEN_NAMESPACE {
 			constexpr const S& last_() const noexcept {
 				return std::get<1>(data_);
 			}
-			constexpr difference_type_t<I>& size_() noexcept requires StoreSize {
+			constexpr iter_difference_t<I>& size_() noexcept requires StoreSize {
 				return std::get<2>(data_);
 			}
-			constexpr const difference_type_t<I>& size_() const noexcept requires StoreSize {
+			constexpr const iter_difference_t<I>& size_() const noexcept requires StoreSize {
 				return std::get<2>(data_);
 			}
 		public:
@@ -96,14 +96,14 @@ STL2_OPEN_NAMESPACE {
 				requires !StoreSize
 			: data_{std::move(i), std::move(s)} {}
 
-			constexpr subrange(I i, S s, difference_type_t<I> n)
+			constexpr subrange(I i, S s, iter_difference_t<I> n)
 				requires StoreSize
 			: data_{std::move(i), std::move(s), n} {
 				if constexpr (RandomAccessIterator<I>) {
 					STL2_EXPECT(first_() + n == last_());
 				}
 			}
-			constexpr subrange(I i, S s, difference_type_t<I> n)
+			constexpr subrange(I i, S s, iter_difference_t<I> n)
 			requires SizedSentinel<S, I>
 			: data_{std::move(i), std::move(s)} {
 				STL2_EXPECT(last_() - first_() == n);
@@ -123,7 +123,7 @@ STL2_OPEN_NAMESPACE {
 
 			template <_ForwardingRange R>
 			requires ConvertibleTo<iterator_t<R>, I> && ConvertibleTo<sentinel_t<R>, S>
-			constexpr subrange(R&& r, difference_type_t<I> n)
+			constexpr subrange(R&& r, iter_difference_t<I> n)
 				requires (K == subrange_kind::sized)
 			: subrange{__stl2::begin(r), __stl2::end(r), n} {
 				if constexpr (SizedRange<R>) {
@@ -139,7 +139,7 @@ STL2_OPEN_NAMESPACE {
 			{}
 
 			template <_PairLikeConvertibleTo<I, S> PairLike>
-			constexpr subrange(PairLike&& r, difference_type_t<I> n)
+			constexpr subrange(PairLike&& r, iter_difference_t<I> n)
 				requires (K == subrange_kind::sized)
 			: subrange{std::get<0>(static_cast<PairLike&&>(r)),
 				std::get<1>(static_cast<PairLike&&>(r)), n}
@@ -161,7 +161,7 @@ STL2_OPEN_NAMESPACE {
 				return first_() == last_();
 			}
 
-			constexpr difference_type_t<I> size() const requires K == subrange_kind::sized {
+			constexpr iter_difference_t<I> size() const requires K == subrange_kind::sized {
 				if constexpr (StoreSize) {
 					return size_();
 				} else {
@@ -169,18 +169,18 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 
-			[[nodiscard]] constexpr subrange next(difference_type_t<I> n = 1) const {
+			[[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const {
 				auto tmp = *this;
 				tmp.advance(n);
 				return tmp;
 			}
-			[[nodiscard]] constexpr subrange prev(difference_type_t<I> n = 1) const
+			[[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
 			requires BidirectionalIterator<I> {
 				auto tmp = *this;
 				tmp.advance(-n);
 				return tmp;
 			}
-			constexpr subrange& advance(difference_type_t<I> n) {
+			constexpr subrange& advance(iter_difference_t<I> n) {
 				auto remainder = __stl2::advance(first_(), n, last_());
 				(void)remainder;
 				if constexpr (StoreSize) {
@@ -191,14 +191,14 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <Iterator I, Sentinel<I> S>
-		subrange(I, S, difference_type_t<I>) -> subrange<I, S, subrange_kind::sized>;
+		subrange(I, S, iter_difference_t<I>) -> subrange<I, S, subrange_kind::sized>;
 
 		template <_IteratorSentinelPair P>
 		subrange(P) ->
 			subrange<std::tuple_element_t<0, P>, std::tuple_element_t<1, P>>;
 
 		template <_IteratorSentinelPair P>
-		subrange(P, difference_type_t<std::tuple_element_t<0, P>>) ->
+		subrange(P, iter_difference_t<std::tuple_element_t<0, P>>) ->
 			subrange<std::tuple_element_t<0, P>, std::tuple_element_t<1, P>, subrange_kind::sized>;
 
 		template <_ForwardingRange R>
@@ -209,7 +209,7 @@ STL2_OPEN_NAMESPACE {
 		subrange(R&&) -> subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
 		template <_ForwardingRange R>
-		subrange(R&&, difference_type_t<iterator_t<R>>) ->
+		subrange(R&&, iter_difference_t<iterator_t<R>>) ->
 			subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
 		// Not to spec: Extension

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 		struct __take_view : view_interface<take_view<R>> {
 		private:
 			R base_ {};
-			using D = difference_type_t<iterator_t<R>>;
+			using D = iter_difference_t<iterator_t<R>>;
 			D count_ {};
 			template <bool Const>
 			struct __sentinel;
@@ -148,7 +148,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template <InputRange R>
-		take_view(R&& base, difference_type_t<iterator_t<R>> n)
+		take_view(R&& base, iter_difference_t<iterator_t<R>> n)
 		  -> take_view<all_view<R>>;
 	}
 
@@ -157,7 +157,7 @@ STL2_OPEN_NAMESPACE {
 			struct fn {
 				template <InputRange Rng>
 				requires ext::ViewableRange<Rng>
-				constexpr auto operator()(Rng&& rng, difference_type_t<iterator_t<Rng>> count) const
+				constexpr auto operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) const
 				{ return ext::take_view{std::forward<Rng>(rng), count}; }
 
 				template <Integral D>

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -29,11 +29,11 @@ STL2_OPEN_NAMESPACE {
 			using base_t = detail::ebo_box<Base, take_exactly_view<Base>>;
 			using base_t::get;
 
-			difference_type_t<iterator_t<Base>> n_;
+			iter_difference_t<iterator_t<Base>> n_;
 		public:
 			take_exactly_view() requires DefaultConstructible<Base> = default;
 
-			constexpr take_exactly_view(Base view, difference_type_t<iterator_t<Base>> n)
+			constexpr take_exactly_view(Base view, iter_difference_t<iterator_t<Base>> n)
 			noexcept(std::is_nothrow_move_constructible<Base>::value)
 			: base_t{std::move(view)}, n_{n}
 			{ STL2_EXPECT(n >= 0); }
@@ -85,7 +85,7 @@ STL2_OPEN_NAMESPACE {
 	#endif
 
 			constexpr default_sentinel end() const noexcept { return {}; }
-			constexpr difference_type_t<iterator_t<Base>> size() const noexcept { return n_; }
+			constexpr iter_difference_t<iterator_t<Base>> size() const noexcept { return n_; }
 			constexpr bool empty() const noexcept { return n_ == 0; }
 		};
 	} // namespace ext

--- a/include/stl2/view/transform.hpp
+++ b/include/stl2/view/transform.hpp
@@ -30,7 +30,7 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template <InputRange R, CopyConstructible F>
-		requires View<R> && Invocable<F&, reference_t<iterator_t<R>>>
+		requires View<R> && Invocable<F&, iter_reference_t<iterator_t<R>>>
 		class transform_view : public view_interface<transform_view<R, F>> {
 		private:
 			R base_;
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 			// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 			template <class ConstR = const R>
 			constexpr const_iterator begin() const requires Range<ConstR> &&
-				Invocable<const F&, reference_t<iterator_t<ConstR>>>
+				Invocable<const F&, iter_reference_t<iterator_t<ConstR>>>
 			{ return {*this, __stl2::begin(base_)}; }
 
 			constexpr sentinel end()
@@ -71,7 +71,7 @@ STL2_OPEN_NAMESPACE {
 			// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 			template <class ConstR = const R>
 			constexpr const_sentinel end() const requires Range<ConstR> &&
-				Invocable<const F&, reference_t<iterator_t<ConstR>>>
+				Invocable<const F&, iter_reference_t<iterator_t<ConstR>>>
 			{ return const_sentinel{__stl2::end(base_)}; }
 
 			constexpr iterator end() requires CommonRange<R>
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 			// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 			template <class ConstR = const R>
 			constexpr const_iterator end() const requires CommonRange<ConstR> &&
-				Invocable<const F&, reference_t<iterator_t<ConstR>>>
+				Invocable<const F&, iter_reference_t<iterator_t<ConstR>>>
 			{ return {*this, __stl2::end(base_)}; }
 
 			constexpr auto size() requires SizedRange<R>
@@ -106,8 +106,8 @@ STL2_OPEN_NAMESPACE {
 		public:
 			using iterator_category = iterator_category_t<iterator_t<Base>>;
 			using value_type =
-				__uncvref<std::invoke_result_t<F&, reference_t<iterator_t<Base>>>>;
-			using difference_type = difference_type_t<iterator_t<Base>>;
+				__uncvref<std::invoke_result_t<F&, iter_reference_t<iterator_t<Base>>>>;
+			using difference_type = iter_difference_t<iterator_t<Base>>;
 
 			__iterator() = default;
 
@@ -250,12 +250,12 @@ STL2_OPEN_NAMESPACE {
 			friend constexpr bool operator!=(const __sentinel& x, const __iterator<Const>& y)
 			{ return !(y == x); }
 
-			friend constexpr difference_type_t<iterator_t<Base>>
+			friend constexpr iter_difference_t<iterator_t<Base>>
 			operator-(const __iterator<Const>& x, const __sentinel& y)
 			requires SizedSentinel<sentinel_t<Base>, iterator_t<Base>>
 			{ return x.current_ - y.end_; }
 
-			friend constexpr difference_type_t<iterator_t<Base>>
+			friend constexpr iter_difference_t<iterator_t<Base>>
 			operator-(const __sentinel& y, const __iterator<Const>& x)
 			requires SizedSentinel<sentinel_t<Base>, iterator_t<Base>>
 			{ return x.end_ - y.current_; }
@@ -266,7 +266,7 @@ STL2_OPEN_NAMESPACE {
 		namespace __transform {
 			struct fn {
 				template <InputRange Rng, CopyConstructible F>
-				requires ext::ViewableRange<Rng> && Invocable<F&, reference_t<iterator_t<Rng>>>
+				requires ext::ViewableRange<Rng> && Invocable<F&, iter_reference_t<iterator_t<Rng>>>
 				constexpr auto operator()(Rng&& rng, F fun) const {
 					return ext::transform_view{std::forward<Rng>(rng), std::move(fun)};
 				}

--- a/include/stl2/view/view_interface.hpp
+++ b/include/stl2/view/view_interface.hpp
@@ -41,21 +41,21 @@ STL2_OPEN_NAMESPACE {
 		concept bool SizedSentinelForwardRange = ForwardRange<R> && SizedSentinel<sentinel_t<R>, iterator_t<R>>;
 		template <class C, class R>
 		concept bool ContainerConvertible = InputRange<R> && ForwardRange<C> && !View<C> &&
-			ConvertibleTo<reference_t<iterator_t<R>>, value_type_t<iterator_t<C>>> &&
+			ConvertibleTo<iter_reference_t<iterator_t<R>>, iter_value_t<iterator_t<C>>> &&
 			Constructible<C, ext::__range_common_iterator<R>, ext::__range_common_iterator<R>>;
 
 		template <Range R>
-		constexpr bool is_in_range(R& r, difference_type_t<iterator_t<R>> n) noexcept {
+		constexpr bool is_in_range(R& r, iter_difference_t<iterator_t<R>> n) noexcept {
 			return 0 <= n;
 		}
 
 		template <SizedRange R>
-		constexpr bool is_in_range(R& r, difference_type_t<iterator_t<R>> n)
+		constexpr bool is_in_range(R& r, iter_difference_t<iterator_t<R>> n)
 			noexcept(noexcept(__stl2::size(r)))
 		{
 			auto sz = __stl2::size(r);
 			using T = std::make_unsigned_t<common_type_t<
-				difference_type_t<iterator_t<R>>,
+				iter_difference_t<iterator_t<R>>,
 				decltype(sz)>>;
 			return static_cast<T>(n) < static_cast<T>(sz);
 		}
@@ -132,13 +132,13 @@ STL2_OPEN_NAMESPACE {
 				return *--last;
 			}
 			template <RandomAccessRange R = D>
-			constexpr decltype(auto) operator[](difference_type_t<iterator_t<R>> n) {
+			constexpr decltype(auto) operator[](iter_difference_t<iterator_t<R>> n) {
 				auto& d = derived();
 				STL2_EXPECT(detail::is_in_range(d, n));
 				return __stl2::begin(d)[n];
 			}
 			template <RandomAccessRange R = const D>
-			constexpr decltype(auto) operator[](difference_type_t<iterator_t<R>> n) const {
+			constexpr decltype(auto) operator[](iter_difference_t<iterator_t<R>> n) const {
 				auto& d = derived();
 				STL2_EXPECT(detail::is_in_range(d, n));
 				return __stl2::begin(d)[n];

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -20,12 +20,12 @@
 namespace ranges = __stl2;
 
 template <ranges::InputIterator I>
-	requires ranges::Regular<ranges::value_type_t<I>>
+	requires ranges::Regular<ranges::iter_value_t<I>>
 class delimiter {
-	ranges::value_type_t<I> value_;
+	ranges::iter_value_t<I> value_;
 public:
 	delimiter() = default;
-	delimiter(ranges::value_type_t<I> value) :
+	delimiter(ranges::iter_value_t<I> value) :
 		value_{std::move(value)} {}
 
 	friend bool operator==(const delimiter& lhs, const delimiter& rhs) {

--- a/test/algorithm/partition_point.cpp
+++ b/test/algorithm/partition_point.cpp
@@ -156,7 +156,7 @@ test_range()
 
 stl2::Iterator{I}
 stl2::ext::subrange<stl2::counted_iterator<I>, stl2::default_sentinel>
-make_counted_view(I i, stl2::difference_type_t<I> n) {
+make_counted_view(I i, stl2::iter_difference_t<I> n) {
   return {stl2::make_counted_iterator(stl2::move(i), n), {}};
 }
 

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -63,7 +63,7 @@ template <class RI>
 void
 test_sort_helper(RI f, RI l)
 {
-	using value_type = stl2::value_type_t<RI>;
+	using value_type = stl2::iter_value_t<RI>;
 	auto sort = make_testable_1<false>([](auto&&... args) {
 		return stl2::sort(std::forward<decltype(args)>(args)...);
 	});

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -43,7 +43,7 @@ template <class RI>
 void
 test_sort_helper(RI f, RI l)
 {
-	using value_type = stl2::value_type_t<RI>;
+	using value_type = stl2::iter_value_t<RI>;
 	auto stable_sort = make_testable_1<false>([](auto&&... args) {
 		return stl2::stable_sort(std::forward<decltype(args)>(args)...);
 	});

--- a/test/concepts/iterator.cpp
+++ b/test/concepts/iterator.cpp
@@ -18,19 +18,19 @@
 
 namespace ns {
 	template <class I>
-	using difference_type_t = ranges::iterator_difference_t<I>;
+	using iter_difference_t = ranges::iterator_difference_t<I>;
 
 	template <class I>
 	using iterator_category_t = ranges::iterator_category_t<I>;
 
 	template <class I>
-	using reference_t = ranges::iterator_reference_t<I>;
+	using iter_reference_t = ranges::iterator_reference_t<I>;
 
 	template <class I>
-	using rvalue_reference_t = ranges::iterator_rvalue_reference_t<I>;
+	using iter_rvalue_reference_t = ranges::iterator_rvalue_reference_t<I>;
 
 	template <class I>
-	using value_type_t = ranges::iterator_value_t<I>;
+	using iter_value_t = ranges::iterator_value_t<I>;
 
 	using ranges::value_type;
 	using ranges::difference_type;
@@ -41,7 +41,7 @@ namespace ns {
 	using ranges::bidirectional_iterator_tag;
 	using ranges::random_access_iterator_tag;
 
-	using ranges::indirect_result_of_t;
+	using ranges::indirect_invoke_result_t;
 }
 
 #elif VALIDATE_STL2
@@ -64,41 +64,41 @@ namespace associated_type_test {
 	struct A { using value_type = int; int& operator*() const; };
 	struct B : A { using value_type = double; };
 
-	CONCEPT_ASSERT(ranges::Same<int&, ns::reference_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::reference_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::reference_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::reference_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::reference_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<const int&, ns::reference_t<const int*>>);
+	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int*>>);
+	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<A>>);
+	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<B>>);
+	CONCEPT_ASSERT(ranges::Same<const int&, ns::iter_reference_t<const int*>>);
 
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::rvalue_reference_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::rvalue_reference_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::rvalue_reference_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::rvalue_reference_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::rvalue_reference_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<const int&&, ns::rvalue_reference_t<const int*>>);
+	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int*>>);
+	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<A>>);
+	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<B>>);
+	CONCEPT_ASSERT(ranges::Same<const int&&, ns::iter_rvalue_reference_t<const int*>>);
 
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<double, ns::value_type_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<const int*>>);
-	CONCEPT_ASSERT(!meta::is_trait<ns::value_type<void>>());
-	CONCEPT_ASSERT(!meta::is_trait<ns::value_type<void*>>());
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<const int* const>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<const int[2]>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int*>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int[]>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<A>>);
+	CONCEPT_ASSERT(ranges::Same<double, ns::iter_value_t<B>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int*>>);
+	CONCEPT_ASSERT(!meta::is_trait<ns::readable_traits<void>>());
+	CONCEPT_ASSERT(!meta::is_trait<ns::readable_traits<void*>>());
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int* const>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int[2]>>);
 	struct S { using value_type = int; using element_type = int const; };
-	CONCEPT_ASSERT(ranges::Same<int, ns::value_type_t<S>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<S>>);
 
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::difference_type_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::difference_type_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::difference_type_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int*>>);
+	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int[4]>>);
 
-	CONCEPT_ASSERT(!meta::is_trait<ns::difference_type<void>>());
-	CONCEPT_ASSERT(!meta::is_trait<ns::difference_type<void*>>());
+	CONCEPT_ASSERT(!meta::is_trait<ns::incrementable_traits<void>>());
+	CONCEPT_ASSERT(!meta::is_trait<ns::incrementable_traits<void*>>());
 
-	CONCEPT_ASSERT(ranges::Same<int, ns::difference_type_t<int>>);
+	CONCEPT_ASSERT(ranges::Same<int, ns::iter_difference_t<int>>);
 #if VALIDATE_STL2
 	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<int*>, __stl2::ext::contiguous_iterator_tag>);
 	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<const int*>, __stl2::ext::contiguous_iterator_tag>);
@@ -167,7 +167,7 @@ namespace readable_test {
 	CONCEPT_ASSERT(ranges::Readable<int*>);
 	CONCEPT_ASSERT(ranges::Readable<const int*>);
 	CONCEPT_ASSERT(ranges::Readable<A>);
-	CONCEPT_ASSERT(ranges::Same<ns::value_type_t<A>,int>);
+	CONCEPT_ASSERT(ranges::Same<ns::iter_value_t<A>,int>);
 
 	struct MoveOnlyReadable {
 		using value_type = std::unique_ptr<int>;
@@ -258,10 +258,10 @@ namespace indirectly_callable_test {
 	CONCEPT_ASSERT(ranges::ext::IndirectInvocable<std::plus<int>, int*, int*>);
 }
 
-namespace indirect_result_of_test {
+namespace indirect_invoke_result_test {
 	template <class R, class... Args>
 	using fn_t = R(Args...);
-	CONCEPT_ASSERT(ranges::Same<ns::indirect_result_of_t<fn_t<void, int>&(const int*)>, void>);
+	CONCEPT_ASSERT(ranges::Same<ns::indirect_invoke_result_t<fn_t<void, int>&, const int*>, void>);
 }
 
 int main() {

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -314,7 +314,7 @@ struct proxy_array {
 
 template <ranges::InputRange R>
 requires
-	ranges::StreamInsertable<ranges::value_type_t<ranges::iterator_t<R>>> &&
+	ranges::StreamInsertable<ranges::iter_value_t<ranges::iterator_t<R>>> &&
 	!ranges::Same<char, std::remove_cv_t<
 		std::remove_all_extents_t<std::remove_reference_t<R>>>>
 std::ostream& operator<<(std::ostream& os, R&& rng) {
@@ -339,11 +339,11 @@ void test_fl() {
 	using I = decltype(list.begin());
 	using S = decltype(list.end());
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::value_type_t<I>, int>);
-	static_assert(ranges::Same<ranges::reference_t<I>, int&>);
-	static_assert(ranges::Same<ranges::rvalue_reference_t<I>, int&&>);
+	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, int&>);
+	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int&&>);
 	static_assert(ranges::Copyable<I>);
 	static_assert(ranges::DefaultConstructible<I>);
 	static_assert(ranges::Semiregular<I>);
@@ -384,11 +384,11 @@ void test_rv() {
 	using Rng = decltype(rv);
 	using I = decltype(rv.begin());
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::value_type_t<I>, int>);
-	static_assert(ranges::Same<ranges::reference_t<I>, int>);
-	static_assert(ranges::Same<ranges::rvalue_reference_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(ranges::RandomAccessRange<Rng>);
 	CHECK(I{} == I{});
@@ -423,11 +423,11 @@ void test_array() {
 	using I = decltype(a.begin());
 	CHECK(noexcept(a.begin()));
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::value_type_t<I>, int>);
-	static_assert(ranges::Same<ranges::reference_t<I>, int&>);
-	static_assert(ranges::Same<ranges::rvalue_reference_t<I>, int&&>);
+	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, int&>);
+	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int&&>);
 	static_assert(ranges::ext::ContiguousIterator<I>);
 	static_assert(ranges::RandomAccessRange<Rng>);
 	static_assert(ranges::RandomAccessRange<const Rng>);
@@ -466,11 +466,11 @@ void test_counted() {
 	int some_ints[] = {0,1,2,3};
 	using I = counted_iterator<const int*>;
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::value_type_t<I>, int>);
-	static_assert(ranges::Same<ranges::reference_t<I>, const int&>);
-	static_assert(ranges::Same<ranges::rvalue_reference_t<I>, const int&&>);
+	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, const int&>);
+	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, const int&&>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(ranges::ext::ContiguousIterator<I>);
 	CHECK(I{} == I{});
@@ -517,11 +517,11 @@ void test_always() {
 	static_assert(std::is_empty<I>());
 	static_assert(sizeof(I) == 1);
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::value_type_t<I>, int>);
-	static_assert(ranges::Same<ranges::reference_t<I>, int>);
-	static_assert(ranges::Same<ranges::rvalue_reference_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, int>);
+	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	CHECK(I{} == I{});
 	ranges::copy_n(i, 13, ranges::ostream_iterator<>{std::cout, " "});
@@ -538,8 +538,8 @@ void test_back_inserter() {
 	auto i = ranges::back_inserter(vec);
 	using I = decltype(i);
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Same<ranges::reference_t<I>, I&>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_reference_t<I>, I&>);
 	static_assert(!ranges::Readable<I>);
 	static_assert(ranges::OutputIterator<I, int>);
 	static_assert(!ranges::InputIterator<I>);
@@ -563,18 +563,18 @@ void test_proxy_array() {
 
 	using I = ranges::iterator_t<Rng>;
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	using R = ranges::reference_t<I>;
+	using R = ranges::iter_reference_t<I>;
 	static_assert(ranges::Same<proxy_wrapper<int>, R>);
-	using V = ranges::value_type_t<I>;
+	using V = ranges::iter_value_t<I>;
 	static_assert(ranges::Same<int, V>);
 	static_assert(ranges::Same<int&&, decltype(iter_move(std::declval<const I&>()))>);
 	static_assert(ranges::Same<int&&, decltype(iter_move(std::declval<I&>()))>);
 
 	static_assert(ranges::__iter_move::has_customization<const I&>);
 	static_assert(ranges::__iter_move::has_customization<I&>);
-	using RR = ranges::rvalue_reference_t<I>;
+	using RR = ranges::iter_rvalue_reference_t<I>;
 	static_assert(ranges::Same<int&&, RR>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(!ranges::ext::ContiguousIterator<I>);
@@ -583,15 +583,15 @@ void test_proxy_array() {
 
 	using CI = ranges::iterator_t<const Rng>;
 	static_assert(ranges::WeaklyIncrementable<CI>);
-	static_assert(ranges::Same<ranges::difference_type_t<CI>, std::ptrdiff_t>);
-	using CR = ranges::reference_t<CI>;
+	static_assert(ranges::Same<ranges::iter_difference_t<CI>, std::ptrdiff_t>);
+	using CR = ranges::iter_reference_t<CI>;
 	static_assert(ranges::Same<proxy_wrapper<const int>, CR>);
-	using CV = ranges::value_type_t<CI>;
+	using CV = ranges::iter_value_t<CI>;
 	static_assert(ranges::Same<int, CV>);
 
 	static_assert(ranges::__iter_move::has_customization<const CI&>);
 	static_assert(ranges::__iter_move::has_customization<CI&>);
-	using CRR = ranges::rvalue_reference_t<CI>;
+	using CRR = ranges::iter_rvalue_reference_t<CI>;
 	static_assert(ranges::Same<const int&&, CRR>);
 
 	static_assert(ranges::CommonReference<CR, CV&>);

--- a/test/iterator/incomplete.cpp
+++ b/test/iterator/incomplete.cpp
@@ -4,7 +4,7 @@
 namespace ranges = __stl2;
 
 struct foo;
-static_assert(ranges::Same<std::ptrdiff_t,ranges::difference_type_t<foo*>>);
+static_assert(ranges::Same<std::ptrdiff_t,ranges::iter_difference_t<foo*>>);
 static_assert(ranges::Same<foo*,ranges::common_type_t<foo*, foo*>>);
 struct foo {};
 

--- a/test/iterator/istream_iterator.cpp
+++ b/test/iterator/istream_iterator.cpp
@@ -29,11 +29,11 @@ int main() {
 	{
 		using I = istream_iterator<int>;
 		static_assert(WeaklyIncrementable<I>);
-		static_assert(Same<difference_type_t<I>, std::ptrdiff_t>);
+		static_assert(Same<iter_difference_t<I>, std::ptrdiff_t>);
 		static_assert(Readable<I>);
-		static_assert(Same<value_type_t<I>, int>);
-		static_assert(Same<reference_t<I>, const int&>);
-		static_assert(Same<rvalue_reference_t<I>, const int&&>);
+		static_assert(Same<iter_value_t<I>, int>);
+		static_assert(Same<iter_reference_t<I>, const int&>);
+		static_assert(Same<iter_rvalue_reference_t<I>, const int&&>);
 		static_assert(Iterator<I>);
 		static_assert(InputIterator<I>);
 		static_assert(!ForwardIterator<I>);

--- a/test/iterator/istreambuf_iterator.cpp
+++ b/test/iterator/istreambuf_iterator.cpp
@@ -35,11 +35,11 @@ namespace {
 
 		using I = istreambuf_iterator<charT, traits>;
 		static_assert(WeaklyIncrementable<I>);
-		static_assert(Same<typename traits::off_type, difference_type_t<I>>);
-		static_assert(Same<charT, value_type_t<I>>);
+		static_assert(Same<typename traits::off_type, iter_difference_t<I>>);
+		static_assert(Same<charT, iter_value_t<I>>);
 		static_assert(Readable<I>);
-		static_assert(Same<charT, reference_t<I>>);
-		static_assert(Same<charT, rvalue_reference_t<I>>);
+		static_assert(Same<charT, iter_reference_t<I>>);
+		static_assert(Same<charT, iter_rvalue_reference_t<I>>);
 		static_assert(Iterator<I>);
 		static_assert(Same<input_iterator_tag, iterator_category_t<I>>);
 		static_assert(InputIterator<I>);
@@ -49,8 +49,8 @@ namespace {
 		static_assert(Common<I, default_sentinel>);
 		static_assert(Same<I, common_type_t<I, default_sentinel>>);
 
-		static_assert(Same<value_type_t<I>, typename I::value_type>);
-		static_assert(Same<difference_type_t<I>, typename I::difference_type>);
+		static_assert(Same<iter_value_t<I>, typename I::value_type>);
+		static_assert(Same<iter_difference_t<I>, typename I::difference_type>);
 		static_assert(Same<input_iterator_tag, typename I::iterator_category>);
 		static_assert(Same<charT, typename I::reference>);
 		static_assert(Same<traits, typename I::traits_type>);

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -304,14 +304,14 @@ template <ranges::ext::ContiguousIterator I, ranges::SizedSentinel<I> S,
 	ranges::ext::ContiguousIterator O>
 requires
 	ranges::IndirectlyCopyable<I, O> &&
-	ranges::Same<ranges::value_type_t<I>, ranges::value_type_t<O>> &&
-	std::is_trivially_copyable<ranges::value_type_t<I>>::value
+	ranges::Same<ranges::iter_value_t<I>, ranges::iter_value_t<O>> &&
+	std::is_trivially_copyable<ranges::iter_value_t<I>>::value
 bool copy(I first, S last, O o) {
 	auto n = last - first;
 	STL2_EXPECT(n >= 0);
 	if (n) {
 		std::memmove(std::addressof(*o), std::addressof(*first),
-			n * sizeof(ranges::value_type_t<I>));
+			n * sizeof(ranges::iter_value_t<I>));
 	}
 	return true;
 }
@@ -363,9 +363,9 @@ void test_iter_swap2() {
 		using I = decltype(a);
 		static_assert(ranges::Same<I, decltype(b)>);
 		static_assert(ranges::Readable<I>);
-		using R = ranges::reference_t<I>;
+		using R = ranges::iter_reference_t<I>;
 		static_assert(ranges::Same<int&, R>);
-		using RR = ranges::rvalue_reference_t<I>;
+		using RR = ranges::iter_rvalue_reference_t<I>;
 		static_assert(ranges::Same<int&&, RR>);
 		static_assert(ranges::SwappableWith<R, R>);
 
@@ -383,11 +383,11 @@ void test_iter_swap2() {
 		auto a = array<int, 4>{0,1,2,3};
 		using I = decltype(a.begin());
 		static_assert(ranges::Readable<I>);
-		using V = ranges::value_type_t<I>;
+		using V = ranges::iter_value_t<I>;
 		static_assert(ranges::Same<int, V>);
-		using R = ranges::reference_t<I>;
+		using R = ranges::iter_reference_t<I>;
 		static_assert(ranges::Same<reference_wrapper<int>, R>);
-		using RR = ranges::rvalue_reference_t<I>;
+		using RR = ranges::iter_rvalue_reference_t<I>;
 		static_assert(ranges::Same<int&&, RR>);
 
 		static_assert(ranges::Same<I, decltype(a.begin() + 2)>);

--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -187,21 +187,21 @@ void test_proxy_iterator() {
 
 	static_assert(
 		ranges::Same<
-			ranges::reference_t<proxy_iterator<A>>,
+			ranges::iter_reference_t<proxy_iterator<A>>,
 			std::reference_wrapper<A>>);
 	static_assert(
 		ranges::Same<
-			ranges::reference_t<const proxy_iterator<A>>,
+			ranges::iter_reference_t<const proxy_iterator<A>>,
 			std::reference_wrapper<A>>);
 	static_assert(
 		ranges::Same<
-			ranges::rvalue_reference_t<proxy_iterator<A>>,
+			ranges::iter_rvalue_reference_t<proxy_iterator<A>>,
 			A&&>);
 
 	{
 		static_assert(
 			ranges::Same<
-				ranges::rvalue_reference_t<
+				ranges::iter_rvalue_reference_t<
 					ranges::move_iterator<proxy_iterator<A>>>,
 				A&&>);
 		auto first = ranges::make_move_iterator(proxy_iterator<A>{ranges::data(vec)}),
@@ -236,12 +236,12 @@ void test_proxy_iterator() {
 	{
 		static_assert(
 			ranges::Same<
-				ranges::rvalue_reference_t<
+				ranges::iter_rvalue_reference_t<
 					ranges::counted_iterator<proxy_iterator<A>>>,
 				A&&>);
 		static_assert(
 			ranges::Same<
-				ranges::rvalue_reference_t<
+				ranges::iter_rvalue_reference_t<
 					ranges::move_iterator<
 						ranges::counted_iterator<proxy_iterator<A>>>>,
 				A&&>);

--- a/test/iterator/ostream_iterator.cpp
+++ b/test/iterator/ostream_iterator.cpp
@@ -18,7 +18,7 @@
 using namespace __stl2;
 
 namespace {
-	template <InputIterator I, Sentinel<I> S, OutputIterator<reference_t<I>> O>
+	template <InputIterator I, Sentinel<I> S, OutputIterator<iter_reference_t<I>> O>
 	tagged_pair<tag::in(I), tag::out(O)>
 	constexpr copy(I first, S last, O out) {
 		for (; first != last; ++first, void(), ++out) {
@@ -34,9 +34,9 @@ int main() {
 
 	using I = ostream_iterator<int>;
 	static_assert(WeaklyIncrementable<I>);
-	static_assert(Same<difference_type_t<I>, std::ptrdiff_t>);
+	static_assert(Same<iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(Iterator<I>);
-	static_assert(Same<reference_t<I>, I&>);
+	static_assert(Same<iter_reference_t<I>, I&>);
 	static_assert(OutputIterator<I, const int&>);
 	static_assert(!InputIterator<I>);
 

--- a/test/iterator/ostreambuf_iterator.cpp
+++ b/test/iterator/ostreambuf_iterator.cpp
@@ -18,7 +18,7 @@
 using namespace __stl2;
 
 namespace {
-	template <InputIterator I, Sentinel<I> S, OutputIterator<reference_t<I>> O>
+	template <InputIterator I, Sentinel<I> S, OutputIterator<iter_reference_t<I>> O>
 	tagged_pair<tag::in(I), tag::out(O)>
 	constexpr copy(I first, S last, O out) {
 		for (; first != last; ++first, void(), ++out) {
@@ -27,7 +27,7 @@ namespace {
 		return {first, out};
 	}
 
-	template <InputRange R, OutputIterator<reference_t<iterator_t<R>>> O>
+	template <InputRange R, OutputIterator<iter_reference_t<iterator_t<R>>> O>
 	constexpr tagged_pair<tag::in(safe_iterator_t<R>), tag::out(O)>
 	copy(R&& range, O out) {
 		return ::copy(__stl2::begin(range), __stl2::end(range), __stl2::move(out));

--- a/test/iterator/reverse_iterator.cpp
+++ b/test/iterator/reverse_iterator.cpp
@@ -73,14 +73,14 @@ template <class It> void test7(It i, It x) {
 }
 
 template <class It>
-void test8(It i, ranges::difference_type_t<It> n, It x) {
+void test8(It i, ranges::iter_difference_t<It> n, It x) {
 	const ranges::reverse_iterator<It> r(i);
 	ranges::reverse_iterator<It> rr = r + n;
 	CHECK(rr.base() == x);
 }
 
 template <class It>
-void test9(It i, ranges::difference_type_t<It> n, It x) {
+void test9(It i, ranges::iter_difference_t<It> n, It x) {
 	ranges::reverse_iterator<It> r(i);
 	ranges::reverse_iterator<It> &rr = r += n;
 	CHECK(r.base() == x);
@@ -100,14 +100,14 @@ template <class It> void test11(It i, It x) {
 	CHECK(&rr == &r);
 }
 template <class It>
-void test12(It i, ranges::difference_type_t<It> n, It x) {
+void test12(It i, ranges::iter_difference_t<It> n, It x) {
 	const ranges::reverse_iterator<It> r(i);
 	ranges::reverse_iterator<It> rr = r - n;
 	CHECK(rr.base() == x);
 }
 
 template <class It>
-void test13(It i, ranges::difference_type_t<It> n, It x) {
+void test13(It i, ranges::iter_difference_t<It> n, It x) {
 	ranges::reverse_iterator<It> r(i);
 	ranges::reverse_iterator<It> &rr = r -= n;
 	CHECK(r.base() == x);
@@ -123,7 +123,7 @@ public:
 	friend bool operator==(const A &x, const A &y) { return x.data_ == y.data_; }
 };
 
-template <class It> void test14(It i, ranges::value_type_t<It> x) {
+template <class It> void test14(It i, ranges::iter_value_t<It> x) {
 	ranges::reverse_iterator<It> r(i);
 	CHECK(*r == x);
 }
@@ -160,9 +160,9 @@ template <class It> void test19(It l, It r, bool x) {
 }
 
 template <class It>
-void test20(It i, ranges::difference_type_t<It> n, ranges::value_type_t<It> x) {
+void test20(It i, ranges::iter_difference_t<It> n, ranges::iter_value_t<It> x) {
 	const ranges::reverse_iterator<It> r(i);
-	ranges::value_type_t<It> rr = r[n];
+	ranges::iter_value_t<It> rr = r[n];
 	CHECK(rr == x);
 }
 
@@ -203,7 +203,7 @@ public:
 
 template <class It>
 void
-test24(It i, ranges::value_type_t<It> x)
+test24(It i, ranges::iter_value_t<It> x)
 {
 	ranges::reverse_iterator<It> r(i);
 	CHECK((*r).get() == x.get());
@@ -227,7 +227,7 @@ public:
 
 template <class It>
 void
-test25(It i, ranges::difference_type_t<It> n, It x)
+test25(It i, ranges::iter_difference_t<It> n, It x)
 {
 	const ranges::reverse_iterator<It> r(i);
 	ranges::reverse_iterator<It> rr = n + r;

--- a/test/memory/uninitialized_move.cpp
+++ b/test/memory/uninitialized_move.cpp
@@ -33,21 +33,21 @@ using ranges::ext::span;
 namespace {
 	template <ranges::InputRange Rng>
 	requires requires {
-		typename ranges::value_type_t<Rng>;
-		&ranges::value_type_t<Rng>::empty;
+		typename ranges::iter_value_t<Rng>;
+		&ranges::iter_value_t<Rng>::empty;
 		requires ranges::Invocable<
-			decltype(&ranges::value_type_t<Rng>::empty),
-			ranges::reference_t<ranges::iterator_t<const Rng>>>;
+			decltype(&ranges::iter_value_t<Rng>::empty),
+			ranges::iter_reference_t<ranges::iterator_t<const Rng>>>;
 	}
 	bool empty(const Rng& rng, const std::ptrdiff_t n) {
 		return ranges::all_of(ranges::make_counted_iterator(rng.begin(), n), ranges::default_sentinel{},
-			&ranges::value_type_t<Rng>::empty);
+			&ranges::iter_value_t<Rng>::empty);
 	}
 
 	template <ranges::InputRange Rng>
 	requires requires {
-		typename ranges::value_type_t<Rng>;
-		requires std::is_fundamental<ranges::value_type_t<Rng>>::value;
+		typename ranges::iter_value_t<Rng>;
+		requires std::is_fundamental<ranges::iter_value_t<Rng>>::value;
 	}
 	bool empty(const Rng&, const std::ptrdiff_t) {
 		return true;

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -107,9 +107,9 @@ class output_iterator
 
 	template <class U> friend class output_iterator;
 public:
-	using difference_type = __stl2::difference_type_t<It>;
+	using difference_type = __stl2::iter_difference_t<It>;
 	using pointer = It;
-	using reference = __stl2::reference_t<It>;
+	using reference = __stl2::iter_reference_t<It>;
 
 	constexpr It base() const {return it_;}
 
@@ -135,10 +135,10 @@ class input_iterator
 	template <class U> friend class input_iterator;
 public:
 	typedef __stl2::input_iterator_tag iterator_category;
-	typedef __stl2::value_type_t<It>      value_type;
-	typedef __stl2::difference_type_t<It> difference_type;
+	typedef __stl2::iter_value_t<It>      value_type;
+	typedef __stl2::iter_difference_t<It> difference_type;
 	typedef It                       pointer;
-	typedef __stl2::reference_t<It>  reference;
+	typedef __stl2::iter_reference_t<It>  reference;
 
 	constexpr It base() const {return it_;}
 
@@ -187,10 +187,10 @@ class forward_iterator
 	template <class U> friend class forward_iterator;
 public:
 	typedef __stl2::forward_iterator_tag iterator_category;
-	typedef __stl2::value_type_t<It>        value_type;
-	typedef __stl2::difference_type_t<It>   difference_type;
+	typedef __stl2::iter_value_t<It>        value_type;
+	typedef __stl2::iter_difference_t<It>   difference_type;
 	typedef It                         pointer;
-	typedef __stl2::reference_t<It>    reference;
+	typedef __stl2::iter_reference_t<It>    reference;
 
 	constexpr It base() const {return it_;}
 
@@ -239,10 +239,10 @@ class bidirectional_iterator
 	template <class U> friend class bidirectional_iterator;
 public:
 	typedef __stl2::bidirectional_iterator_tag iterator_category;
-	typedef __stl2::value_type_t<It>              value_type;
-	typedef __stl2::difference_type_t<It>         difference_type;
+	typedef __stl2::iter_value_t<It>              value_type;
+	typedef __stl2::iter_difference_t<It>         difference_type;
 	typedef It                               pointer;
-	typedef __stl2::reference_t<It>          reference;
+	typedef __stl2::iter_reference_t<It>          reference;
 
 	constexpr It base() const {return it_;}
 
@@ -288,10 +288,10 @@ class random_access_iterator
 	template <class U> friend class random_access_iterator;
 public:
 	typedef __stl2::random_access_iterator_tag iterator_category;
-	typedef __stl2::value_type_t<It>              value_type;
-	typedef __stl2::difference_type_t<It>         difference_type;
+	typedef __stl2::iter_value_t<It>              value_type;
+	typedef __stl2::iter_difference_t<It>         difference_type;
 	typedef It                               pointer;
-	typedef __stl2::reference_t<It>          reference;
+	typedef __stl2::iter_reference_t<It>          reference;
 
 	constexpr It base() const {return it_;}
 
@@ -380,7 +380,7 @@ operator>=(const random_access_iterator<T>& x, const random_access_iterator<U>& 
 
 template <class T, class U>
 constexpr
-__stl2::difference_type_t<T>
+__stl2::iter_difference_t<T>
 operator-(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
 	return x.base() - y.base();

--- a/test/view/transform_view.cpp
+++ b/test/view/transform_view.cpp
@@ -48,7 +48,7 @@ int main()
 	std::pair<int, int> rgp[] = {{1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}, {7,7}, {8,8}, {9,9}, {10,10}};
 	auto rng2 = rgp | view::transform(&std::pair<int,int>::first);
 	static_assert(Same<int &, decltype(*begin(rng2))>);
-	static_assert(Same<value_type_t<iterator_t<decltype(rng2)>>, int>);
+	static_assert(Same<iter_value_t<iterator_t<decltype(rng2)>>, int>);
 	static_assert(Same<decltype(iter_move(begin(rng2))), int &&>);
 	static_assert(View<decltype(rng2)>);
 	static_assert(CommonRange<decltype(rng2)>);


### PR DESCRIPTION
* [indirect_]result_of[_t] -> [indirect_]invoke_result[_t]
* value_type -> readable_traits
* value_type_t -> iter_value_t
* difference_type -> incrementable_traits
* difference_type_t -> iter_difference_t
* reference_t -> iter_reference_t
* rvalue_reference_t -> iter_rvalue_reference_t