### PR TITLE
Updated repeat and repeat_n so they permit lvalues

### DIFF
--- a/include/stl2/view/repeat.hpp
+++ b/include/stl2/view/repeat.hpp
@@ -75,9 +75,15 @@ STL2_OPEN_NAMESPACE {
 	namespace view::ext {
 		class __repeat_fn {
 			template <class T>
-			constexpr auto operator()(T&& t) const
+			constexpr auto operator()(T const& t) const
 			STL2_NOEXCEPT_REQUIRES_RETURN(
-				__stl2::ext::repeat_view{std::forward<T>(t)}
+				__stl2::ext::repeat_view{t}
+			)
+
+			template <class T>
+			constexpr auto operator()(remove_reference_t<T>&& t) const
+			STL2_NOEXCEPT_REQUIRES_RETURN(
+				__stl2::ext::repeat_view{std::move(t)}
 			)
 		};
 

--- a/include/stl2/view/repeat_n.hpp
+++ b/include/stl2/view/repeat_n.hpp
@@ -26,11 +26,21 @@ STL2_OPEN_NAMESPACE {
 	namespace view::ext {
 		class __repeat_n_fn {
 			template <class T>
-			constexpr auto operator()(T&& t, std::ptrdiff_t const n) const
+			constexpr auto operator()(T const& t, std::ptrdiff_t const n) const
 			STL2_NOEXCEPT_REQUIRES_RETURN(
 				STL2_EXPECT(n >= 0),
-				__stl2::ext::repeat_n_view<T>{std::forward<T>(t), n}
+				__stl2::ext::repeat_n_view<T>(t, n)
 			)
+
+			template <class T>
+			constexpr auto operator()(remove_reference_t<T>&& t, std::ptrdiff_t const n) const
+			STL2_NOEXCEPT_REQUIRES_RETURN(
+				STL2_EXPECT(n >= 0),
+				__stl2::ext::repeat_n_view<T>(std::move(t), n)
+			)
+
+			template <class T>
+			constexpr auto operator()(remove_reference_t<T> const&&, std::ptrdiff_t) = delete;
 		};
 
 		inline constexpr __repeat_n_fn repeat_n {};

--- a/test/view/repeat_n_view.cpp
+++ b/test/view/repeat_n_view.cpp
@@ -31,9 +31,19 @@ int main() {
 	static_assert(sizeof(v) == 2 * sizeof(std::ptrdiff_t));
 
 	{
-		struct empty {};
+		struct empty { 
+			bool operator==(empty const&) const noexcept { return true; }
+			bool operator!=(empty const&) const noexcept { return false; }
+		};
 		auto v = ranges::ext::repeat_n_view<empty>{{}, (1ULL << 20)};
 		static_assert(sizeof(decltype(v.begin())) == sizeof(std::ptrdiff_t));
+
+		auto e = empty{};
+		auto v2 = ranges::view::ext::repeat_n(e, 3);
+		CHECK_EQUAL(v2, {e, e, e});
+
+		auto v3 = ranges::view::ext::repeat_n(std::move(e), 3);
+		CHECK_EQUAL(v2, v3);
 	}
 	{
 		auto v = ranges::view::ext::repeat_n(9, 10);

--- a/test/view/repeat_view.cpp
+++ b/test/view/repeat_view.cpp
@@ -104,6 +104,19 @@ int main() {
 		static_assert(ranges::RandomAccessIterator<decltype(v.begin())>);
 		CHECK_EQUAL(v, {9, 9, 9, 9, 9, 9, 9, 9, 9, 9});
 	}
+	{
+		struct empty { 
+			bool operator==(empty const&) const noexcept { return true; }
+			bool operator!=(empty const&) const noexcept { return false; }
+		};
+
+		auto e = empty{};
+		auto v2 = ranges::view::ext::repeat(e) | ranges::view::take(3);
+		CHECK_EQUAL(v2, {e, e, e});
+
+		auto v3 = ranges::view::ext::repeat(std::move(e)) | ranges::view::take(3);
+		CHECK_EQUAL(v2, v3);
+	}
 
 	return test_result();
 }


### PR DESCRIPTION
The salient requirement for repeat and repeat_n is that their T is a copy-constructible object, but when an lvalue is passed to either, it was forwarded, and so was treated as an lvalue reference, which breaks that requirement.

This fix separates lvalue references from rvalue references, rather than conflating them using forwarding references.