### PR TITLE
Minor cleanup

### DIFF
--- a/include/stl2/ranges.hpp
+++ b/include/stl2/ranges.hpp
@@ -17,6 +17,7 @@
 
 #include <stl2/detail/range/access.hpp>
 #include <stl2/detail/range/concepts.hpp>
+#include <stl2/detail/range/nth_iterator.hpp>
 #include <stl2/detail/range/primitives.hpp>
 #include <stl2/view/all.hpp>
 #include <stl2/view/common.hpp>

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -11,8 +11,8 @@
 //
 // Project home: https://github.com/caseycarter/cmcstl2
 //
-#ifndef STL2_VIEW_TAKE_HPP
-#define STL2_VIEW_TAKE_HPP
+#ifndef STL2_VIEW_TAKE_WHILE_HPP
+#define STL2_VIEW_TAKE_WHILE_HPP
 
 #include <stl2/detail/fwd.hpp>
 #include <stl2/detail/meta.hpp>
@@ -116,4 +116,4 @@ STL2_OPEN_NAMESPACE {
 	} // namespace view::ext
 } STL2_CLOSE_NAMESPACE
 
-#endif
+#endif // STL2_VIEW_TAKE_WHILE_HPP


### PR DESCRIPTION
* Header guard was still as `STL2_VIEW_TAKE_HPP` for take_while.hpp
* `nth_iterator` missing from `<experimental/ranges/range>`