### PR TITLE
Non-modifying algorithms are not found by ADL.

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -22,35 +22,36 @@
 // adjacent_find [alg.adjacent.find]
 //
 STL2_OPEN_NAMESPACE {
-	template <ForwardIterator I, Sentinel<I> S, class Pred = equal_to<>,
-		class Proj = identity>
-	requires
-		IndirectRelation<Pred, projected<I, Proj>>
-	I adjacent_find(I first, S last, Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		if (first == last) {
-			return first;
-		}
-
-		auto next = first;
-		for (; ++next != last; first = next) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *first), __stl2::invoke(proj, *next))) {
+	struct __adjacent_find_fn {
+		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectRelation<projected<I, Proj>> Pred = equal_to<>>
+		constexpr I operator()(I first, S last, Pred pred = Pred{}, Proj proj = Proj{}) const
+		{
+			if (first == last) {
 				return first;
 			}
-		}
-		return next;
-	}
 
-	template <ForwardRange Rng, class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<Pred, projected<iterator_t<Rng>, Proj>>
-	safe_iterator_t<Rng>
-	adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		return __stl2::adjacent_find(
-			__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+			auto next = first;
+			for (; ++next != last; first = next) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj, *first), __stl2::invoke(proj, *next))) {
+					return first;
+				}
+			}
+			return next;
+		}
+
+		template<ForwardRange R, class Proj = identity,
+			IndirectRelation<projected<iterator_t<R>, Proj>> Pred = equal_to<>>
+		constexpr safe_iterator_t<R>
+		operator()(R&& r, Pred pred = Pred{}, Proj proj = Proj{}) const
+		{
+			return (*this)(
+				__stl2::begin(r), __stl2::end(r),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __adjacent_find_fn adjacent_find {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/all_of.hpp
+++ b/include/stl2/detail/algorithm/all_of.hpp
@@ -24,31 +24,31 @@
 // all_of [alg.all_of]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	bool all_of(I first, S last, Pred pred, Proj proj = Proj{})
-	{
-		if (first != last) {
-			do {
-				if (!__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
-					return false;
-				}
-			} while (++first != last);
+	struct __all_of_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr bool operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			if (first != last) {
+				do {
+					if (!__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
+						return false;
+					}
+				} while (++first != last);
+			}
+			return true;
 		}
-		return true;
-	}
 
-	template <InputRange R, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<R>, Proj>>
-	bool all_of(R&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::all_of(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr bool operator()(R&& rng, Pred pred, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(rng), __stl2::end(rng),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __all_of_fn all_of {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/any_of.hpp
+++ b/include/stl2/detail/algorithm/any_of.hpp
@@ -23,31 +23,31 @@
 // any_of [alg.any_of]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	bool any_of(I first, S last, Pred pred, Proj proj = Proj{})
-	{
-		if (first != last) {
-			do {
-				if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
-					return true;
-				}
-			} while (++first != last);
+	struct __any_of_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr bool operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			if (first != last) {
+				do {
+					if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
+						return true;
+					}
+				} while (++first != last);
+			}
+			return false;
 		}
-		return false;
-	}
 
-	template <InputRange R, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<R>, Proj>>
-	bool any_of(R&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::any_of(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr bool operator()(R&& rng, Pred pred, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(rng), __stl2::end(rng),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __any_of_fn any_of {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -21,32 +21,32 @@
 // count [alg.count]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-	requires
-		IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
-	iter_difference_t<I>
-	count(I first, S last, const T& value, Proj proj = Proj{})
-	{
-		iter_difference_t<I> n = 0;
-		for (; first != last; ++first) {
-			if (__stl2::invoke(proj, *first) == value) {
-				++n;
+	struct __count_fn {
+		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
+		requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>
+		constexpr iter_difference_t<I>
+		operator()(I first, S last, const T& value, Proj proj = Proj{}) const
+		{
+			iter_difference_t<I> n = 0;
+			for (; first != last; ++first) {
+				if (__stl2::invoke(proj, *first) == value) {
+					++n;
+				}
 			}
+			return n;
 		}
-		return n;
-	}
 
-	template <InputRange Rng, class T, class Proj = identity>
-	requires
-		IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
-	iter_difference_t<iterator_t<Rng>>
-	count(Rng&& rng, const T& value, Proj proj = Proj{})
-	{
-		return __stl2::count(__stl2::begin(rng), __stl2::end(rng),
-			value, std::ref(proj));
-	}
+		template<InputRange R, class T, class Proj = identity>
+		requires IndirectRelation<equal_to<>, projected<iterator_t<R>, Proj>, const T*>
+		constexpr iter_difference_t<iterator_t<R>>
+		operator()(R&& r, const T& value, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(r), __stl2::end(r),
+				value, std::ref(proj));
+		}
+	};
+
+	inline constexpr __count_fn count {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -21,30 +21,31 @@
 // count_if [alg.count]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	iter_difference_t<I> count_if(I first, S last, Pred pred, Proj proj = Proj{})
-	{
-		auto n = iter_difference_t<I>{0};
-		for (; first != last; ++first) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
-				++n;
+	struct __count_if_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr iter_difference_t<I> operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			auto n = iter_difference_t<I>{0};
+			for (; first != last; ++first) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
+					++n;
+				}
 			}
+			return n;
 		}
-		return n;
-	}
 
-	template <InputRange Rng, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
-	iter_difference_t<iterator_t<Rng>> count_if(Rng&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::count_if(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr iter_difference_t<iterator_t<R>>
+		operator()(R&& r, Pred pred, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(r), __stl2::end(r),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __count_if_fn count_if {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/equal.hpp
+++ b/include/stl2/detail/algorithm/equal.hpp
@@ -21,120 +21,121 @@
 // equal [alg.equal]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-		class Pred, class Proj1, class Proj2>
-	requires
-		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
-	bool __equal_3(I1 first1, S1 last1, I2 first2, Pred& pred,
-		Proj1& proj1, Proj2& proj2)
-	{
-		for (; first1 != last1; ++first1, ++first2) {
-			if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
-				return false;
+	class __equal_fn {
+		template <InputIterator I1, Sentinel<I1> S1, InputIterator I2,
+			class Pred, class Proj1, class Proj2>
+		requires
+			IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		static constexpr bool __equal_3(I1 first1, S1 last1, I2 first2, Pred& pred,
+			Proj1& proj1, Proj2& proj2)
+		{
+			for (; first1 != last1; ++first1, ++first2) {
+				if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
+					return false;
+				}
 			}
+			return true;
 		}
-		return true;
-	}
 
-	template <InputIterator I1, Sentinel<I1> S1,
-		InputIterator I2, Sentinel<I2> S2,
-		class Pred, class Proj1, class Proj2>
-	requires
-		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
-	bool __equal_4(I1 first1, S1 last1, I2 first2, S2 last2, Pred& pred,
-		Proj1& proj1, Proj2& proj2)
-	{
-		for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
-			if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
-				return false;
+		template <InputIterator I1, Sentinel<I1> S1,
+			InputIterator I2, Sentinel<I2> S2,
+			class Pred, class Proj1, class Proj2>
+		requires
+			IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		static constexpr bool __equal_4(I1 first1, S1 last1, I2 first2, S2 last2, Pred& pred,
+			Proj1& proj1, Proj2& proj2)
+		{
+			for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
+				if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
+					return false;
+				}
 			}
+			return first1 == last1 && first2 == last2;
 		}
-		return first1 == last1 && first2 == last2;
-	}
-
-	template <InputIterator I1, Sentinel<I1> S1, class I2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	[[deprecated]] bool
-	equal(I1 first1, S1 last1, I2&& first2_, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	requires
-		InputIterator<std::decay_t<I2>> && !Range<I2> &&
-		IndirectlyComparable<I1, std::decay_t<I2>, Pred, Proj1, Proj2>
-	{
-		auto first2 = std::forward<I2>(first2_);
-		return __stl2::__equal_3(
-			std::move(first1), std::move(last1),
-			std::move(first2), pred, proj1, proj2);
-	}
-
-	template <InputRange Rng1, class I2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	[[deprecated]] bool equal(Rng1&& rng1, I2&& first2_, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	requires
-		InputIterator<std::decay_t<I2>> && !Range<I2> &&
-		IndirectlyComparable<iterator_t<Rng1>, std::decay_t<I2>, Pred, Proj1, Proj2>
-	{
-		auto first2 = std::forward<I2>(first2_);
-		return __stl2::__equal_3(__stl2::begin(rng1), __stl2::end(rng1),
-			std::move(first2), pred, proj1, proj2);
-	}
-
-	template <InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
-		class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
-	bool equal(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		return __stl2::__equal_4(
-			std::move(first1), std::move(last1),
-			std::move(first2), std::move(last2),
-			pred, proj1, proj2);
-	}
-
-	template <InputIterator I1, SizedSentinel<I1> S1, InputIterator I2, SizedSentinel<I2> S2,
-		class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
-	bool equal(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		auto len1 = __stl2::distance(first1, last1);
-		auto len2 = __stl2::distance(first2, std::move(last2));
-		return len1 == len2 &&
-			__stl2::__equal_3(std::move(first1), std::move(last1),
+	public:
+		template <InputIterator I1, Sentinel<I1> S1, class I2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		[[deprecated]] constexpr bool
+		operator()(I1 first1, S1 last1, I2&& first2_, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		requires
+			InputIterator<std::decay_t<I2>> && !Range<I2> &&
+			IndirectlyComparable<I1, std::decay_t<I2>, Pred, Proj1, Proj2>
+		{
+			auto first2 = std::forward<I2>(first2_);
+			return __equal_fn::__equal_3(
+				std::move(first1), std::move(last1),
 				std::move(first2), pred, proj1, proj2);
-	}
+		}
 
-	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectlyComparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>
-	bool equal(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		return __stl2::__equal_4(
-			__stl2::begin(rng1), __stl2::end(rng1),
-			__stl2::begin(rng2), __stl2::end(rng2),
-			pred, proj1, proj2);
-	}
+		template <InputRange Rng1, class I2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		[[deprecated]] constexpr bool operator()(Rng1&& rng1, I2&& first2_, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		requires
+			InputIterator<std::decay_t<I2>> && !Range<I2> &&
+			IndirectlyComparable<iterator_t<Rng1>, std::decay_t<I2>, Pred, Proj1, Proj2>
+		{
+			auto first2 = std::forward<I2>(first2_);
+			return __equal_fn::__equal_3(__stl2::begin(rng1), __stl2::end(rng1),
+				std::move(first2), pred, proj1, proj2);
+		}
 
-	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		SizedRange<Rng1> && SizedRange<Rng2> &&
-		IndirectlyComparable<
-			iterator_t<Rng1>, iterator_t<Rng2>,
-			Pred, Proj1, Proj2>
-	bool equal(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		return __stl2::distance(rng1) == __stl2::distance(rng2) &&
-			__stl2::__equal_3(
-				__stl2::begin(rng1), __stl2::end(rng1),
-				__stl2::begin(rng2), pred, proj1, proj2);
-	}
+		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return __equal_fn::__equal_4(
+				std::move(first1), std::move(last1),
+				std::move(first2), std::move(last2),
+				pred, proj1, proj2);
+		}
+
+		template <InputIterator I1, SizedSentinel<I1> S1, InputIterator I2, SizedSentinel<I2> S2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			auto len1 = __stl2::distance(first1, last1);
+			auto len2 = __stl2::distance(first2, std::move(last2));
+			return len1 == len2 &&
+				__equal_fn::__equal_3(std::move(first1), std::move(last1),
+					std::move(first2), pred, proj1, proj2);
+		}
+
+		template <InputRange R1, InputRange R2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+		constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return __equal_fn::__equal_4(
+				__stl2::begin(r1), __stl2::end(r1),
+				__stl2::begin(r2), __stl2::end(r2),
+				pred, proj1, proj2);
+		}
+
+		template <InputRange R1, InputRange R2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		requires
+			SizedRange<R1> && SizedRange<R2> &&
+			IndirectlyComparable<
+				iterator_t<R1>, iterator_t<R2>,
+				Pred, Proj1, Proj2>
+		constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return __stl2::distance(r1) == __stl2::distance(r2) &&
+				__equal_fn::__equal_3(
+					__stl2::begin(r1), __stl2::end(r1),
+					__stl2::begin(r2), pred, proj1, proj2);
+		}
+	};
+
+	inline constexpr __equal_fn equal {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -21,27 +21,28 @@
 // find [alg.find]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-	requires
-		IndirectRelation<
-			equal_to<>, projected<I, Proj>, const T*>
-	I find(I first, S last, const T& value, Proj proj = Proj{})
-	{
-		for (; first != last; ++first) {
-			if (__stl2::invoke(proj, *first) == value) {
-				break;
+	struct __find_fn {
+		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
+		requires IndirectRelation<equal_to<>, projected<I, Proj>, const T*>
+		constexpr I operator()(I first, S last, const T& value, Proj proj = Proj{}) const
+		{
+			for (; first != last; ++first) {
+				if (__stl2::invoke(proj, *first) == value) {
+					break;
+				}
 			}
+			return first;
 		}
-		return first;
-	}
 
-	template <InputRange Rng, class T, class Proj = identity>
-	requires
-		IndirectRelation<
-			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
-	safe_iterator_t<Rng> find(Rng&& rng, const T& value, Proj proj = Proj{}) {
-		return __stl2::find(__stl2::begin(rng), __stl2::end(rng), value, std::ref(proj));
-	}
+		template<InputRange R, class T, class Proj = identity>
+		requires IndirectRelation<equal_to<>, projected<iterator_t<R>, Proj>, const T*>
+		constexpr safe_iterator_t<R>
+		operator()(R&& r, const T& value, Proj proj = Proj{}) const {
+			return (*this)(__stl2::begin(r), __stl2::end(r), value, std::ref(proj));
+		}
+	};
+
+	inline constexpr __find_fn find {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -18,139 +18,133 @@
 #include <stl2/iterator.hpp>
 #include <stl2/detail/fwd.hpp>
 #include <stl2/detail/meta.hpp>
+#include <stl2/detail/concepts/algorithm.hpp>
 #include <stl2/detail/concepts/callable.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
 // find_end [alg.find.end]
 //
 STL2_OPEN_NAMESPACE {
-	template <ForwardIterator I1, Sentinel<I1> S1,
-		ForwardIterator I2, Sentinel<I2> S2,
-		class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
-	I1 find_end(I1 first1, const S1 last1,
-		const I2 first2, const S2 last2,
-		Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		if (first2 == last2) {
-			return __stl2::next(first1, last1);
-		}
-
-		std::optional<I1> res;
-		for (; first1 != last1; ++first1) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *first1), *first2)) {
-				auto m1 = first1;
-				auto m2 = first2;
-				do {
-					if (++m2 == last2) {
-						res = first1;
-						break;
-					}
-					if (++m1 == last1) {
-						return std::move(res).value_or(std::move(m1));
-					}
-				} while (__stl2::invoke(pred, __stl2::invoke(proj, *m1), *m2));
+	struct __find_end_fn {
+		template<ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr I1 operator()(I1 first1, const S1 last1,
+			const I2 first2, const S2 last2,
+			Pred pred = Pred{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			if (first2 == last2) {
+				return __stl2::next(first1, last1);
 			}
-		}
-		return std::move(res).value_or(std::move(first1));
-	}
 
-	template <BidirectionalIterator I1, BidirectionalIterator I2,
-		class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
-	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
-		Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		if (first2 == last2) {
-			return last1;  // Everything matches an empty sequence
-		}
-
-		--last2;
-		auto l1 = last1;
-		while (l1 != first1) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *--l1), *last2)) {
-				auto m1 = l1;
-				auto m2 = last2;
-				do {
-					if (m2 == first2) {
-						return m1;
-					}
-					if (m1 == first1) {
-						return last1;
-					}
-				} while (__stl2::invoke(pred, __stl2::invoke(proj, *--m1), *--m2));
+			std::optional<I1> res;
+			for (; first1 != last1; ++first1) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
+					auto m1 = first1;
+					auto m2 = first2;
+					do {
+						if (++m2 == last2) {
+							res = first1;
+							break;
+						}
+						if (++m1 == last1) {
+							return std::move(res).value_or(std::move(m1));
+						}
+					} while (__stl2::invoke(pred, __stl2::invoke(proj1, *m1), __stl2::invoke(proj2, *m2)));
+				}
 			}
+			return std::move(res).value_or(std::move(first1));
 		}
 
-		return last1;
-	}
+		template<BidirectionalIterator I1, BidirectionalIterator I2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr I1 operator()(I1 first1, I1 last1, I2 first2, I2 last2,
+			Pred pred = Pred{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			if (first2 == last2) {
+				return last1;  // Everything matches an empty sequence
+			}
 
-	template <RandomAccessIterator I1, RandomAccessIterator I2,
-		class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
-	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
-		Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		// Take advantage of knowing source and pattern lengths.
-		// Stop short when source is smaller than pattern
-		const auto len2 = last2 - first2;
-		if (len2 == 0 || last1 - first1 < len2) {
+			--last2;
+			auto l1 = last1;
+			while (l1 != first1) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj1, *--l1), __stl2::invoke(proj2, *last2))) {
+					auto m1 = l1;
+					auto m2 = last2;
+					do {
+						if (m2 == first2) {
+							return m1;
+						}
+						if (m1 == first1) {
+							return last1;
+						}
+					} while (__stl2::invoke(pred, __stl2::invoke(proj1, *--m1), __stl2::invoke(proj2, *--m2)));
+				}
+			}
+
 			return last1;
 		}
 
-		// End of pattern match can't go before here
-		const auto s = first1 + (len2 - 1);
+		template<RandomAccessIterator I1, RandomAccessIterator I2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr I1 operator()(I1 first1, I1 last1, I2 first2, I2 last2,
+			Pred pred = Pred{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			// Take advantage of knowing source and pattern lengths.
+			// Stop short when source is smaller than pattern
+			const auto len2 = last2 - first2;
+			if (len2 == 0 || last1 - first1 < len2) {
+				return last1;
+			}
 
-		for (auto l1 = last1; l1 != s; --l1) {
-			auto m1 = l1;
-			auto m2 = last2;
-			while (__stl2::invoke(pred, __stl2::invoke(proj, *--m1), *--m2)) {
-				if (m2 == first2) {
-					return m1;
+			// End of pattern match can't go before here
+			const auto s = first1 + (len2 - 1);
+
+			for (auto l1 = last1; l1 != s; --l1) {
+				auto m1 = l1;
+				auto m2 = last2;
+				while (__stl2::invoke(pred, __stl2::invoke(proj1, *--m1), __stl2::invoke(proj2, *--m2))) {
+					if (m2 == first2) {
+						return m1;
+					}
 				}
 			}
+			return last1;
 		}
-		return last1;
-	}
 
-	template <BidirectionalIterator I1, Sentinel<I1> S1,
-		BidirectionalIterator I2, Sentinel<I2> S2,
-		class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<
-			Pred, I2, projected<I1, Proj>>
-	I1 find_end(I1 first1, S1 s1, I2 first2, S2 s2, Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		auto last1 = __stl2::next(first1, std::move(s1));
-		auto last2 = __stl2::next(first2, std::move(s2));
-		return __stl2::find_end(
-			std::move(first1), std::move(last1),
-			std::move(first2), std::move(last2),
-			std::ref(pred), std::ref(proj));
-	}
+		template<BidirectionalIterator I1, Sentinel<I1> S1, BidirectionalIterator I2, Sentinel<I2> S2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		constexpr I1 operator()(I1 first1, S1 s1, I2 first2, S2 s2,
+			Pred pred = Pred{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			auto last1 = __stl2::next(first1, std::move(s1));
+			auto last2 = __stl2::next(first2, std::move(s2));
+			return (*this)(
+				std::move(first1), std::move(last1),
+				std::move(first2), std::move(last2),
+				std::ref(pred), std::ref(proj1), std::ref(proj2));
+		}
 
-	template <ForwardRange Rng1, ForwardRange Rng2,
-		class Pred = equal_to<>, class Proj = identity>
-	requires
-		IndirectRelation<
-			Pred, iterator_t<Rng2>, projected<iterator_t<Rng1>, Proj>>
-	safe_iterator_t<Rng1>
-	find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{})
-	{
-		return __stl2::find_end(
-			__stl2::begin(rng1), __stl2::end(rng1),
-			__stl2::begin(rng2), __stl2::end(rng2),
-			std::ref(pred), std::ref(proj));
-	}
+		template <ForwardRange R1, ForwardRange R2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+		constexpr safe_iterator_t<R1>
+		operator()(R1&& r1, R2&& r2, Pred pred = Pred{}, Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return (*this)(
+				__stl2::begin(r1), __stl2::end(r1),
+				__stl2::begin(r2), __stl2::end(r2),
+				std::ref(pred), std::ref(proj1), std::ref(proj2));
+		}
 
-	// Holding off on initializer_list overloads for now; this
-	// overload set is already very fragile.
+		// Holding off on initializer_list overloads for now; this
+		// overload set is already very fragile.
+	};
+
+	inline constexpr __find_end_fn find_end {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -21,44 +21,43 @@
 // find_first_of [alg.find.first.of]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I1, Sentinel<I1> S1,
-		ForwardIterator I2, Sentinel<I2> S2,
-		class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectRelation<Pred,
-			projected<I1, Proj1>,
-			projected<I2, Proj2>>
-	I1 find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
-		Pred pred = Pred{}, Proj1 proj1 = Proj1{},
-		Proj2 proj2 = Proj2{})
-	{
-		for (; first1 != last1; ++first1) {
-			for (auto pos = first2; pos != last2; ++pos) {
-				if (__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *pos))) {
-					return first1;
+	struct __find_first_of_fn {
+		template<InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
+			class Proj1 = identity, class Proj2 = identity,
+			IndirectRelation<projected<I1, Proj1>,	projected<I2, Proj2>> Pred = equal_to<>>
+		constexpr I1 operator()(I1 first1, S1 last1, I2 first2, S2 last2,
+			Pred pred = Pred{}, Proj1 proj1 = Proj1{},
+			Proj2 proj2 = Proj2{}) const
+		{
+			for (; first1 != last1; ++first1) {
+				for (auto pos = first2; pos != last2; ++pos) {
+					if (__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *pos))) {
+						return first1;
+					}
 				}
 			}
+			return first1;
 		}
-		return first1;
-	}
 
-	template <InputRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
-	safe_iterator_t<Rng1>
-	find_first_of(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		return __stl2::find_first_of(
-			__stl2::begin(rng1), __stl2::end(rng1),
-			__stl2::begin(rng2), __stl2::end(rng2),
-			std::ref(pred), std::ref(proj1),
-			std::ref(proj2));
-	}
+		template<InputRange R1, ForwardRange R2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		requires
+			IndirectRelation<Pred,
+				projected<iterator_t<R1>, Proj1>,
+				projected<iterator_t<R2>, Proj2>>
+		constexpr safe_iterator_t<R1>
+		operator()(R1&& r1, R2&& r2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return (*this)(
+				__stl2::begin(r1), __stl2::end(r1),
+				__stl2::begin(r2), __stl2::end(r2),
+				std::ref(pred), std::ref(proj1),
+				std::ref(proj2));
+		}
+	};
+
+	inline constexpr __find_first_of_fn find_first_of {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_if.hpp
+++ b/include/stl2/detail/algorithm/find_if.hpp
@@ -21,30 +21,29 @@
 // find_if [alg.find]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	I find_if(I first, S last, Pred pred, Proj proj = Proj{})
-	{
-		for (; first != last; ++first) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
-				break;
+	struct __find_if_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr I operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			for (; first != last; ++first) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
+					break;
+				}
 			}
+			return first;
 		}
-		return first;
-	}
 
-	template <InputRange Rng, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
-	safe_iterator_t<Rng>
-	find_if(Rng&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::find_if(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr safe_iterator_t<R> operator()(R&& r, Pred pred, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(r), __stl2::end(r),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __find_if_fn find_if {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_if_not.hpp
+++ b/include/stl2/detail/algorithm/find_if_not.hpp
@@ -22,28 +22,25 @@
 // find_if_not [alg.find]
 //
 STL2_OPEN_NAMESPACE {
-	template <class I, class S, class Pred, class Proj = identity>
-	requires
-		InputIterator<__f<I>> &&
-		Sentinel<__f<S>, __f<I>> &&
-		IndirectUnaryPredicate<
-			Pred, projected<__f<I>, Proj>>
-	__f<I> find_if_not(I&& first, S&& last, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::find_if(std::forward<I>(first), std::forward<S>(last),
-			__stl2::not_fn(std::ref(pred)), std::ref(proj));
-	}
+	struct __find_if_not_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr I operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			return __stl2::find_if(std::forward<I>(first), std::forward<S>(last),
+				__stl2::not_fn(std::ref(pred)), std::ref(proj));
+		}
 
-	template <InputRange Rng, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
-	safe_iterator_t<Rng>
-	find_if_not(Rng&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::find_if(__stl2::begin(rng), __stl2::end(rng),
-			__stl2::not_fn(std::ref(pred)), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr safe_iterator_t<R> operator()(R&& r, Pred pred, Proj proj = Proj{}) const
+		{
+			return __stl2::find_if(__stl2::begin(r), __stl2::end(r),
+				__stl2::not_fn(std::ref(pred)), std::ref(proj));
+		}
+	};
+
+	inline constexpr __find_if_not_fn find_if_not {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/for_each.hpp
+++ b/include/stl2/detail/algorithm/for_each.hpp
@@ -22,27 +22,29 @@
 // for_each [alg.for_each]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class F, class Proj = identity>
-	requires
-		IndirectUnaryInvocable<F, projected<I, Proj>>
-	tagged_pair<tag::in(I), tag::fun(F)>
-	for_each(I first, S last, F fun, Proj proj = Proj{})
-	{
-		for (; first != last; ++first) {
-			static_cast<void>(__stl2::invoke(fun, __stl2::invoke(proj, *first)));
+	struct __for_each_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryInvocable<projected<I, Proj>> F>
+		constexpr tagged_pair<tag::in(I), tag::fun(F)>
+		operator()(I first, S last, F fun, Proj proj = Proj{}) const
+		{
+			for (; first != last; ++first) {
+				static_cast<void>(__stl2::invoke(fun, __stl2::invoke(proj, *first)));
+			}
+			return {std::move(first), std::move(fun)};
 		}
-		return {std::move(first), std::move(fun)};
-	}
 
-	template <InputRange Rng, class F, class Proj = identity>
-	requires
-		IndirectUnaryInvocable<F, projected<iterator_t<Rng>, Proj>>
-	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::fun(F)>
-	for_each(Rng&& rng, F fun, Proj proj = Proj{})
-	{
-		return {__stl2::for_each(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(fun), std::ref(proj)).in(), std::move(fun)};
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryInvocable<projected<iterator_t<R>, Proj>> F>
+		constexpr tagged_pair<tag::in(safe_iterator_t<R>), tag::fun(F)>
+		operator()(R&& r, F fun, Proj proj = Proj{}) const
+		{
+			return {(*this)(__stl2::begin(r), __stl2::end(r),
+				std::ref(fun), std::ref(proj)).in(), std::move(fun)};
+		}
+	};
+
+	inline constexpr __for_each_fn for_each {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -22,80 +22,79 @@
 // mismatch [mismatch]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I1, Sentinel<I1> S1, class I2,
-		class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
-	[[deprecated]] tagged_pair<tag::in1(I1), tag::in2(std::decay_t<I2>)>
-	mismatch(I1 first1, S1 last1, I2&& first2_, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	requires
-		IndirectRelation<Pred,
-			projected<I1, Proj1>,
-			projected<std::decay_t<I2>, Proj2>>
-	{
-		auto first2 = std::forward<I2>(first2_);
-		for (; first1 != last1; ++first1, ++first2) {
-			if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
-				break;
+	struct __mismatch_fn {
+		template <InputIterator I1, Sentinel<I1> S1, class I2,
+			class Pred = equal_to<>, class Proj1 = identity, class Proj2 = identity>
+		[[deprecated]] constexpr tagged_pair<tag::in1(I1), tag::in2(std::decay_t<I2>)>
+		operator()(I1 first1, S1 last1, I2&& first2_, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		requires
+			IndirectRelation<Pred,
+				projected<I1, Proj1>,
+				projected<std::decay_t<I2>, Proj2>>
+		{
+			auto first2 = std::forward<I2>(first2_);
+			for (; first1 != last1; ++first1, ++first2) {
+				if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
+					break;
+				}
 			}
+			return {std::move(first1), std::move(first2)};
 		}
-		return {std::move(first1), std::move(first2)};
-	}
 
-	template <InputIterator I1, Sentinel<I1> S1,
-		InputIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectRelation<
-			Pred, projected<I1, Proj1>, projected<I2, Proj2>>
-	tagged_pair<tag::in1(I1), tag::in2(I2)>
-	mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
-			if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
-				break;
+		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
+			class Proj1 = identity, class Proj2 = identity,
+			IndirectRelation<projected<I1, Proj1>, projected<I2, Proj2>> Pred = equal_to<>>
+		constexpr tagged_pair<tag::in1(I1), tag::in2(I2)>
+		operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
+				if (!__stl2::invoke(pred, __stl2::invoke(proj1, *first1), __stl2::invoke(proj2, *first2))) {
+					break;
+				}
 			}
+			return {std::move(first1), std::move(first2)};
 		}
-		return {std::move(first1), std::move(first2)};
-	}
 
-	template <InputRange Rng1, class I2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	[[deprecated]]
-	tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(__f<I2>)>
-	mismatch(Rng1&& rng1, I2&& first2_, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	requires
-		InputIterator<std::decay_t<I2>> &&
-		!Range<I2> &&
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<std::decay_t<I2>, Proj2>>
-	{
-		auto first2 = std::forward<I2>(first2_);
-		return __stl2::mismatch(
-			__stl2::begin(rng1), __stl2::end(rng1),
-			std::move(first2), std::ref(pred),
-			std::ref(proj1), std::ref(proj2));
-	}
+		template <InputRange Rng1, class I2, class Pred = equal_to<>,
+			class Proj1 = identity, class Proj2 = identity>
+		[[deprecated]]
+		constexpr tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(__f<I2>)>
+		operator()(Rng1&& rng1, I2&& first2_, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		requires
+			InputIterator<std::decay_t<I2>> &&
+			!Range<I2> &&
+			IndirectRelation<Pred,
+				projected<iterator_t<Rng1>, Proj1>,
+				projected<std::decay_t<I2>, Proj2>>
+		{
+			auto first2 = std::forward<I2>(first2_);
+			return (*this)(
+				__stl2::begin(rng1), __stl2::end(rng1),
+				std::move(first2), std::ref(pred),
+				std::ref(proj1), std::ref(proj2));
+		}
 
-	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
-	tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>)>
-	mismatch(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
-		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
-	{
-		return __stl2::mismatch(
-			__stl2::begin(rng1), __stl2::end(rng1),
-			__stl2::begin(rng2), __stl2::end(rng2),
-			std::ref(pred),
-			std::ref(proj1),
-			std::ref(proj2));
-	}
+		template<InputRange R1, InputRange R2,
+			class Proj1 = identity, class Proj2 = identity,
+			IndirectRelation<projected<iterator_t<R1>, Proj1>,
+				projected<iterator_t<R2>, Proj2>> Pred = equal_to<>>
+		constexpr tagged_pair<tag::in1(safe_iterator_t<R1>), tag::in2(safe_iterator_t<R2>)>
+		operator()(R1&& r1, R2&& r2, Pred pred = Pred{},
+			Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
+		{
+			return (*this)(
+				__stl2::begin(r1), __stl2::end(r1),
+				__stl2::begin(r2), __stl2::end(r2),
+				std::ref(pred),
+				std::ref(proj1),
+				std::ref(proj2));
+		}
+	};
+
+	inline constexpr __mismatch_fn mismatch {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/none_of.hpp
+++ b/include/stl2/detail/algorithm/none_of.hpp
@@ -21,29 +21,29 @@
 // none_of [alg.none_of]
 //
 STL2_OPEN_NAMESPACE {
-	template <InputIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	bool none_of(I first, S last, Pred pred, Proj proj = Proj{})
-	{
-		for (; first != last; ++first) {
-			if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
-				return false;
+	struct __none_of_fn {
+		template<InputIterator I, Sentinel<I> S, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		constexpr bool operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
+		{
+			for (; first != last; ++first) {
+				if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
+					return false;
+				}
 			}
+			return true;
 		}
-		return true;
-	}
 
-	template <InputRange Rng, class Pred, class Proj = identity>
-	requires
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>>
-	bool none_of(Rng&& rng, Pred pred, Proj proj = Proj{})
-	{
-		return __stl2::none_of(__stl2::begin(rng), __stl2::end(rng),
-			std::ref(pred), std::ref(proj));
-	}
+		template<InputRange R, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		constexpr bool operator()(R&& r, Pred pred, Proj proj = Proj{}) const
+		{
+			return (*this)(__stl2::begin(r), __stl2::end(r),
+				std::ref(pred), std::ref(proj));
+		}
+	};
+
+	inline constexpr __none_of_fn none_of {};
 } STL2_CLOSE_NAMESPACE
 
 #endif


### PR DESCRIPTION
Changes to the non-modifying algorithms include turning them into callable objects so that they cannot be found by ADL.

This is a small, self-contained part of #190, that while still large, is more straightforward and digestible. Note: I think most of this diff is concerned with whitespace, it might be better to view locally.