### PR TITLE
Change ebo_box<T>::item_ to be default-initialised

### DIFF
--- a/include/stl2/detail/ebo_box.hpp
+++ b/include/stl2/detail/ebo_box.hpp
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr const T&& get() const&& noexcept { return std::move(item_); }
 
 		private:
-			T item_;
+			T item_{};
 		};
 
 		template <ext::DestructibleObject T, class Tag>


### PR DESCRIPTION
When ebo_box<T> holds a fundamental type, item_'s
value-initialisation prevents default-initialised
objects (presumably inheriting from ebo_box) from
being used in a constexpr context.

This commit default-initialises item_ so that it
is more likely to be usable in constexpr contexts.