### PR TITLE
Kill ADL for next, prev, and distance

### DIFF
--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 			Incrementable<I> &&
 			requires(I& i) {
 				{ --i } -> Same<I>&;
-				i--; Same<decltype(i--), I>;
+				i--; requires Same<I, decltype(i--)>;
 			};
 			// Let a and b be objects of type I.
 			// Axiom: &--a == &a

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -71,10 +71,11 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	concept bool WeaklyIncrementable =
 		Semiregular<I> &&
-		requires(I& i) {
+		requires(I i) {
 			typename iter_difference_t<I>;
-			{ ++i } -> Same<I&>&&;
-			i++;
+			requires SignedIntegral<iter_difference_t<I>>;
+			{ ++i } -> Same<I>&; // not required to be equality-preserving
+			i++; // not required to be equality-preserving
 		};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -82,10 +83,10 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I>
 	concept bool Incrementable =
+		Regular<I> &&
 		WeaklyIncrementable<I> &&
-		EqualityComparable<I> &&
-		requires(I& i) {
-			{ i++ } -> Same<I>&&;
+		requires(I i) {
+			i++; requires Same<decltype(i++), I>;
 		};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -96,8 +97,8 @@ STL2_OPEN_NAMESPACE {
 		concept bool Decrementable =
 			Incrementable<I> &&
 			requires(I& i) {
-				{ --i } -> Same<I&>&&;
-				{ i-- } -> Same<I>&&;
+				{ --i } -> Same<I>&;
+				i--; Same<decltype(i--), I>;
 			};
 			// Let a and b be objects of type I.
 			// Axiom: &--a == &a

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 		template<class I>
 		concept bool Decrementable =
 			Incrementable<I> &&
-			requires(I& i) {
+			requires(I i) {
 				{ --i } -> Same<I>&;
 				i--; requires Same<I, decltype(i--)>;
 			};

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -191,112 +191,49 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	// next
-	Iterator{I}
-	constexpr I next(I x, iter_difference_t<I> n = 1)
-	STL2_NOEXCEPT_RETURN(
-		__stl2::advance(x, n),
-		x
-	)
+	struct __next_fn {
+		template<Iterator I>
+		constexpr I operator()(I x, iter_difference_t<I> n = 1) const
+		STL2_NOEXCEPT_RETURN(
+			__stl2::advance(x, n),
+			x
+		)
 
-	template<class S, class I>
-	requires
-		Sentinel<__f<S>, I>
-	constexpr I next(I x, S&& bound)
-	STL2_NOEXCEPT_RETURN(
-		__stl2::advance(x, std::forward<S>(bound)),
-		x
-	)
+		template<Iterator I, Sentinel<I> S>
+		constexpr I operator()(I x, S bound) const
+		STL2_NOEXCEPT_RETURN(
+			__stl2::advance(x, std::forward<S>(bound)),
+			x
+		)
 
-	template<class S, class I>
-	requires
-		Sentinel<__f<S>, I>
-	constexpr I next(I x, iter_difference_t<I> n, S&& bound)
-	STL2_NOEXCEPT_RETURN(
-		__stl2::advance(x, n, std::forward<S>(bound)),
-		x
-	)
+		template<Iterator I, Sentinel<I> S>
+		constexpr I operator()(I x, iter_difference_t<I> n, S bound) const
+		STL2_NOEXCEPT_RETURN(
+			__stl2::advance(x, n, std::forward<S>(bound)),
+			x
+		)
+	};
+
+	inline constexpr __next_fn next {};
 
 	// prev
-	BidirectionalIterator{I}
-	constexpr I prev(I x, iter_difference_t<I> n = 1)
-	STL2_NOEXCEPT_RETURN(
-		__stl2::advance(x, -n),
-		x
-	)
+	struct __prev_fn {
+		template<BidirectionalIterator I>
+		constexpr I operator()(I x, iter_difference_t<I> n = 1) const
+		STL2_NOEXCEPT_RETURN(
+			__stl2::advance(x, -n),
+			x
+		)
 
-	BidirectionalIterator{I}
-	constexpr I prev(I x, iter_difference_t<I> n, I bound)
-	STL2_NOEXCEPT_RETURN(
-		__stl2::advance(x, -n, std::move(bound)),
-		x
-	)
+		template<BidirectionalIterator I>
+		constexpr I operator()(I x, iter_difference_t<I> n, I bound) const
+		STL2_NOEXCEPT_RETURN(
+			__stl2::advance(x, -n, std::move(bound)),
+			x
+		)
+	};
 
-	namespace ext {
-		Sentinel{S, I}
-		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
-		enumerate(I first, S last)
-		noexcept(noexcept(++first != last) &&
-			std::is_nothrow_move_constructible<I>::value)
-		{
-			iter_difference_t<I> n = 0;
-			while (first != last) {
-				++n;
-				++first;
-			}
-			return {n, std::move(first)};
-		}
-
-		SizedSentinel{S, I}
-		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
-		enumerate(I first, S last)
-		noexcept(noexcept(__stl2::next(std::move(first), std::move(last))) &&
-			std::is_nothrow_move_constructible<I>::value)
-		{
-			auto d = last - first;
-			STL2_EXPECT((Same<I, S> || d >= 0));
-			return {d, __stl2::next(std::move(first), std::move(last))};
-		}
-
-		template<class S, class I>
-		requires
-			Sentinel<S, I> && !SizedSentinel<S, I> && SizedSentinel<I, I>
-		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
-		enumerate(I first, S last)
-		noexcept(noexcept(__stl2::next(first, std::move(last))) &&
-			std::is_nothrow_move_constructible<I>::value)
-		{
-			auto end = __stl2::next(first, std::move(last));
-			auto n = end - first;
-			return {n, std::move(end)};
-		}
-	}
-
-	// distance
-	Sentinel{S, I}
-		// Pre: [first, last)
-	constexpr iter_difference_t<I> distance(I first, S last)
-	STL2_NOEXCEPT_RETURN(
-		ext::enumerate(std::move(first), std::move(last)).first
-	)
-
-	SizedSentinel{S, I}
-		// Pre: [first, last)
-	constexpr iter_difference_t<I> distance(I first, S last)
-	noexcept(noexcept(last - first))
-	{
-		auto d = last - first;
-		STL2_EXPECT(d >= 0);
-		return d;
-	}
-
-	template<class I>
-	requires
-		SizedSentinel<I, I>
-		// Pre: [first, last) || [last, first)
-	constexpr iter_difference_t<I> distance(I first, I last)
-	STL2_NOEXCEPT_RETURN(
-		last - first
-	)
+	inline constexpr __prev_fn prev {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/range/primitives.hpp
+++ b/include/stl2/detail/range/primitives.hpp
@@ -25,13 +25,50 @@
 STL2_OPEN_NAMESPACE {
 	// enumerate
 	namespace ext {
-		Range{R}
+		template<Iterator I, Sentinel<I> S>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
+		enumerate(I first, S last)
+		noexcept(noexcept(++first != last) &&
+			std::is_nothrow_move_constructible<I>::value)
+		{
+			iter_difference_t<I> n = 0;
+			while (first != last) {
+				++n;
+				++first;
+			}
+			return {n, std::move(first)};
+		}
+
+		template<Iterator I, SizedSentinel<I> S>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
+		enumerate(I first, S last)
+		noexcept(noexcept(__stl2::next(std::move(first), std::move(last))) &&
+			std::is_nothrow_move_constructible<I>::value)
+		{
+			auto d = last - first;
+			STL2_EXPECT((Same<I, S> || d >= 0));
+			return {d, __stl2::next(std::move(first), std::move(last))};
+		}
+
+		template<Iterator I, Sentinel<I> S>
+		requires (!SizedSentinel<S, I>) && SizedSentinel<I, I>
+		constexpr tagged_pair<tag::count(iter_difference_t<I>), tag::end(I)>
+		enumerate(I first, S last)
+		noexcept(noexcept(__stl2::next(first, std::move(last))) &&
+			std::is_nothrow_move_constructible<I>::value)
+		{
+			auto end = __stl2::next(first, std::move(last));
+			auto n = end - first;
+			return {n, std::move(end)};
+		}
+
+		template<Range R>
 		constexpr auto enumerate(R&& r)
 		STL2_NOEXCEPT_RETURN(
 			__stl2::ext::enumerate(__stl2::begin(r), __stl2::end(r))
 		)
 
-		SizedRange{R}
+		template<SizedRange R>
 		constexpr auto enumerate(R&& r)
 		STL2_NOEXCEPT_RETURN(
 			tagged_pair<tag::count(iter_difference_t<iterator_t<R>>),
@@ -42,25 +79,54 @@ STL2_OPEN_NAMESPACE {
 		)
 	}
 
-	Range{R}
-	constexpr iter_difference_t<iterator_t<R>> distance(R&& r)
-	noexcept(noexcept(__stl2::distance(__stl2::begin(r), __stl2::end(r))))
-	{
-		const iter_difference_t<iterator_t<R>> n =
-			__stl2::distance(__stl2::begin(r), __stl2::end(r));
-		STL2_EXPECT(n >= 0);
-		return n;
-	}
+	struct __distance_fn {
+		template<Iterator I, Sentinel<I> S>
+		constexpr iter_difference_t<I> operator()(I first, S last) const
+		// [[expects axiom: reachable(first, last)]]
+		STL2_NOEXCEPT_RETURN(
+			ext::enumerate(std::move(first), std::move(last)).first
+		)
 
-	SizedRange{R}
-	constexpr iter_difference_t<iterator_t<R>> distance(R&& r)
-	noexcept(noexcept(__stl2::size(r)))
-	{
-		const auto n =
-			static_cast<iter_difference_t<iterator_t<R>>>(__stl2::size(r));
-		STL2_EXPECT(n >= 0);
-		return n;
-	}
+		template<Iterator I, SizedSentinel<I> S>
+		constexpr iter_difference_t<I> operator()(I first, S last) const
+		noexcept(noexcept(last - first))
+		// [[expects axiom: reachable(first, last)]]
+		{
+			auto d = last - first;
+			STL2_EXPECT(d >= 0);
+			return d;
+		}
+
+		template<Iterator I>
+		requires SizedSentinel<I, I>
+		constexpr iter_difference_t<I> operator()(I first, I last) const
+		// [[expects axiom: reachable(first, last)]]
+		STL2_NOEXCEPT_RETURN(
+			last - first
+		)
+
+		template<Range R>
+		constexpr iter_difference_t<iterator_t<R>> operator()(R&& r) const
+		noexcept(noexcept(std::declval<__distance_fn const&>()(__stl2::begin(r), __stl2::end(r))))
+		{
+			const iter_difference_t<iterator_t<R>> n =
+				(*this)(__stl2::begin(r), __stl2::end(r));
+			STL2_EXPECT(n >= 0);
+			return n;
+		}
+
+		template<SizedRange R>
+		constexpr iter_difference_t<iterator_t<R>> operator()(R&& r) const
+		noexcept(noexcept(__stl2::size(r)))
+		{
+			const auto n =
+				static_cast<iter_difference_t<iterator_t<R>>>(__stl2::size(r));
+			STL2_EXPECT(n >= 0);
+			return n;
+		}
+	};
+
+	inline constexpr __distance_fn distance {};
 } STL2_CLOSE_NAMESPACE
 
 #endif


### PR DESCRIPTION
Same deal as before + a few changes to `Incrementable` so it matches P0896.

I can't do `advance` yet, as `counted_iterator` provides overloads of `advance`. My goal (after San Diego) is to turn `counted_iterator` into `__counting_cursor` and then make a `basic_iterator` out of it.

Getting `distance` to be a function object now would be nice for getting `zip_with` to work.