### PR TITLE
Changes to help sync cmcstl2 up with P0896R4

### DIFF
--- a/include/stl2/detail/algorithm/copy.hpp
+++ b/include/stl2/detail/algorithm/copy.hpp
@@ -20,52 +20,56 @@
 // copy [alg.copy]
 //
 STL2_OPEN_NAMESPACE {
-	template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
-	requires
-		IndirectlyCopyable<I, O>
-	tagged_pair<tag::in(I), tag::out(O)>
-	copy(I first, S last, O result)
-	{
-		for (; first != last; ++first, ++result) {
-			*result = *first;
-		}
-		return {std::move(first), std::move(result)};
-	}
+	template<class I, class O>
+	using copy_result = __in_out_result<I, O>;
 
-	template<InputRange Rng, class O>
-	requires
-		WeaklyIncrementable<__f<O>> &&
-		IndirectlyCopyable<iterator_t<Rng>, __f<O>>
-	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
-	copy(Rng&& rng, O&& result)
-	{
-		return __stl2::copy(__stl2::begin(rng), __stl2::end(rng), std::forward<O>(result));
-	}
-
-	// Extension: two-range copy
-	namespace ext {
-		template<InputIterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
-		requires
-			IndirectlyCopyable<I1, I2>
-		tagged_pair<tag::in(I1), tag::out(I2)>
-		copy(I1 first, S1 last, I2 result_first, S2 result_last)
+	struct __copy_fn : private __niebloid {
+		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
+		requires IndirectlyCopyable<I, O>
+		constexpr copy_result<I, O>
+		operator()(I first, S last, O result) const
 		{
-			for (; first != last && result_first != result_last; ++first, ++result_first) {
-				*result_first = *first;
+			for (; first != last; ++first, ++result) {
+				*result = *first;
 			}
-			return {std::move(first), std::move(result_first)};
+			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange Rng1, Range Rng2>
-		requires
-			IndirectlyCopyable<iterator_t<Rng1>, iterator_t<Rng2>>
-		tagged_pair<tag::in(safe_iterator_t<Rng1>), tag::out(safe_iterator_t<Rng2>)>
-		copy(Rng1&& rng1, Rng2&& rng2)
+		template<InputRange R, WeaklyIncrementable O>
+		requires IndirectlyCopyable<iterator_t<R>, O>
+		constexpr copy_result<safe_iterator_t<R>, O>
+		operator()(R&& r, O result) const
 		{
-			return ext::copy(__stl2::begin(rng1), __stl2::end(rng1),
-				__stl2::begin(rng2), __stl2::end(rng2));
+			return (*this)(begin(r), end(r), std::forward<O>(result));
 		}
-	}
+	};
+
+	inline constexpr __copy_fn copy {};
+
+	namespace ext {
+		struct __copy_fn_ext : private __niebloid {
+			template<InputIterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
+			requires IndirectlyCopyable<I1, I2>
+			constexpr copy_result<I1, I2>
+			operator()(I1 first, S1 last, I2 result_first, S2 result_last) const
+			{
+				for (; first != last && result_first != result_last; ++first, (void)++result_first) {
+					*result_first = *first;
+				}
+				return {std::move(first), std::move(result_first)};
+			}
+
+			template<InputRange R1, Range R2>
+			requires IndirectlyCopyable<iterator_t<R1>, iterator_t<R2>>
+			constexpr copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+			operator()(R1&& r1, R2&& r2) const
+			{
+				return (*this)(begin(r1), end(r1), begin(r2), end(r2));
+			}
+		};
+
+		inline constexpr __copy_fn_ext copy {};
+	} // namespace ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/copy_backward.hpp
+++ b/include/stl2/detail/algorithm/copy_backward.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr copy_backward_result<safe_iterator_t<R>, I>
 		operator()(R&& r, I result) const
 		{
-			return (*this)(begin(r), end(r), std::forward<I>(result));
+			return (*this)(begin(r), end(r), std::move(result));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -24,39 +24,42 @@
 // copy_if [alg.copy]
 //
 STL2_OPEN_NAMESPACE {
-	template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-		class Pred, class Proj = identity>
-	requires
-		IndirectlyCopyable<I, O> &&
-		IndirectUnaryPredicate<
-			Pred, projected<I, Proj>>
-	tagged_pair<tag::in(I), tag::out(O)>
-	copy_if(I first, S last, O result, Pred pred, Proj proj = {})
-	{
-		for (; first != last; ++first) {
-			iter_reference_t<I>&& v = *first;
-			if (__stl2::invoke(pred, __stl2::invoke(proj, v))) {
-				*result = std::forward<iter_reference_t<I>>(v);
-				++result;
+	template<class I, class O>
+	using copy_if_result = __in_out_result<I, O>;
+
+	struct __copy_if_fn : private __niebloid {
+		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class Proj = identity,
+			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		requires IndirectlyCopyable<I, O>
+		constexpr copy_if_result<I, O>
+		operator()(I first, S last, O result, Pred pred, Proj proj = {}) const
+		{
+			for (; first != last; ++first) {
+				iter_reference_t<I>&& v = *first;
+				if (__stl2::invoke(pred, __stl2::invoke(proj, v))) {
+					*result = std::forward<iter_reference_t<I>>(v);
+					++result;
+				}
 			}
+
+			return {std::move(first), std::move(result)};
 		}
 
-		return {std::move(first), std::move(result)};
-	}
+		template<InputRange R, WeaklyIncrementable O, class Proj = identity,
+			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		requires IndirectlyCopyable<iterator_t<R>, O>
+		constexpr copy_if_result<safe_iterator_t<R>, O>
+		operator()(R&& r, O result, Pred pred, Proj proj = {}) const
+		{
+			return (*this)(
+				begin(r), end(r),
+				std::forward<O>(result),
+				std::ref(pred),
+				std::ref(proj));
+		}
+	};
 
-	template<InputRange Rng, class O, class Pred, class Proj = identity>
-	requires
-		WeaklyIncrementable<__f<O>> &&
-		IndirectUnaryPredicate<
-			Pred, projected<iterator_t<Rng>, Proj>> &&
-		IndirectlyCopyable<iterator_t<Rng>, __f<O>>
-	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
-	copy_if(Rng&& rng, O&& result, Pred pred, Proj proj = {})
-	{
-		return __stl2::copy_if(__stl2::begin(rng), __stl2::end(rng),
-			std::forward<O>(result), std::ref(pred),
-			std::ref(proj));
-	}
+	inline constexpr __copy_if_fn copy_if {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			return (*this)(
 				begin(r), end(r),
-				std::forward<O>(result),
+				std::move(result),
 				std::ref(pred),
 				std::ref(proj));
 		}

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		template<InputIterator I, WeaklyIncrementable O>
 		requires IndirectlyCopyable<I, O>
 		constexpr copy_n_result<I, O>
-			operator()(I first_, iter_difference_t<I> n, O result) const
+		operator()(I first_, iter_difference_t<I> n, O result) const
 		{
 			STL2_EXPECT(n >= 0);
 			auto norig = n;

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -21,22 +21,29 @@
 // copy_n [alg.copy]
 //
 STL2_OPEN_NAMESPACE {
-	template<InputIterator I, WeaklyIncrementable O>
-	requires IndirectlyCopyable<I, O>
-	tagged_pair<tag::in(I), tag::out(O)>
-	copy_n(I first_, iter_difference_t<I> n, O result)
-	{
-		STL2_EXPECT(n >= 0);
-		auto norig = n;
-		auto first = __stl2::ext::uncounted(first_);
-		for(; n > 0; ++first, ++result, --n) {
-			*result = *first;
+	template<class I, class O>
+	using copy_n_result = __in_out_result<I, O>;
+
+	struct __copy_n_fn : private __niebloid {
+		template<InputIterator I, WeaklyIncrementable O>
+		requires IndirectlyCopyable<I, O>
+		constexpr copy_n_result<I, O>
+			operator()(I first_, iter_difference_t<I> n, O result) const
+		{
+			STL2_EXPECT(n >= 0);
+			auto norig = n;
+			auto first = __stl2::ext::uncounted(first_);
+			for(; n > 0; ++first, ++result, --n) {
+				*result = *first;
+			}
+			return {
+				__stl2::ext::recounted(first_, first, norig),
+				std::move(result)
+			};
 		}
-		return {
-			__stl2::ext::recounted(first_, first, norig),
-			std::move(result)
-		};
-	}
+	};
+
+	inline constexpr __copy_n_fn copy_n {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -36,15 +36,17 @@ STL2_OPEN_NAMESPACE {
 	{
 		while (true) {
 			if (first1 == last1) {
-				auto [in, out] = copy(
+				auto cresult = copy(
 					std::move(first2), std::move(last2), std::move(result));
-				std::tie(first2, result) = std::tie(in, out);
+				first2 = std::move(cresult.in);
+				result = std::move(cresult.out);
 				break;
 			}
 			if (first2 == last2) {
-				auto [in, out] = copy(
+				auto cresult = copy(
 					std::move(first1), std::move(last1), std::move(result));
-				std::tie(first1, result) = std::tie(in, out);
+				first1 = std::move(cresult.in);
+				result = std::move(cresult.out);
 				break;
 			}
 			iter_reference_t<I1>&& v1 = *first1;

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -36,13 +36,15 @@ STL2_OPEN_NAMESPACE {
 	{
 		while (true) {
 			if (first1 == last1) {
-				std::tie(first2, result) = __stl2::copy(
+				auto [in, out] = copy(
 					std::move(first2), std::move(last2), std::move(result));
+				std::tie(first2, result) = std::tie(in, out);
 				break;
 			}
 			if (first2 == last2) {
-				std::tie(first1, result) = __stl2::copy(
+				auto [in, out] = copy(
 					std::move(first1), std::move(last1), std::move(result));
+				std::tie(first1, result) = std::tie(in, out);
 				break;
 			}
 			iter_reference_t<I1>&& v1 = *first1;

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -42,8 +42,8 @@ STL2_OPEN_NAMESPACE {
 	{
 		auto r = result_first;
 		if(r != result_last) {
-			std::tie(first, r) =
-				ext::copy(std::move(first), last, std::move(r), result_last);
+			auto [in, out] = ext::copy(std::move(first), last, std::move(r), result_last);
+			std::tie(first, r) = std::tie(in, out);
 
 			__stl2::make_heap(result_first, r, std::ref(comp), std::ref(proj2));
 			const auto len = __stl2::distance(result_first, r);

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -42,8 +42,9 @@ STL2_OPEN_NAMESPACE {
 	{
 		auto r = result_first;
 		if(r != result_last) {
-			auto [in, out] = ext::copy(std::move(first), last, std::move(r), result_last);
-			std::tie(first, r) = std::tie(in, out);
+			auto cresult = ext::copy(std::move(first), last, std::move(r), result_last);
+			first = std::move(cresult.in);
+			r = std::move(cresult.out);
 
 			__stl2::make_heap(result_first, r, std::ref(comp), std::ref(proj2));
 			const auto len = __stl2::distance(result_first, r);

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -23,50 +23,53 @@
 // set_difference [set.difference]
 //
 STL2_OPEN_NAMESPACE {
-	template<InputIterator I1, Sentinel<I1> S1,
-		InputIterator I2, Sentinel<I2> S2,
-		WeaklyIncrementable O, class Comp = less,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		Mergeable<I1, I2, O, Comp, Proj1, Proj2>
-	tagged_pair<tag::in(I1), tag::out(O)>
-	set_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
-		Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {})
-	{
-		while (first1 != last1 && first2 != last2) {
-			iter_reference_t<I1>&& v1 = *first1;
-			iter_reference_t<I2>&& v2 = *first2;
-			auto&& p1 = __stl2::invoke(proj1, v1);
-			auto&& p2 = __stl2::invoke(proj2, v2);
-			if (__stl2::invoke(comp, p1, p2)) {
-				*result = std::forward<iter_reference_t<I1>>(v1);
-				++result;
-				++first1;
-			} else {
-				if (!__stl2::invoke(comp, p2, p1)) {
-					++first1;
-				}
-				++first2;
-			}
-		}
-		return __stl2::copy(std::move(first1), std::move(last1), std::move(result));
-	}
+	template<class I, class O>
+	using set_difference_result = __in_out_result<I, O>;
 
-	template<InputRange Rng1, InputRange Rng2, class O, class Comp = less,
-		class Proj1 = identity, class Proj2 = identity>
-	requires
-		WeaklyIncrementable<__f<O>> &&
-		Mergeable<
-			iterator_t<Rng1>, iterator_t<Rng2>,
-			__f<O>, Comp, Proj1, Proj2>
-	tagged_pair<tag::in(safe_iterator_t<Rng1>), tag::out(__f<O>)>
-	set_difference(Rng1&& rng1, Rng2&& rng2, O&& result, Comp comp = {},
-		Proj1 proj1 = {}, Proj2 proj2 = {})
-	{
-		return __stl2::set_difference(__stl2::begin(rng1), __stl2::end(rng1),
-			__stl2::begin(rng2), __stl2::end(rng2), std::forward<O>(result),
-			std::ref(comp), std::ref(proj1), std::ref(proj2));
-	}
+	struct __set_difference_fn : private __niebloid {
+		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
+			WeaklyIncrementable O, class Comp = less,
+			class Proj1 = identity, class Proj2 = identity>
+		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		constexpr set_difference_result<I1, O>
+		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
+			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
+		{
+			while (first1 != last1 && first2 != last2) {
+				iter_reference_t<I1>&& v1 = *first1;
+				iter_reference_t<I2>&& v2 = *first2;
+				auto&& p1 = __stl2::invoke(proj1, v1);
+				auto&& p2 = __stl2::invoke(proj2, v2);
+				if (__stl2::invoke(comp, p1, p2)) {
+					*result = std::forward<iter_reference_t<I1>>(v1);
+					++result;
+					++first1;
+				} else {
+					if (!__stl2::invoke(comp, p2, p1)) {
+						++first1;
+					}
+					++first2;
+				}
+			}
+			return copy(std::move(first1), std::move(last1), std::move(result));
+		}
+
+		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+			class Comp = less, class Proj1 = identity, class Proj2 = identity>
+		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		constexpr set_difference_result<safe_iterator_t<R1>, O>
+		operator()(R1&& r1, R2&& r2, O result,
+			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
+		{
+			return (*this)(
+				begin(r1), end(r1),
+				begin(r2), end(r2),
+				std::forward<O>(result),
+				std::ref(comp), std::ref(proj1), std::ref(proj2));
+		}
+	};
+
+	inline constexpr __set_difference_fn set_difference {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 			return (*this)(
 				begin(r1), end(r1),
 				begin(r2), end(r2),
-				std::forward<O>(result),
+				std::move(result),
 				std::ref(comp), std::ref(proj1), std::ref(proj2));
 		}
 	};

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -38,13 +38,15 @@ STL2_OPEN_NAMESPACE {
 	{
 		while (true) {
 			if (first1 == last1) {
-				auto [in, out] = copy(std::move(first2), std::move(last2), std::move(result));
-				std::tie(first2, result) = std::tie(in, out);
+				auto cresult = copy(std::move(first2), std::move(last2), std::move(result));
+				first2 = std::move(cresult.in);
+				result = std::move(cresult.out);
 				break;
 			}
 			if (first2 == last2) {
-				auto [in, out] = copy(std::move(first1), std::move(last1), std::move(result));
-				std::tie(first1, result) = std::tie(in, out);
+				auto cresult = copy(std::move(first1), std::move(last1), std::move(result));
+				first1 = std::move(cresult.in);
+				result = std::move(cresult.out);
 				break;
 			}
 			iter_reference_t<I1>&& v1 = *first1;

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -38,13 +38,13 @@ STL2_OPEN_NAMESPACE {
 	{
 		while (true) {
 			if (first1 == last1) {
-				std::tie(first2, result) =
-					__stl2::copy(std::move(first2), std::move(last2), std::move(result));
+				auto [in, out] = copy(std::move(first2), std::move(last2), std::move(result));
+				std::tie(first2, result) = std::tie(in, out);
 				break;
 			}
 			if (first2 == last2) {
-				std::tie(first1, result) =
-					__stl2::copy(std::move(first1), std::move(last1), std::move(result));
+				auto [in, out] = copy(std::move(first1), std::move(last1), std::move(result));
+				std::tie(first1, result) = std::tie(in, out);
 				break;
 			}
 			iter_reference_t<I1>&& v1 = *first1;

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -36,12 +36,12 @@ STL2_OPEN_NAMESPACE {
 	{
 		while (true) {
 			if (first1 == last1) {
-				auto res = __stl2::copy(std::move(first2), std::move(last2), std::move(result));
-				return {std::move(first1), std::move(res.in()), std::move(res.out())};
+				auto res = copy(std::move(first2), std::move(last2), std::move(result));
+				return {std::move(first1), std::move(res.in), std::move(res.out)};
 			}
 			if (first2 == last2) {
-				auto res = __stl2::copy(std::move(first1), std::move(last1), std::move(result));
-				return {std::move(res.in()), std::move(first2), std::move(res.out())};
+				auto res = copy(std::move(first1), std::move(last1), std::move(result));
+				return {std::move(res.in), std::move(first2), std::move(res.out)};
 			}
 			iter_reference_t<I1>&& v1 = *first1;
 			iter_reference_t<I2>&& v2 = *first2;

--- a/include/stl2/detail/algorithm/tagspec.hpp
+++ b/include/stl2/detail/algorithm/tagspec.hpp
@@ -31,6 +31,12 @@ STL2_OPEN_NAMESPACE {
 		STL2_DEFINE_GETTER(end)
 		STL2_DEFINE_GETTER(count) // Extension
 	}
+
+	template<class I, class O>
+	struct __in_out_result {
+		I in;
+		O out;
+	};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/iterator/dangling.hpp
+++ b/include/stl2/detail/iterator/dangling.hpp
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 	using __maybe_dangling =
 		meta::if_<meta::is_trait<meta::defer<__begin_t, R>>, U, dangling<U>>;
 
-	template<Range R>
-	using safe_iterator_t = __maybe_dangling<R, iterator_t<R>>;
+	template<_ForwardingRange R>
+	using safe_iterator_t = iterator_t<R>;
 
 } STL2_CLOSE_NAMESPACE
 

--- a/test/algorithm/adjacent_find.cpp
+++ b/test/algorithm/adjacent_find.cpp
@@ -28,8 +28,5 @@ int main()
 							   decltype(ranges::adjacent_find(v2, ranges::equal_to{},
 									&std::pair<int, int>::second))>::value);
 
-	auto l = {0, 2, 2, 4, 6};
-	CHECK(ranges::adjacent_find(std::move(l)).get_unsafe()[2] == 4);
-
 	return test_result();
 }

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -70,18 +70,18 @@ int main()
 	std::pair<int, int> out[size(a)] = {};
 
 	auto res = ranges::copy(begin(a), end(a), out);
-	CHECK(res.first == end(a));
-	CHECK(res.second == out + size(out));
-	CHECK(&res.first == &res.in());
-	CHECK(&res.second == &res.out());
+	CHECK(res.in == end(a));
+	CHECK(res.out == out + size(out));
+	CHECK(&res.in == &res.in);
+	CHECK(&res.out == &res.out);
 	CHECK(std::equal(a, a + size(a), out));
 
 	std::fill_n(out, size(out), std::make_pair(0, 0));
 	CHECK(!std::equal(a, a + size(a), out));
 
 	res = ranges::copy(a, out);
-	CHECK(res.first == a + size(a));
-	CHECK(res.second == out + size(out));
+	CHECK(res.in == a + size(a));
+	CHECK(res.out == out + size(out));
 	CHECK(std::equal(a, a + size(a), out));
 
 	std::fill_n(out, size(out), std::make_pair(0, 0));
@@ -93,26 +93,11 @@ int main()
 		{
 			std::fill_n(buf, sizeof(buf), '\0');
 			auto res3 = ranges::copy(str, buf);
-			*res3.second = '\0';
-			CHECK(res3.first == std::next(begin(str), std::strlen(sz)));
-			CHECK(res3.second == buf + std::strlen(sz));
+			*res3.out = '\0';
+			CHECK(res3.in == std::next(begin(str), std::strlen(sz)));
+			CHECK(res3.out == buf + std::strlen(sz));
 			CHECK(std::strcmp(sz, buf) == 0);
 		}
-		{
-			std::fill_n(buf, sizeof(buf), '\0');
-			auto res4 = ranges::copy(std::move(str), buf);
-			*res4.second = '\0';
-			CHECK(res4.first == std::next(begin(str), std::strlen(sz)));
-			CHECK(res4.second == buf + std::strlen(sz));
-			CHECK(std::strcmp(sz, buf) == 0);
-		}
-	}
-
-	{
-		int target[8]{};
-		auto l = {1,2,3,4,5,6};
-		CHECK(ranges::copy(std::move(l), target + 1).out() == target + 7);
-		CHECK_EQUAL(target, {0,1,2,3,4,5,6,0});
 	}
 
 	return test_result();

--- a/test/algorithm/copy_backward.cpp
+++ b/test/algorithm/copy_backward.cpp
@@ -26,9 +26,9 @@ namespace {
 			int target[8]{};
 			auto result = ranges::copy_backward(ranges::make_counted_iterator(v.begin(), 4),
 				ranges::make_counted_iterator(v.begin(), 0), ranges::end(target));
-			CHECK(result.in().count() == 0);
-			CHECK(result.in().base() == v.begin());
-			CHECK(result.out() == target + 4);
+			CHECK(result.in.count() == 0);
+			CHECK(result.in.base() == v.begin());
+			CHECK(result.out == target + 4);
 			CHECK(std::count(target, target + 4, 0) == 4);
 			CHECK(std::count(target + 4, target + 8, 42) == 4);
 		}
@@ -37,9 +37,9 @@ namespace {
 			int target[8]{};
 			auto result = ranges::copy_backward(ranges::make_counted_iterator(v.begin(), 4),
 				ranges::default_sentinel{}, ranges::end(target));
-			CHECK(result.in().count() == 0);
-			CHECK(result.in().base() == v.begin());
-			CHECK(result.out() == target + 4);
+			CHECK(result.in.count() == 0);
+			CHECK(result.in.base() == v.begin());
+			CHECK(result.out == target + 4);
 			CHECK(std::count(target, target + 4, 0) == 4);
 			CHECK(std::count(target + 4, target + 8, 42) == 4);
 		}
@@ -49,7 +49,7 @@ namespace {
 		int target[8]{};
 		auto l1 = {1, 2, 3, 4};
 		auto result = ranges::copy_backward(std::move(l1), ranges::end(target));
-		CHECK(result.out() == target + 4);
+		CHECK(result.out == target + 4);
 		CHECK(std::count(target, target + 4, 0) == 4);
 		auto l2 = {1, 2, 3, 4};
 		CHECK_EQUAL(ranges::subrange(target + 4, target + 8), std::move(l2));
@@ -67,22 +67,16 @@ int main()
 	std::pair<int, int> out[size(a)] = {};
 
 	auto res = ranges::copy_backward(begin(a), end(a), end(out));
-	CHECK(res.first == end(a));
-	CHECK(res.second == begin(out));
+	CHECK(res.in == end(a));
+	CHECK(res.out == begin(out));
 	CHECK(std::equal(a, a + size(a), out));
 
 	std::fill_n(out, size(out), std::make_pair(0, 0));
 	CHECK(!std::equal(a, a + size(a), out));
 
 	res = ranges::copy_backward(a, end(out));
-	CHECK(res.first == end(a));
-	CHECK(res.second == begin(out));
-	CHECK(std::equal(a, a + size(a), out));
-
-	std::fill_n(out, size(out), std::make_pair(0, 0));
-	auto res2 = ranges::copy_backward(ranges::move(a), end(out));
-	CHECK(res2.first.get_unsafe() == end(a));
-	CHECK(res2.second == begin(out));
+	CHECK(res.in == end(a));
+	CHECK(res.out == begin(out));
 	CHECK(std::equal(a, a + size(a), out));
 
 	test_repeat_view();

--- a/test/algorithm/copy_if.cpp
+++ b/test/algorithm/copy_if.cpp
@@ -36,8 +36,8 @@ int main() {
 		};
 
 		auto res = ranges::copy_if(source, source + n, target, is_even);
-		CHECK(res.in() == source + n);
-		CHECK(res.out() == target + n / 2);
+		CHECK(res.in == source + n);
+		CHECK(res.out == target + n / 2);
 
 		CHECK(std::equal(target, target + n / 2, evens));
 		CHECK(std::count(target + n / 2, target + n, -1) == n / 2);
@@ -48,20 +48,8 @@ int main() {
 		std::fill_n(target, n, -1);
 
 		auto res = ranges::copy_if(source, target, is_even);
-		CHECK(res.in() == source + n);
-		CHECK(res.out() == target + n / 2);
-
-		CHECK(std::equal(target, target + n / 2, evens));
-		CHECK(std::count(target + n / 2, target + n, -1) == n / 2);
-	}
-
-	{
-		int target[n];
-		std::fill_n(target, n, -1);
-
-		auto res = ranges::copy_if(std::move(source), target, is_even);
-		CHECK(res.in().get_unsafe() == source + n);
-		CHECK(res.out() == target + n / 2);
+		CHECK(res.in == source + n);
+		CHECK(res.out == target + n / 2);
 
 		CHECK(std::equal(target, target + n / 2, evens));
 		CHECK(std::count(target + n / 2, target + n, -1) == n / 2);
@@ -79,8 +67,8 @@ int main() {
 		}
 
 		auto res = ranges::copy_if(source, target, is_even, &S::value);
-		CHECK(res.in() == source + n);
-		CHECK(res.out() == target + n / 2);
+		CHECK(res.in == source + n);
+		CHECK(res.out == target + n / 2);
 
 		for (auto i = n / 2; i-- > 0;) {
 			CHECK(target[i].value == source[2 * i].value);
@@ -97,7 +85,7 @@ int main() {
 		{
 			auto l = {5,4,3,2,1,0};
 			auto res = ranges::copy_if(std::move(l), target, is_even);
-			CHECK(res.out() == target + n / 2);
+			CHECK(res.out == target + n / 2);
 		}
 
 		CHECK(std::equal(target, target + n / 2, evens));

--- a/test/algorithm/copy_n.cpp
+++ b/test/algorithm/copy_n.cpp
@@ -23,8 +23,8 @@ int main() {
 	std::fill_n(target, n, 0);
 	static_assert(n >= 2);
 	auto res = stl2::copy_n(source, n - 2, target);
-	CHECK(res.in() == source + n - 2);
-	CHECK(res.out() == target + n - 2);
+	CHECK(res.in == source + n - 2);
+	CHECK(res.out == target + n - 2);
 
 	CHECK(std::equal(source, source + n - 2, target));
 	CHECK(target[n - 2] == 0);

--- a/test/algorithm/find.cpp
+++ b/test/algorithm/find.cpp
@@ -50,11 +50,6 @@ int main()
 	pi = find(ia, 10);
 	CHECK(pi == ia+s);
 
-	auto pj = find(move(ia), 3);
-	CHECK((pj.get_unsafe() != ia+s && *pj.get_unsafe() == 3));
-	pj = find(move(ia), 10);
-	CHECK(pj.get_unsafe() == ia+s);
-
 	S sa[] = {{0}, {1}, {2}, {3}, {4}, {5}};
 	S *ps = find(sa, 3, &S::i_);
 	CHECK((ps != end(sa) && ps->i_ == 3));

--- a/test/algorithm/find_if.cpp
+++ b/test/algorithm/find_if.cpp
@@ -57,11 +57,6 @@ int main()
 	pi = find_if(ia, [](int i){return i == 10;});
 	CHECK(pi == ia+s);
 
-	auto pj = find_if(move(ia), [](int i){return i == 3;});
-	CHECK(*pj.get_unsafe() == 3);
-	pj = find_if(move(ia), [](int i){return i == 10;});
-	CHECK(pj.get_unsafe() == ia+s);
-
 	S sa[] = {{0}, {1}, {2}, {3}, {4}, {5}};
 	S *ps = find_if(sa, [](int i){return i == 3;}, &S::i_);
 	CHECK(ps->i_ == 3);

--- a/test/algorithm/find_if_not.cpp
+++ b/test/algorithm/find_if_not.cpp
@@ -57,11 +57,6 @@ int main()
 	pi = find_if_not(ia, [](int i){return i != 10;});
 	CHECK(pi == ia+s);
 
-	auto pj = find_if_not(move(ia), [](int i){return i != 3;});
-	CHECK(*pj.get_unsafe() == 3);
-	pj = find_if_not(move(ia), [](int i){return i != 10;});
-	CHECK(pj.get_unsafe() == ia+s);
-
 	S sa[] = {{0}, {1}, {2}, {3}, {4}, {5}};
 	S *ps = find_if_not(sa, [](int i){return i != 3;}, &S::i_);
 	CHECK(ps->i_ == 3);

--- a/test/algorithm/is_heap_until.hpp
+++ b/test/algorithm/is_heap_until.hpp
@@ -1068,9 +1068,5 @@ int main()
 	is_heap_until(i185, i185+7, std::greater<int>(), &S::i)
 		.check([&](S *r){ CHECK(r == i185+1); });
 
-	// Test rvalue range
-	auto res = stl2::is_heap_until(stl2::move(i185), std::greater<int>(), &S::i);
-	CHECK(res.get_unsafe() == i185+1);
-
 	return ::test_result();
 }

--- a/test/algorithm/is_sorted_until.cpp
+++ b/test/algorithm/is_sorted_until.cpp
@@ -403,12 +403,5 @@ int main()
 		CHECK(stl2::is_sorted_until(as, std::greater<int>{}, &A::a) == stl2::next(stl2::begin(as),1));
 	}
 
-	/// Rvalue range test:
-	{
-		A as[] = {{0}, {1}, {2}, {3}, {4}};
-		CHECK(stl2::is_sorted_until(stl2::move(as), std::less<int>{}, &A::a).get_unsafe() == stl2::end(as));
-		CHECK(stl2::is_sorted_until(stl2::move(as), std::greater<int>{}, &A::a).get_unsafe() == stl2::next(stl2::begin(as),1));
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/lower_bound.cpp
+++ b/test/algorithm/lower_bound.cpp
@@ -65,10 +65,7 @@ int main()
 	CHECK(stl2::lower_bound(a, 1, less(), &std::pair<int, int>::first) == &a[2]);
 	CHECK(stl2::lower_bound(c, 1, less(), &std::pair<int, int>::first) == &c[2]);
 
-	CHECK(stl2::lower_bound(stl2::move(a), 1, less(), &std::pair<int, int>::first).get_unsafe() == &a[2]);
-	CHECK(stl2::lower_bound(stl2::move(c), 1, less(), &std::pair<int, int>::first).get_unsafe() == &c[2]);
-
-	CHECK(*stl2::lower_bound(stl2::iota_view<int>{}, 42).get_unsafe() == 42);
+	CHECK(*stl2::lower_bound(stl2::iota_view<int>{}, 42) == 42);
 
 	return test_result();
 }

--- a/test/algorithm/partial_sort_copy.cpp
+++ b/test/algorithm/partial_sort_copy.cpp
@@ -142,22 +142,5 @@ int main()
             CHECK(x->i == i);
     }
 
-    // Check rvalue ranges
-    {
-        constexpr int N = 256;
-        constexpr int M = N/2-1;
-        S input[N];
-        U output[M];
-        for (int i = 0; i < N; ++i)
-            input[i].i = i;
-        std::shuffle(input, input+N, gen);
-        auto r = stl2::partial_sort_copy(input, std::move(output), std::less<int>(), &S::i, &U::i);
-        U* e = output + std::min(N, M);
-        CHECK(r.get_unsafe() == e);
-        int i = 0;
-        for (U* x = output; x < e; ++x, ++i)
-            CHECK(x->i == i);
-    }
-
     return ::test_result();
 }

--- a/test/algorithm/partition.cpp
+++ b/test/algorithm/partition.cpp
@@ -205,13 +205,5 @@ int main()
 	for (S* i = r; i < ia+sa; ++i)
 		CHECK(!is_odd()(i->i));
 
-	// Test rvalue range
-	auto r2 = stl2::partition(stl2::move(ia), is_odd(), &S::i);
-	CHECK(r2.get_unsafe() == ia + 5);
-	for (S* i = ia; i < r2.get_unsafe(); ++i)
-		CHECK(is_odd()(i->i));
-	for (S* i = r2.get_unsafe(); i < ia+sa; ++i)
-		CHECK(!is_odd()(i->i));
-
 	return ::test_result();
 }

--- a/test/algorithm/partition_copy.cpp
+++ b/test/algorithm/partition_copy.cpp
@@ -110,26 +110,6 @@ void test_proj()
 	CHECK(r2[3].i == 8);
 }
 
-void test_rvalue()
-{
-	// Test rvalue ranges
-	const S ia[] = {S{1}, S{2}, S{3}, S{4}, S{6}, S{8}, S{5}, S{7}};
-	S r1[10] = {S{0}};
-	S r2[10] = {S{0}};
-	auto p = stl2::partition_copy(stl2::move(ia), r1, r2, is_odd(), &S::i);
-	CHECK(std::get<0>(p).get_unsafe() == std::end(ia));
-	CHECK(std::get<1>(p) == r1 + 4);
-	CHECK(r1[0].i == 1);
-	CHECK(r1[1].i == 3);
-	CHECK(r1[2].i == 5);
-	CHECK(r1[3].i == 7);
-	CHECK(std::get<2>(p) == r2 + 4);
-	CHECK(r2[0].i == 2);
-	CHECK(r2[1].i == 4);
-	CHECK(r2[2].i == 6);
-	CHECK(r2[3].i == 8);
-}
-
 int main()
 {
 	test_iter<input_iterator<const int*> >();
@@ -139,7 +119,6 @@ int main()
 	test_range<input_iterator<const int*>, sentinel<const int*>>();
 
 	test_proj();
-	test_rvalue();
 
 	return ::test_result();
 }

--- a/test/algorithm/partition_point.cpp
+++ b/test/algorithm/partition_point.cpp
@@ -235,7 +235,7 @@ int main()
 
 	// Test infinite range
 	CHECK(*stl2::partition_point(stl2::iota_view<int>{0},
-								[](int i){ return i < 42; }).get_unsafe() == 42);
+								[](int i){ return i < 42; }) == 42);
 
 	return ::test_result();
 }

--- a/test/algorithm/remove.cpp
+++ b/test/algorithm/remove.cpp
@@ -159,17 +159,5 @@ int main()
 	CHECK(ia[4].i == 3);
 	CHECK(ia[5].i == 4);
 
-	// Check rvalue range
-	S ia2[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
-	constexpr unsigned sa2 = stl2::size(ia2);
-	auto r2 = stl2::remove(stl2::move(ia2), 2, &S::i);
-	CHECK(r2.get_unsafe() == ia2 + sa2-3);
-	CHECK(ia2[0].i == 0);
-	CHECK(ia2[1].i == 1);
-	CHECK(ia2[2].i == 3);
-	CHECK(ia2[3].i == 4);
-	CHECK(ia2[4].i == 3);
-	CHECK(ia2[5].i == 4);
-
 	return ::test_result();
 }

--- a/test/algorithm/remove_copy.cpp
+++ b/test/algorithm/remove_copy.cpp
@@ -152,21 +152,5 @@ int main()
 		CHECK(ib[5].i == 4);
 	}
 
-	// Check rvalue range
-	{
-		S ia[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
-		constexpr unsigned sa = stl2::size(ia);
-		S ib[sa];
-		auto r = stl2::remove_copy(stl2::move(ia), ib, 2, &S::i);
-		CHECK(r.first.get_unsafe() == ia + sa);
-		CHECK(r.second == ib + sa-3);
-		CHECK(ib[0].i == 0);
-		CHECK(ib[1].i == 1);
-		CHECK(ib[2].i == 3);
-		CHECK(ib[3].i == 4);
-		CHECK(ib[4].i == 3);
-		CHECK(ib[5].i == 4);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/remove_copy_if.cpp
+++ b/test/algorithm/remove_copy_if.cpp
@@ -153,21 +153,5 @@ int main()
 		CHECK(ib[5].i == 4);
 	}
 
-	// Check rvalue range
-	{
-		S ia[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
-		constexpr unsigned sa = stl2::size(ia);
-		S ib[sa];
-		auto r = stl2::remove_copy_if(stl2::move(ia), ib, [](int i){return i == 2;}, &S::i);
-		CHECK(r.first.get_unsafe() == ia + sa);
-		CHECK(r.second == ib + sa-3);
-		CHECK(ib[0].i == 0);
-		CHECK(ib[1].i == 1);
-		CHECK(ib[2].i == 3);
-		CHECK(ib[3].i == 4);
-		CHECK(ib[4].i == 3);
-		CHECK(ib[5].i == 4);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/remove_if.cpp
+++ b/test/algorithm/remove_if.cpp
@@ -176,20 +176,5 @@ int main()
 		CHECK(ia[5].i == 4);
 	}
 
-	{
-		// Check rvalue range
-		S ia[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
-		constexpr unsigned sa = stl2::size(ia);
-		using namespace std::placeholders;
-		auto r = stl2::remove_if(stl2::move(ia), std::bind(std::equal_to<int>(), _1, 2), &S::i);
-		CHECK(r.get_unsafe() == ia + sa-3);
-		CHECK(ia[0].i == 0);
-		CHECK(ia[1].i == 1);
-		CHECK(ia[2].i == 3);
-		CHECK(ia[3].i == 4);
-		CHECK(ia[4].i == 3);
-		CHECK(ia[5].i == 4);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/replace.cpp
+++ b/test/algorithm/replace.cpp
@@ -96,18 +96,5 @@ int main()
 		CHECK(i == stl2::end(ia));
 	}
 
-	// test rvalue range
-	{
-		using P = std::pair<int,std::string>;
-		P ia[] = {{0,"0"}, {1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}};
-		auto i = stl2::replace(stl2::move(ia), 2, std::make_pair(42,"42"), &std::pair<int,std::string>::first);
-		CHECK(ia[0] == P{0,"0"});
-		CHECK(ia[1] == P{1,"1"});
-		CHECK(ia[2] == P{42,"42"});
-		CHECK(ia[3] == P{3,"3"});
-		CHECK(ia[4] == P{4,"4"});
-		CHECK(i.get_unsafe() == stl2::end(ia));
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/replace_if.cpp
+++ b/test/algorithm/replace_if.cpp
@@ -97,19 +97,5 @@ int main()
 		CHECK(i == stl2::end(ia));
 	}
 
-	// test rvalue range
-	{
-		using P = std::pair<int,std::string>;
-		P ia[] = {{0,"0"}, {1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}};
-		auto i = stl2::replace_if(stl2::move(ia), [](int i){return i==2;}, std::make_pair(42,"42"),
-			&std::pair<int,std::string>::first);
-		CHECK(ia[0] == P{0,"0"});
-		CHECK(ia[1] == P{1,"1"});
-		CHECK(ia[2] == P{42,"42"});
-		CHECK(ia[3] == P{3,"3"});
-		CHECK(ia[4] == P{4,"4"});
-		CHECK(i.get_unsafe() == stl2::end(ia));
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/reverse_copy.cpp
+++ b/test/algorithm/reverse_copy.cpp
@@ -111,13 +111,6 @@ void test()
 		CHECK_EQUAL(jd, {3, 2, 1, 0});
 		CHECK(p4.first == Iter(id+sd));
 		CHECK(base(p4.second) == jd+sd);
-
-		// test rvalue ranges
-		std::memset(jd, 0, sizeof(jd));
-		auto p5 = stl2::reverse_copy(stl2::subrange(Iter(id), Sent(id+sd)), OutIter(jd));
-		CHECK_EQUAL(jd, {3, 2, 1, 0});
-		CHECK(p5.first == Iter(id+sd));
-		CHECK(base(p4.second) == jd+sd);
 	}
 }
 

--- a/test/algorithm/rotate.cpp
+++ b/test/algorithm/rotate.cpp
@@ -260,19 +260,6 @@ int main()
 	test<bidirectional_iterator<int *>, sentinel<int*>>();
 	test<random_access_iterator<int *>, sentinel<int*>>();
 
-	// test rvalue range
-	{
-		int rgi[] = {0,1,2,3,4,5};
-		auto r = stl2::rotate(stl2::move(rgi), rgi+2);
-		CHECK(r.get_unsafe().begin() == rgi+4);
-		CHECK(r.get_unsafe().end() == stl2::end(rgi));
-		CHECK(rgi[0] == 2);
-		CHECK(rgi[1] == 3);
-		CHECK(rgi[2] == 4);
-		CHECK(rgi[3] == 5);
-		CHECK(rgi[4] == 0);
-		CHECK(rgi[5] == 1);
-	}
 
 	return ::test_result();
 }

--- a/test/algorithm/rotate_copy.cpp
+++ b/test/algorithm/rotate_copy.cpp
@@ -37,101 +37,101 @@ void test_iter()
 	const unsigned sa = sizeof(ia)/sizeof(ia[0]);
 	int ib[sa] = {0};
 
-	std::pair<InIter, OutIter> r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia), OutIter(ib));
-	CHECK(base(r.first) == ia);
-	CHECK(base(r.second) == ib);
+	auto r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia), OutIter(ib));
+	CHECK(base(r.in) == ia);
+	CHECK(base(r.out) == ib);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+1);
-	CHECK(base(r.second) == ib+1);
+	CHECK(base(r.in) == ia+1);
+	CHECK(base(r.out) == ib+1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+1), Sent(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+1);
-	CHECK(base(r.second) == ib+1);
+	CHECK(base(r.in) == ia+1);
+	CHECK(base(r.out) == ib+1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+1), Sent(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 0);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+2), Sent(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+1), Sent(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 2);
 	CHECK(ib[2] == 0);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+2), Sent(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 2);
 	CHECK(ib[1] == 0);
 	CHECK(ib[2] == 1);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+3), Sent(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia), Sent(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 	CHECK(ib[3] == 3);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+1), Sent(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 2);
 	CHECK(ib[2] == 3);
 	CHECK(ib[3] == 0);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+2), Sent(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 2);
 	CHECK(ib[1] == 3);
 	CHECK(ib[2] == 0);
 	CHECK(ib[3] == 1);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+3), Sent(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 3);
 	CHECK(ib[1] == 0);
 	CHECK(ib[2] == 1);
 	CHECK(ib[3] == 2);
 
 	r = stl2::rotate_copy(InIter(ia), InIter(ia+4), Sent(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
@@ -145,101 +145,101 @@ void test_rng()
 	const unsigned sa = sizeof(ia)/sizeof(ia[0]);
 	int ib[sa] = {0};
 
-	std::pair<InIter, OutIter> r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia))), InIter(ia), OutIter(ib));
-	CHECK(base(r.first) == ia);
-	CHECK(base(r.second) == ib);
+	auto r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia))), InIter(ia), OutIter(ib));
+	CHECK(base(r.in) == ia);
+	CHECK(base(r.out) == ib);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+1))), InIter(ia), OutIter(ib));
-	CHECK(base(r.first) == ia+1);
-	CHECK(base(r.second) == ib+1);
+	CHECK(base(r.in) == ia+1);
+	CHECK(base(r.out) == ib+1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+1))), InIter(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+1);
-	CHECK(base(r.second) == ib+1);
+	CHECK(base(r.in) == ia+1);
+	CHECK(base(r.out) == ib+1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+2))), InIter(ia), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+2))), InIter(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 0);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+2))), InIter(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+2);
-	CHECK(base(r.second) == ib+2);
+	CHECK(base(r.in) == ia+2);
+	CHECK(base(r.out) == ib+2);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+3))), InIter(ia), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+3))), InIter(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 2);
 	CHECK(ib[2] == 0);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+3))), InIter(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 2);
 	CHECK(ib[1] == 0);
 	CHECK(ib[2] == 1);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+3))), InIter(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+3);
-	CHECK(base(r.second) == ib+3);
+	CHECK(base(r.in) == ia+3);
+	CHECK(base(r.out) == ib+3);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+4))), InIter(ia), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
 	CHECK(ib[3] == 3);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+4))), InIter(ia+1), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 1);
 	CHECK(ib[1] == 2);
 	CHECK(ib[2] == 3);
 	CHECK(ib[3] == 0);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+4))), InIter(ia+2), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 2);
 	CHECK(ib[1] == 3);
 	CHECK(ib[2] == 0);
 	CHECK(ib[3] == 1);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+4))), InIter(ia+3), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 3);
 	CHECK(ib[1] == 0);
 	CHECK(ib[2] == 1);
 	CHECK(ib[3] == 2);
 
 	r = stl2::rotate_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia+4))), InIter(ia+4), OutIter(ib));
-	CHECK(base(r.first) == ia+4);
-	CHECK(base(r.second) == ib+4);
+	CHECK(base(r.in) == ia+4);
+	CHECK(base(r.out) == ib+4);
 	CHECK(ib[0] == 0);
 	CHECK(ib[1] == 1);
 	CHECK(ib[2] == 2);
@@ -301,21 +301,6 @@ int main()
 	test<const int*, bidirectional_iterator<int*> >();
 	test<const int*, random_access_iterator<int*> >();
 	test<const int*, int*>();
-
-	// test rvalue range
-	{
-		int rgi[] = {0,1,2,3,4,5};
-		int rgo[6] = {0};
-		auto r = stl2::rotate_copy(stl2::move(rgi), rgi+2, rgo);
-		CHECK(r.first.get_unsafe() == stl2::end(rgi));
-		CHECK(r.second == stl2::end(rgo));
-		CHECK(rgo[0] == 2);
-		CHECK(rgo[1] == 3);
-		CHECK(rgo[2] == 4);
-		CHECK(rgo[3] == 5);
-		CHECK(rgo[4] == 0);
-		CHECK(rgo[5] == 1);
-	}
 
 	return ::test_result();
 }

--- a/test/algorithm/search.cpp
+++ b/test/algorithm/search.cpp
@@ -254,13 +254,5 @@ int main()
 		CHECK((e - b) == 0);
 	}
 
-	// Test rvalue ranges
-	{
-		int ib[] = {0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 4};
-		int ie[] = {1, 2, 3};
-		CHECK(eq(subrange{ib+4, ib+7},
-			ranges::search(ranges::move(ib), ie).get_unsafe()));
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/search_n.cpp
+++ b/test/algorithm/search_n.cpp
@@ -193,11 +193,5 @@ int main()
 		CHECK(it2.count() == 0);
 	}
 
-	// Test rvalue ranges
-	{
-		int ib[] = {0, 0, 1, 1, 2, 2};
-		CHECK(stl2::search_n(stl2::move(ib), 2, 1).get_unsafe() == ib+2);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/set_difference.hpp
+++ b/test/algorithm/set_difference.hpp
@@ -45,22 +45,20 @@ test_iter()
 	});
 
 	set_difference(Iter1(ia), Iter1(ia+sa), Iter2(ib), Iter2(ib+sb), OutIter(ic)).
-		check([&](std::pair<Iter1, OutIter> res)
-		{
-			CHECK(bool((base(res.first) - ia) == sa));
-			CHECK(bool((base(res.second) - ic) == sr));
-			CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == 0);
+		check([&](auto res) {
+			CHECK(bool((base(res.in) - ia) == sa));
+			CHECK(bool((base(res.out) - ic) == sr));
+			CHECK(std::lexicographical_compare(ic, base(res.out), ir, ir+sr) == 0);
 			stl2::fill(ic, 0);
 		}
 	);
 	int irr[] = {6};
 	const int srr = sizeof(irr)/sizeof(irr[0]);
 	set_difference(Iter1(ib), Iter1(ib+sb), Iter2(ia), Iter2(ia+sa), OutIter(ic)).
-		check([&](std::pair<Iter1, OutIter> res)
-		{
-			CHECK(bool((base(res.first) - ib) == sb));
-			CHECK(bool((base(res.second) - ic) == srr));
-			CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == 0);
+		check([&](auto res) {
+			CHECK(bool((base(res.in) - ib) == sb));
+			CHECK(bool((base(res.out) - ic) == srr));
+			CHECK(std::lexicographical_compare(ic, base(res.out), irr, irr+srr) == 0);
 			stl2::fill(ic, 0);
 		}
 	);
@@ -83,22 +81,20 @@ test_comp()
 	});
 
 	set_difference(Iter1(ia), Iter1(ia+sa), Iter2(ib), Iter2(ib+sb), OutIter(ic), std::less<int>()).
-		check([&](std::pair<Iter1, OutIter> res)
-		{
-			CHECK(bool((base(res.first) - ia) == sa));
-			CHECK(bool((base(res.second) - ic) == sr));
-			CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == 0);
+		check([&](auto res) {
+			CHECK(bool((base(res.in) - ia) == sa));
+			CHECK(bool((base(res.out) - ic) == sr));
+			CHECK(std::lexicographical_compare(ic, base(res.out), ir, ir+sr) == 0);
 			stl2::fill(ic, 0);
 		}
 	);
 	int irr[] = {6};
 	const int srr = sizeof(irr)/sizeof(irr[0]);
 	set_difference(Iter1(ib), Iter1(ib+sb), Iter2(ia), Iter2(ia+sa), OutIter(ic), std::less<int>()).
-		check([&](std::pair<Iter1, OutIter> res)
-		{
-			CHECK(bool((base(res.first) - ib) == sb));
-			CHECK(bool((base(res.second) - ic) == srr));
-			CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == 0);
+		check([&](auto res) {
+			CHECK(bool((base(res.in) - ib) == sb));
+			CHECK(bool((base(res.out) - ic) == srr));
+			CHECK(std::lexicographical_compare(ic, base(res.out), irr, irr+srr) == 0);
 			stl2::fill(ic, 0);
 		}
 	);

--- a/test/algorithm/set_difference6.cpp
+++ b/test/algorithm/set_difference6.cpp
@@ -25,42 +25,18 @@ int main()
 		int ir[] = {1, 2, 3, 3, 3, 4, 4};
 		const int sr = sizeof(ir)/sizeof(ir[0]);
 
-		std::pair<S *, U *> res = stl2::set_difference(ia, ib, ic, std::less<int>(), &S::i, &T::j);
-		CHECK((res.first - ia) == sa);
-		CHECK((res.second - ic) == sr);
-		CHECK(stl2::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == 0);
+		auto res = stl2::set_difference(ia, ib, ic, std::less<int>(), &S::i, &T::j);
+		CHECK((res.in - ia) == sa);
+		CHECK((res.out - ic) == sr);
+		CHECK(stl2::lexicographical_compare(ic, res.out, ir, ir+sr, std::less<int>(), &U::k) == 0);
 		stl2::fill(ic, U{0});
 
 		int irr[] = {6};
 		const int srr = sizeof(irr)/sizeof(irr[0]);
-		std::pair<T *, U *> res2 = stl2::set_difference(ib, ia, ic, std::less<int>(), &T::j, &S::i);
-		CHECK((res2.first - ib) == sb);
-		CHECK((res2.second - ic) == srr);
-		CHECK(stl2::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
-	}
-
-	// Test rvalue ranges
-	{
-		S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};
-		const int sa = sizeof(ia)/sizeof(ia[0]);
-		T ib[] = {T{2}, T{4}, T{4}, T{6}};
-		const int sb = sizeof(ib)/sizeof(ib[0]);
-		U ic[20];
-		int ir[] = {1, 2, 3, 3, 3, 4, 4};
-		const int sr = sizeof(ir)/sizeof(ir[0]);
-
-		auto res = stl2::set_difference(std::move(ia), std::move(ib), ic, std::less<int>(), &S::i, &T::j);
-		CHECK((res.first.get_unsafe() - ia) == sa);
-		CHECK((res.second - ic) == sr);
-		CHECK(stl2::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == 0);
-		stl2::fill(ic, U{0});
-
-		int irr[] = {6};
-		const int srr = sizeof(irr)/sizeof(irr[0]);
-		auto res2 = stl2::set_difference(std::move(ib), std::move(ia), ic, std::less<int>(), &T::j, &S::i);
-		CHECK((res2.first.get_unsafe() - ib) == sb);
-		CHECK((res2.second - ic) == srr);
-		CHECK(stl2::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+		auto res2 = stl2::set_difference(ib, ia, ic, std::less<int>(), &T::j, &S::i);
+		CHECK((res2.in - ib) == sb);
+		CHECK((res2.out - ic) == srr);
+		CHECK(stl2::lexicographical_compare(ic, res2.out, ir, irr+srr, std::less<int>(), &U::k) == 0);
 	}
 
 	return ::test_result();

--- a/test/algorithm/set_symmetric_difference6.cpp
+++ b/test/algorithm/set_symmetric_difference6.cpp
@@ -35,29 +35,5 @@ int main()
 		CHECK(stl2::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
 	}
 
-	// Test rvalue ranges
-	{
-		S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};
-		T ib[] = {T{2}, T{4}, T{4}, T{6}};
-		U ic[20];
-		int ir[] = {1, 2, 3, 3, 3, 4, 4, 6};
-		const int sr = sizeof(ir)/sizeof(ir[0]);
-
-		auto res1 =
-			stl2::set_symmetric_difference(std::move(ia), std::move(ib), ic, std::less<int>(), &S::i, &T::j);
-		CHECK(std::get<0>(res1).get_unsafe() == stl2::end(ia));
-		CHECK(std::get<1>(res1).get_unsafe() == stl2::end(ib));
-		CHECK((std::get<2>(res1) - ic) == sr);
-		CHECK(stl2::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == 0);
-		stl2::fill(ic, U{0});
-
-		auto res2 =
-			stl2::set_symmetric_difference(std::move(ib), std::move(ia), ic, std::less<int>(), &T::j, &S::i);
-		CHECK(std::get<0>(res2).get_unsafe() == stl2::end(ib));
-		CHECK(std::get<1>(res2).get_unsafe() == stl2::end(ia));
-		CHECK((std::get<2>(res2) - ic) == sr);
-		CHECK(stl2::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/set_union6.cpp
+++ b/test/algorithm/set_union6.cpp
@@ -44,15 +44,15 @@ int main()
 		const int sr = sizeof(ir)/sizeof(ir[0]);
 
 		auto res = stl2::set_union(std::move(ia), std::move(ib), ic, std::less<int>(), &S::i, &T::j);
-		CHECK(std::get<0>(res).get_unsafe() == stl2::end(ia));
-		CHECK(std::get<1>(res).get_unsafe() == stl2::end(ib));
+		CHECK(std::get<0>(res) == stl2::end(ia));
+		CHECK(std::get<1>(res) == stl2::end(ib));
 		CHECK((std::get<2>(res) - ic) == sr);
 		CHECK(stl2::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == 0);
 		stl2::fill(ic, U{0});
 
 		auto res2 = stl2::set_union(std::move(ib), std::move(ia), ic, std::less<int>(), &T::j, &S::i);
-		CHECK(std::get<0>(res2).get_unsafe() == stl2::end(ib));
-		CHECK(std::get<1>(res2).get_unsafe() == stl2::end(ia));
+		CHECK(std::get<0>(res2) == stl2::end(ib));
+		CHECK(std::get<1>(res2) == stl2::end(ia));
 		CHECK((std::get<2>(res2) - ic) == sr);
 		CHECK(stl2::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
 	}

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -278,22 +278,6 @@ int main()
 		}
 	}
 
-	// Check rvalue range
-	{
-		std::vector<S> v(1000, S{});
-		for(int i = 0; (std::size_t)i < v.size(); ++i)
-		{
-			v[i].i = v.size() - i - 1;
-			v[i].j = i;
-		}
-		CHECK(stl2::sort(std::move(v), std::less<int>{}, &S::i).get_unsafe() == v.end());
-		for(int i = 0; (std::size_t)i < v.size(); ++i)
-		{
-			CHECK(v[i].i == i);
-			CHECK((std::size_t)v[i].j == v.size() - i - 1);
-		}
-	}
-
 #if 0
 	// Check sorting a zip view, which uses iter_move
 	{

--- a/test/algorithm/stable_partition.cpp
+++ b/test/algorithm/stable_partition.cpp
@@ -415,24 +415,6 @@ int main()
 		CHECK(ap[9].p == P{4, 2});
 	}
 
-	// Test rvalue ranges
-	using P = std::pair<int, int>;
-	{  // check mixed
-		S ap[] = { {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}, {{2, 2}}, {{3, 1}}, {{3, 2}}, {{4, 1}}, {{4, 2}} };
-		auto r = ranges::stable_partition(std::move(ap), odd_first(), &S::p);
-		CHECK(r.get_unsafe() == ap + 4);
-		CHECK(ap[0].p == P{1, 1});
-		CHECK(ap[1].p == P{1, 2});
-		CHECK(ap[2].p == P{3, 1});
-		CHECK(ap[3].p == P{3, 2});
-		CHECK(ap[4].p == P{0, 1});
-		CHECK(ap[5].p == P{0, 2});
-		CHECK(ap[6].p == P{2, 1});
-		CHECK(ap[7].p == P{2, 2});
-		CHECK(ap[8].p == P{4, 1});
-		CHECK(ap[9].p == P{4, 2});
-	}
-
 	{
 		int some_ints[] = {1, 0};
 		auto first = some_ints + 0, last = some_ints + 2;

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -218,21 +218,5 @@ int main()
 		}
 	}
 
-	// Check rvalue range
-	{
-		std::vector<S> v(1000, S{});
-		for(int i = 0; (std::size_t)i < v.size(); ++i)
-		{
-			v[i].i = v.size() - i - 1;
-			v[i].j = i;
-		}
-		CHECK(stl2::stable_sort(std::move(v), std::less<int>{}, &S::i).get_unsafe() == v.end());
-		for(int i = 0; (std::size_t)i < v.size(); ++i)
-		{
-			CHECK(v[i].i == i);
-			CHECK((std::size_t)v[i].j == v.size() - i - 1);
-		}
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/unique.cpp
+++ b/test/algorithm/unique.cpp
@@ -146,15 +146,5 @@ int main()
 	test<random_access_iterator<int*>, range_call>();
 	test<int*, range_call>();
 
-	// Test rvalue range
-	{
-		int a[] = {0, 1, 1, 1, 2, 2, 2};
-		auto r = stl2::unique(stl2::move(a));
-		CHECK(r.get_unsafe() == a + 3);
-		CHECK(a[0] == 0);
-		CHECK(a[1] == 1);
-		CHECK(a[2] == 2);
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/unique_copy.cpp
+++ b/test/algorithm/unique_copy.cpp
@@ -297,15 +297,5 @@ int main()
 		CHECK_EQUAL(stl2::subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
 	}
 
-	// Test rvalue ranges:
-	{
-		S const ia[] = {{1,1},{2,2},{3,3},{3,4},{4,5},{5,6},{5,7},{5,8},{6,9},{7,10}};
-		S ib[stl2::size(ia)];
-		auto r = stl2::unique_copy(stl2::move(ia), ib, stl2::equal_to(), &S::i);
-		CHECK(r.first.get_unsafe() == stl2::end(ia));
-		CHECK(r.second == ib + 7);
-		CHECK_EQUAL(stl2::subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
-	}
-
 	return ::test_result();
 }

--- a/test/algorithm/upper_bound.cpp
+++ b/test/algorithm/upper_bound.cpp
@@ -65,16 +65,7 @@ int main()
 	CHECK(stl2::upper_bound(a, 1, less(), &std::pair<int, int>::first) == &a[4]);
 	CHECK(stl2::upper_bound(c, 1, less(), &std::pair<int, int>::first) == &c[4]);
 
-	CHECK(stl2::upper_bound(stl2::move(a), a[2]).get_unsafe() == &a[3]);
-	CHECK(stl2::upper_bound(stl2::move(c), c[3]).get_unsafe() == &c[4]);
-
-	CHECK(stl2::upper_bound(stl2::move(a), a[4], less()).get_unsafe() == &a[5]);
-	CHECK(stl2::upper_bound(stl2::move(c), c[5], less()).get_unsafe() == &c[6]);
-
-	CHECK(stl2::upper_bound(stl2::move(a), 1, less(), &std::pair<int, int>::first).get_unsafe() == &a[4]);
-	CHECK(stl2::upper_bound(stl2::move(c), 1, less(), &std::pair<int, int>::first).get_unsafe() == &c[4]);
-
-	CHECK(*stl2::upper_bound(stl2::iota_view<int>{}, 42).get_unsafe() == 43);
+	CHECK(*stl2::upper_bound(stl2::iota_view<int>{}, 42) == 43);
 
 	return test_result();
 }


### PR DESCRIPTION
* Changes `safe_iterator_t`
   * Tests using `get_unsafe` revised or removed.
* copy[_*] changed to niebloids.
* Users of the copy family updated also (internally).

I'm not confident that I revised all of the tests correctly.