### PR TITLE
Bugsbugsbugs

### DIFF
--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -92,7 +92,8 @@ STL2_OPEN_NAMESPACE {
 		return {std::move(r), std::move(i)};
 	}
 
-	constexpr Integral __gcd(Integral x, Integral y)
+	template<Integral I>
+	constexpr I __gcd(I x, I y)
 	{
 		do {
 			auto t = x % y;

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -94,7 +94,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyCopyable<I, O> &&
 		IndirectRelation<R, projected<I, Proj>> &&
 		(ForwardIterator<I> ||
-		 InputIterator<O> && Same<iter_value_t<I>, iter_value_t<O>> ||
+		 (InputIterator<O> && Same<iter_value_t<I>, iter_value_t<O>>) ||
 		 IndirectlyCopyableStorable<I, O>)
 	tagged_pair<tag::in(I), tag::out(O)>
 	unique_copy(I first, S last, O result, R comp = {},
@@ -114,7 +114,7 @@ STL2_OPEN_NAMESPACE {
 		IndirectlyCopyable<iterator_t<Rng>, O> &&
 		IndirectRelation<R, projected<iterator_t<Rng>, Proj>> &&
 		(ForwardIterator<iterator_t<Rng>> ||
-		 InputIterator<O> && Same<iter_value_t<iterator_t<Rng>>, iter_value_t<O>> ||
+		 (InputIterator<O> && Same<iter_value_t<iterator_t<Rng>>, iter_value_t<O>>) ||
 		 IndirectlyCopyableStorable<iterator_t<Rng>, O>)
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
 	unique_copy(Rng&& rng, O result, R comp = {}, Proj proj = {})

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -32,17 +32,18 @@ STL2_OPEN_NAMESPACE {
 	: meta::bool_<sizeof...(T) == 1> {};
 
 	template<class T, class U, class... Rest>
-	requires
-		CommonReference<T, U>
+	requires CommonReference<T, U>
 	struct __common_reference<T, U, Rest...>
 	: __common_reference<common_reference_t<T, U>, Rest...> {};
 
 	template<Readable... Is>
-	using __iter_args_lists =
+	using __iter_args_lists_ =
 		meta::push_back<
 			meta::cartesian_product<
 				meta::list<meta::list<iter_value_t<Is>&, iter_reference_t<Is>>...>>,
 			meta::list<iter_common_reference_t<Is>...>>;
+	template<class... Is>
+	using __iter_args_lists = __iter_args_lists_<Is...>;
 
 	template<typename MapFn, typename ReduceFn>
 	using __iter_map_reduce_fn =

--- a/include/stl2/detail/concepts/core.hpp
+++ b/include/stl2/detail/concepts/core.hpp
@@ -51,7 +51,10 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// Same
 	//
-#if defined(__GNUC__)
+#if defined(__clang__)
+	template<class T, class U>
+	STL2_CONCEPT _SameImpl = __is_same(T, U);
+#elif defined(__GNUC__)
 	template<class T, class U>
 	STL2_CONCEPT _SameImpl = __is_same_as(T, U);
 #else
@@ -75,7 +78,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T, class U>
 	STL2_CONCEPT DerivedFrom =
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
 		__is_base_of(U, T) &&
 #else
 		std::is_base_of_v<U, T> &&
@@ -87,7 +90,12 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class From, class To>
 	STL2_CONCEPT ConvertibleTo =
-		std::is_convertible_v<From, To> && requires(From (&f)()) {
+#if defined(__clang__) || defined(_MSC_VER)
+		__is_convertible_to(From, To) &&
+#else
+		std::is_convertible_v<From, To> &&
+#endif
+		requires(From (&f)()) {
 			static_cast<To>(f());
 		};
 		// Axiom: implicit and explicit conversion have equal results.

--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -60,6 +60,14 @@
  #endif
 #endif
 
+#ifndef STL2_WORKAROUND_CLANG_37556
+ #ifdef __clang__ // Workaround https://bugs.llvm.org/show_bug.cgi?id=37556
+  #define STL2_WORKAROUND_CLANG_37556 1
+ #else
+  #define STL2_WORKAROUND_CLANG_37556 0
+ #endif
+#endif
+
 #define STL2_OPEN_NAMESPACE \
 	namespace std { namespace experimental { namespace ranges { inline namespace v1
 #define STL2_CLOSE_NAMESPACE }}}

--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -95,12 +95,14 @@ namespace __stl2 = ::std::experimental::ranges;
 	noexcept(noexcept(__VA_ARGS__)) \
 	{ return __VA_ARGS__; }
 
+#define STL2_REQUIRES_RETURN(...) \
+	requires requires { __VA_ARGS__; } \
+	{ return (__VA_ARGS__); }
 
 #define STL2_NOEXCEPT_REQUIRES_RETURN(...) \
 	noexcept(noexcept(__VA_ARGS__)) \
 	requires requires { __VA_ARGS__; } \
-	{ return (__VA_ARGS__); } \
-
+	{ return (__VA_ARGS__); }
 
 #if STL2_CONSTEXPR_EXTENSIONS
  #define STL2_CONSTEXPR_EXT constexpr

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -130,7 +130,7 @@ STL2_OPEN_NAMESPACE {
 		template<class> struct reference_type {};
 		template<class C>
 		requires
-			requires(const C& c) { { c.read() } -> auto&&; }
+			requires(const C& c) { c.read(); requires __can_reference<decltype(c.read())>; }
 		struct reference_type<C> {
 			using type = decltype(declval<const C&>().read());
 		};
@@ -176,7 +176,7 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT Readable =
 			Cursor<C> &&
 			requires(const C& c) {
-				{ c.read() } -> auto&&;
+				c.read(); requires __can_reference<decltype(c.read())>;
 				typename reference_t<C>;
 				typename value_type_t<C>;
 			};
@@ -184,7 +184,7 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT Arrow =
 			Readable<C> &&
 			requires(const C& c) {
-				{ c.arrow() } -> auto&&;
+				c.arrow(); requires __can_reference<decltype(c.arrow())>;
 			};
 		template<class C, class T>
 		STL2_CONCEPT Writable =
@@ -228,7 +228,7 @@ STL2_OPEN_NAMESPACE {
 		template<class C>
 		STL2_CONCEPT IndirectMove =
 			Readable<C> && requires(const C& c) {
-				{ c.indirect_move() } -> auto&&;
+				c.indirect_move(); requires __can_reference<decltype(c.indirect_move())>;
 			};
 
 		template<class> struct rvalue_reference {};

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -136,7 +136,8 @@ STL2_OPEN_NAMESPACE {
 			{
 				return i1 == i2;
 			}
-			constexpr bool operator()(const auto& lhs, const auto& rhs) const
+			template<class T, class U>
+			constexpr bool operator()(const T& lhs, const U& rhs) const
 			STL2_NOEXCEPT_RETURN(
 				bool(lhs == rhs)
 			)
@@ -148,8 +149,9 @@ STL2_OPEN_NAMESPACE {
 		template<class I2, SizedSentinel<I2> I1,
 			SizedSentinel<I2> S1, SizedSentinel<I1> S2>
 		struct difference_visitor {
+			template<class T, class U>
 			constexpr iter_difference_t<I2> operator()(
-				const auto& lhs, const auto& rhs) const
+				const T& lhs, const U& rhs) const
 			STL2_NOEXCEPT_RETURN(
 				static_cast<iter_difference_t<I2>>(lhs - rhs)
 			)

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -210,7 +210,7 @@ STL2_OPEN_NAMESPACE {
 		}
 		decltype(auto) operator*() const
 		noexcept(noexcept(*std::declval<const I&>()))
-		requires detail::Dereferenceable<const I> {
+		requires __dereferenceable<const I> {
 			STL2_EXPECT(std::holds_alternative<I>(v_));
 			return *__stl2::__get_unchecked<I>(v_);
 		}

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -250,7 +250,8 @@ STL2_OPEN_NAMESPACE {
 	namespace __iter_swap {
 		// Poison pill for iter_swap. (See the detailed discussion at
 		// https://github.com/ericniebler/stl2/issues/139)
-		void iter_swap(auto, auto) = delete;
+		template<class T, class U>
+		void iter_swap(T, U) = delete;
 
 		template<class, class>
 		constexpr bool has_customization = false;

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -30,7 +30,7 @@
 // Iterator concepts [iterator.requirements]
 //
 STL2_OPEN_NAMESPACE {
-		template<class T>
+	template<class T>
 	using __with_reference = T&;
 	template<class T>
 	STL2_CONCEPT __can_reference = requires { typename __with_reference<T>; };
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 	STL2_CONCEPT __dereferenceable = requires(T& t) {
 		// { *t } -> __can_reference;
 		*t; typename __with_reference<decltype(*t)>;
-			};
+	};
 
 	///////////////////////////////////////////////////////////////////////////
 	// iter_reference_t [iterator.assoc]
@@ -637,16 +637,17 @@ STL2_OPEN_NAMESPACE {
 				requires DerivedFrom<typename I::iterator_category, std::input_iterator_tag> ||
 						 DerivedFrom<typename I::iterator_category, std::output_iterator_tag>;
 			};
+		template<class I>
+		STL2_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;
 	}
 } STL2_CLOSE_NAMESPACE
 
 namespace std {
-	template<::__stl2::Iterator Out>
+	template<::__stl2::ProbablySTL2Iterator Out>
 		// HACKHACK to avoid partial specialization after instantiation errors. Platform
 		// vendors can avoid this hack by fixing up stdlib headers to fwd declare these
 		// partial specializations in the same place that std::iterator_traits is first
 		// defined.
-		requires !::__stl2::detail::LooksLikeSTL1Iterator<Out>
 	struct iterator_traits<Out> {
 		using difference_type   = ::__stl2::iter_difference_t<Out>;
 		using value_type        = meta::_t<::__stl2::detail::value_type_with_a_default<Out>>;
@@ -655,15 +656,12 @@ namespace std {
 		using iterator_category = std::output_iterator_tag;
 	};
 
-	template<::__stl2::InputIterator In>
-	requires
-		!::__stl2::detail::LooksLikeSTL1Iterator<In>
+	template<::__stl2::ProbablySTL2Iterator In>
+	requires ::__stl2::InputIterator<In>
 	struct iterator_traits<In> { };
 
-	template<::__stl2::InputIterator In>
-	requires
-		!::__stl2::detail::LooksLikeSTL1Iterator<In> &&
-		::__stl2::Sentinel<In, In>
+	template<::__stl2::ProbablySTL2Iterator In>
+	requires ::__stl2::InputIterator<In> && ::__stl2::Sentinel<In, In>
 	struct iterator_traits<In> {
 		using difference_type   = ::__stl2::iter_difference_t<In>;
 		using value_type        = ::__stl2::iter_value_t<In>;

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -639,11 +639,11 @@ STL2_OPEN_NAMESPACE {
 			};
 		template<class I>
 		STL2_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;
-	}
+	} // namespace detail
 } STL2_CLOSE_NAMESPACE
 
 namespace std {
-	template<::__stl2::ProbablySTL2Iterator Out>
+	template<::__stl2::detail::ProbablySTL2Iterator Out>
 		// HACKHACK to avoid partial specialization after instantiation errors. Platform
 		// vendors can avoid this hack by fixing up stdlib headers to fwd declare these
 		// partial specializations in the same place that std::iterator_traits is first
@@ -656,11 +656,11 @@ namespace std {
 		using iterator_category = std::output_iterator_tag;
 	};
 
-	template<::__stl2::ProbablySTL2Iterator In>
+	template<::__stl2::detail::ProbablySTL2Iterator In>
 	requires ::__stl2::InputIterator<In>
 	struct iterator_traits<In> { };
 
-	template<::__stl2::ProbablySTL2Iterator In>
+	template<::__stl2::detail::ProbablySTL2Iterator In>
 	requires ::__stl2::InputIterator<In> && ::__stl2::Sentinel<In, In>
 	struct iterator_traits<In> {
 		using difference_type   = ::__stl2::iter_difference_t<In>;

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -156,12 +156,14 @@ STL2_OPEN_NAMESPACE {
 		const counted_iterator<I1>& x, const counted_iterator<I2>& y) noexcept {
 		return x.count() == y.count();
 	}
+	template<class I>
 	constexpr bool operator==(
-		const counted_iterator<auto>& x, default_sentinel) noexcept {
+		const counted_iterator<I>& x, default_sentinel) noexcept {
 		return x.count() == 0;
 	}
+	template<class I>
 	constexpr bool operator==(
-		default_sentinel, const counted_iterator<auto>& x) noexcept {
+		default_sentinel, const counted_iterator<I>& x) noexcept {
 		return x.count() == 0;
 	}
 	template<class I1, class I2>
@@ -170,12 +172,14 @@ STL2_OPEN_NAMESPACE {
 		const counted_iterator<I1>& x, const counted_iterator<I2>& y) noexcept {
 		return !(x == y);
 	}
+	template<class I>
 	constexpr bool operator!=(
-		const counted_iterator<auto>& x, default_sentinel y) noexcept {
+		const counted_iterator<I>& x, default_sentinel y) noexcept {
 		return !(x == y);
 	}
+	template<class I>
 	constexpr bool operator!=(
-		default_sentinel x, const counted_iterator<auto>& y) noexcept {
+		default_sentinel x, const counted_iterator<I>& y) noexcept {
 		return !(x == y);
 	}
 	template<class I1, class I2>
@@ -254,7 +258,8 @@ STL2_OPEN_NAMESPACE {
 			return i;
 		}
 
-		constexpr auto uncounted(const counted_iterator<auto>& i)
+		template<class I>
+		constexpr auto uncounted(const counted_iterator<I>& i)
 		STL2_NOEXCEPT_RETURN(
 			i.base()
 		)

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -67,7 +67,7 @@ STL2_OPEN_NAMESPACE {
 		}
 		decltype(auto) operator*() const
 		noexcept(noexcept(*std::declval<const I&>()))
-		requires detail::Dereferenceable<const I> {
+		requires __dereferenceable<const I> {
 			return *current();
 		}
 		constexpr counted_iterator& operator++() {

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -246,9 +246,11 @@ STL2_OPEN_NAMESPACE {
 
 	template<RandomAccessIterator I>
 	constexpr void advance(counted_iterator<I>& i, iter_difference_t<I> n)
-	STL2_NOEXCEPT_RETURN(
-		(STL2_EXPECT(n <= i.count()), i += n, void())
-	)
+	noexcept(noexcept(i += n))
+	{
+		STL2_EXPECT(n <= i.count());
+		i += n;
+	}
 
 	namespace ext {
 		template<Iterator I>

--- a/include/stl2/detail/iterator/dangling.hpp
+++ b/include/stl2/detail/iterator/dangling.hpp
@@ -21,10 +21,10 @@
 
 STL2_OPEN_NAMESPACE {
 	////////////////////////////////////////////////////////////////////////////
- 	// dangling
+	// dangling
 	// Not to spec: Kill it with fire.
 	//
- 	template<ext::CopyConstructibleObject T>
+	template<ext::CopyConstructibleObject T>
 	class dangling {
 		T value;
 	public:

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 				// Avoid gcc ICE (TODO file bug):
 				a - b;
 				requires Integral<decltype(a - b)>;
-			 	// { a - b } -> Integral;
+				// { a - b } -> Integral;
 			}
 	struct incrementable_traits<T>
 	: make_signed<decltype(declval<const T>() - declval<const T>())> {};

--- a/include/stl2/detail/iterator/istreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/istreambuf_iterator.hpp
@@ -127,8 +127,9 @@ STL2_OPEN_NAMESPACE {
 				// Yuck. This can't be simply "basic_iterator<cursor>".
 				// Since basic_iterator<cursor> derives from mixin, mixin must be
 				// instantiable before basic_iterator<cursor> is complete.
+				template<Same<cursor> C>
 				STL2_CONSTEXPR_EXT bool
-				equal(const basic_iterator<Same<cursor> >& that) const noexcept {
+				equal(const basic_iterator<C>& that) const noexcept {
 					return base_t::get().equal(__stl2::get_cursor(that));
 				}
 			};

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -141,26 +141,28 @@ STL2_OPEN_NAMESPACE {
 				current_ += n;
 			}
 
-			constexpr bool equal(
-				const cursor<EqualityComparableWith<I> >& that) const
+			template<EqualityComparableWith<I> I2>
+			constexpr bool equal(const cursor<I2>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::current(that)
 			)
 
-			constexpr bool equal(
-				const move_sentinel<Sentinel<I> >& that) const
+			template<Sentinel<I> S>
+			constexpr bool equal(const move_sentinel<S>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::sentinel(that)
 			)
 
+			template<SizedSentinel<I> S>
 			constexpr iter_difference_t<I>
-			distance_to(const cursor<SizedSentinel<I> >& that) const
+			distance_to(const cursor<S>& that) const
 			STL2_NOEXCEPT_RETURN(
 				access::current(that) - current_
 			)
 
+			template<SizedSentinel<I> S>
 			constexpr iter_difference_t<I>
-			distance_to(const move_sentinel<SizedSentinel<I> >& that) const
+			distance_to(const move_sentinel<S>& that) const
 			STL2_NOEXCEPT_RETURN(
 				access::sentinel(that) - current_
 			)
@@ -172,8 +174,8 @@ STL2_OPEN_NAMESPACE {
 			)
 
 			// Extension
-			constexpr void indirect_swap(
-				const cursor<IndirectlySwappable<I> >& that) const
+			template<IndirectlySwappable<I> I2>
+			constexpr void indirect_swap(const cursor<I2>& that) const
 			STL2_NOEXCEPT_RETURN(
 				__stl2::iter_swap(current_, access::current(that))
 			)

--- a/include/stl2/detail/iterator/reverse_iterator.hpp
+++ b/include/stl2/detail/iterator/reverse_iterator.hpp
@@ -103,14 +103,14 @@ STL2_OPEN_NAMESPACE {
 				current_ -= n;
 			}
 
-			constexpr bool equal(
-				const cursor<EqualityComparableWith<I> >& that) const
+			template<EqualityComparableWith<I> J>
+			constexpr bool equal(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::current(that)
 			)
 
-			constexpr iter_difference_t<I> distance_to(
-				const cursor<SizedSentinel<I> >& that) const
+			template<SizedSentinel<I> J>
+			constexpr iter_difference_t<I> distance_to(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				-(access::current(that) - current_)
 			)
@@ -122,8 +122,8 @@ STL2_OPEN_NAMESPACE {
 			)
 
 			// Extension
-			constexpr void indirect_swap(
-				const cursor<IndirectlySwappable<I> >& that) const
+			template<IndirectlySwappable<I> J>
+			constexpr void indirect_swap(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				__stl2::iter_swap(
 					__stl2::prev(current_), __stl2::prev(access::current(that)))

--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -275,8 +275,8 @@ STL2_OPEN_NAMESPACE {
 			constexpr reverse_iterator rend() const noexcept { return reverse_iterator{begin()}; }
 
 			// Extension for P0970
-			friend constexpr iterator begin(span&& s) noexcept { return s.begin(); }
-			friend constexpr iterator end(span&& s) noexcept { return s.end(); }
+			friend constexpr iterator begin(span s) noexcept { return s.begin(); }
+			friend constexpr iterator end(span s) noexcept { return s.end(); }
 
 			// [span.comparison], span comparison operators
 			template<EqualityComparableWith<ElementType> U, index_type UExtent>

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -137,6 +137,22 @@ STL2_OPEN_NAMESPACE {
 	template<class T, class U>
 	struct is_nothrow_swappable :
 		is_nothrow_swappable_t<T, U> {};
+
+	namespace detail {
+		template<_Is<std::is_class> Derived>
+		struct __member_swap {
+		private:
+			constexpr Derived& derived() noexcept {
+				return static_cast<Derived&>(*this);
+			}
+		public:
+			friend constexpr void swap(__member_swap& x, __member_swap& y)
+			STL2_NOEXCEPT_REQUIRES_RETURN(
+				x.derived().swap(y.derived())
+			)
+		};
+	}
+	using detail::__member_swap;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/tagged.hpp
+++ b/include/stl2/detail/tagged.hpp
@@ -97,7 +97,12 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<ext::DestructibleObject Base, TagSpecifier... Tags>
 	requires sizeof...(Tags) <= tuple_size<Base>::value
-	struct tagged : meta::_t<__tagged::chain<Base, 0, Tags...>>	{
+	struct tagged
+	: meta::_t<__tagged::chain<Base, 0, Tags...>>
+#if STL2_WORKAROUND_CLANG_37556
+	, private __member_swap<tagged<Base, Tags...>>
+#endif
+	{
 	private:
 		using base_t = meta::_t<__tagged::chain<Base, 0, Tags...>>;
 	public:
@@ -152,12 +157,12 @@ STL2_OPEN_NAMESPACE {
 			__stl2::swap(static_cast<Base&>(*this), static_cast<Base&>(that));
 		}
 
+#if !STL2_WORKAROUND_CLANG_37556
 		friend constexpr void swap(tagged& a, tagged& b)
-		noexcept(noexcept(a.swap(b)))
-		requires Swappable<Base>
-		{
-			a.swap(b);
-		}
+		STL2_NOEXCEPT_REQUIRES_RETURN(
+			a.swap(b)
+		)
+#endif
 	};
 
 	#define STL2_DEFINE_GETTER(name)                                                                \

--- a/include/stl2/detail/temporary_vector.hpp
+++ b/include/stl2/detail/temporary_vector.hpp
@@ -23,7 +23,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct temporary_buffer_deleter {
-			void operator()(auto* ptr) const {
+			template<class T>
+			void operator()(T* ptr) const {
 				std::return_temporary_buffer(ptr);
 			}
 		};

--- a/include/stl2/meta/meta.hpp
+++ b/include/stl2/meta/meta.hpp
@@ -578,23 +578,26 @@ namespace meta
         /// Compose the Invocables \p Fns in the parameter pack \p Ts.
         /// \ingroup composition
         template<Invocable... Fns>
-        struct compose
+        struct compose_
         {
         };
 
         template<Invocable Fn0>
-        struct compose<Fn0>
+        struct compose_<Fn0>
         {
             template<typename... Ts>
             using invoke = invoke<Fn0, Ts...>;
         };
 
         template<Invocable Fn0, Invocable... Fns>
-        struct compose<Fn0, Fns...>
+        struct compose_<Fn0, Fns...>
         {
             template<typename... Ts>
-            using invoke = invoke<Fn0, invoke<compose<Fns...>, Ts...>>;
+            using invoke = invoke<Fn0, invoke<compose_<Fns...>, Ts...>>;
         };
+
+        template<typename... Fns>
+        using compose = compose_<Fns...>;
 
         namespace lazy
         {
@@ -783,7 +786,10 @@ namespace meta
         /// result of applying Invocable `compose<Gs...>` to all the arguments.
         /// \ingroup composition
         template<Invocable... Fns>
-        using on = detail::on_<Fns...>;
+        using on_ = detail::on_<Fns...>;
+
+        template<typename... Fns>
+        using on = on_<Fns...>;
 
         namespace lazy
         {
@@ -897,13 +903,19 @@ namespace meta
         /// doing short-circuiting.
         /// \ingroup logical
         template<Integral... Bs>
-        using strict_and = and_c<_v<Bs>...>;
+        using strict_and_ = and_c<_v<Bs>...>;
+
+        template<typename... Bs>
+        using strict_and = strict_and_<Bs...>;
 
         /// Logically and together all the integral constant-wrapped Boolean parameters, \e with
         /// short-circuiting.
         /// \ingroup logical
         template<Integral... Bs>
-        using and_ = _t<detail::_and_<Bs...>>;
+        using _and_ = _t<detail::_and_<Bs...>>;
+
+        template<typename... Bs>
+        using and_ = _and_<Bs...>;
 
         /// Logically or together all the Boolean parameters
         /// \ingroup logical
@@ -914,13 +926,19 @@ namespace meta
         /// doing short-circuiting.
         /// \ingroup logical
         template<Integral... Bs>
-        using strict_or = or_c<_v<Bs>...>;
+        using strict_or_ = or_c<_v<Bs>...>;
+
+        template<typename... Bs>
+        using strict_or = strict_or_<Bs...>;
 
         /// Logically or together all the integral constant-wrapped Boolean parameters, \e with
         /// short-circuiting.
         /// \ingroup logical
         template<Integral... Bs>
-        using or_ = _t<detail::_or_<Bs...>>;
+        using _or_ = _t<detail::_or_<Bs...>>;
+
+        template<typename... Bs>
+        using or_ = _or_<Bs...>;
 
         namespace lazy
         {
@@ -1128,7 +1146,10 @@ namespace meta
         /// \f$ O(L) \f$ where \f$ L \f$ is the number of lists in the list of lists.
         /// \ingroup transformation
         template<List... Ls>
-        using concat = _t<detail::concat_<Ls...>>;
+        using concat_ = _t<detail::concat_<Ls...>>;
+
+        template<typename... Lists>
+        using concat = concat_<Lists...>;
 
         namespace lazy
         {
@@ -1471,12 +1492,18 @@ namespace meta
         /// An integral constant wrapper around the minimum of `Ts::type::value...`
         /// \ingroup math
         template<Integral... Ts>
-        using min = fold<pop_front<list<Ts...>>, front<list<Ts...>>, quote<detail::min_>>;
+        using min_ = fold<pop_front<list<Ts...>>, front<list<Ts...>>, quote<detail::min_>>;
+
+        template<typename... Ts>
+        using min = min_<Ts...>;
 
         /// An integral constant wrapper around the maximum of `Ts::type::value...`
         /// \ingroup math
         template<Integral... Ts>
-        using max = fold<pop_front<list<Ts...>>, front<list<Ts...>>, quote<detail::max_>>;
+        using max_ = fold<pop_front<list<Ts...>>, front<list<Ts...>>, quote<detail::max_>>;
+
+        template<typename... Ts>
+        using max = max_<Ts...>;
 
         namespace lazy
         {

--- a/include/stl2/meta/meta_fwd.hpp
+++ b/include/stl2/meta/meta_fwd.hpp
@@ -137,7 +137,7 @@ namespace meta
         struct id;
 
         template<Invocable... Fs>
-        struct compose;
+        struct compose_;
 
         namespace extension
         {

--- a/include/stl2/view/drop.hpp
+++ b/include/stl2/view/drop.hpp
@@ -101,7 +101,7 @@ STL2_OPEN_NAMESPACE {
 		struct __drop_fn : detail::__pipeable<__drop_fn> {
 			template<Range Rng>
 			constexpr auto operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::drop_view(all(std::forward<Rng>(rng)), count)
 			)
 

--- a/include/stl2/view/drop_while.hpp
+++ b/include/stl2/view/drop_while.hpp
@@ -81,7 +81,7 @@ STL2_OPEN_NAMESPACE {
 		struct __drop_while_fn : detail::__pipeable<__drop_while_fn> {
 			template<class Rng, class Pred>
 			constexpr auto operator()(Rng&& rng, Pred&& pred) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::drop_while_view{view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
 			)
 

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -68,7 +68,8 @@ STL2_OPEN_NAMESPACE {
 		{ return __iterator{*this, __stl2::end(base_)}; }
 	};
 
-	template<class V, class Pred>
+	template<InputRange V, IndirectUnaryPredicate<iterator_t<V>> Pred>
+	requires View<V>
 	class filter_view<V, Pred>::__iterator {
 	private:
 		iterator_t<V> current_ {};
@@ -155,7 +156,8 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.current_, y.current_); }
 	};
 
-	template<class V, class Pred>
+	template<InputRange V, IndirectUnaryPredicate<iterator_t<V>> Pred>
+	requires View<V>
 	class filter_view<V, Pred>::__sentinel {
 	private:
 		sentinel_t<V> end_;

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -187,7 +187,7 @@ STL2_OPEN_NAMESPACE {
 			template<InputRange R, IndirectUnaryPredicate<iterator_t<R>> Pred>
 			requires ViewableRange<R>
 			constexpr auto operator()(R&& rng, Pred pred) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				filter_view<all_view<R>, Pred>{std::forward<R>(rng), std::move(pred)}
 			)
 			template<CopyConstructible Pred>

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -118,8 +118,8 @@ STL2_OPEN_NAMESPACE {
 		struct __indirect_fn : detail::__pipeable<__indirect_fn> {
 			template<class Rng>
 			constexpr auto operator()(Rng&& rng) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
-				__stl2::ext::indirect_view(all(std::forward<Rng>(rng)))
+			STL2_REQUIRES_RETURN(
+				__stl2::ext::indirect_view{all(std::forward<Rng>(rng))}
 			)
 		};
 

--- a/include/stl2/view/iota.hpp
+++ b/include/stl2/view/iota.hpp
@@ -78,7 +78,8 @@ STL2_OPEN_NAMESPACE {
 		(!Integral<I> || !Integral<Bound> || std::is_signed_v<I> == std::is_signed_v<Bound>)
 	iota_view(I, Bound) -> iota_view<I, Bound>;
 
-	template<class I, class Bound>
+	template<WeaklyIncrementable I, Semiregular Bound>
+	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::iterator
 	: detail::iota_view_iterator_base<I> {
 	private:
@@ -171,7 +172,8 @@ STL2_OPEN_NAMESPACE {
 		{ return *x - *y; }
 	};
 
-	template<class I, class Bound>
+	template<WeaklyIncrementable I, Semiregular Bound>
+	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::sentinel {
 	private:
 		Bound bound_;

--- a/include/stl2/view/join.hpp
+++ b/include/stl2/view/join.hpp
@@ -123,7 +123,10 @@ STL2_OPEN_NAMESPACE {
 			View<iter_value_t<iterator_t<Rng>>>)
 	explicit join_view(Rng&&) -> join_view<all_view<Rng>>;
 
-	template<class Rng>
+	template<InputRange Rng>
+	requires View<Rng> && InputRange<iter_reference_t<iterator_t<Rng>>> &&
+		(std::is_reference_v<iter_reference_t<iterator_t<Rng>>> ||
+			View<iter_value_t<iterator_t<Rng>>>)
 	template<bool Const>
 	struct join_view<Rng>::__iterator
 	: detail::join_view_iterator_base<__maybe_const<Const, Rng>> {
@@ -260,7 +263,10 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.inner_, y.inner_); }
 	};
 
-	template<class Rng>
+	template<InputRange Rng>
+	requires View<Rng> && InputRange<iter_reference_t<iterator_t<Rng>>> &&
+		(std::is_reference_v<iter_reference_t<iterator_t<Rng>>> ||
+			View<iter_value_t<iterator_t<Rng>>>)
 	template<bool Const>
 	struct join_view<Rng>::__sentinel {
 	private:

--- a/include/stl2/view/ref.hpp
+++ b/include/stl2/view/ref.hpp
@@ -84,7 +84,7 @@ STL2_OPEN_NAMESPACE {
 		struct __ref_fn : detail::__pipeable<__ref_fn> {
 			template<class R>
 			auto operator()(R&& rng) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::ref_view(std::forward<R>(rng))
 			)
 		};

--- a/include/stl2/view/repeat.hpp
+++ b/include/stl2/view/repeat.hpp
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 		struct __repeat_fn {
 			template<class T>
 			constexpr auto operator()(T&& t) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::repeat_view{static_cast<T&&>(t)}
 			)
 		};

--- a/include/stl2/view/repeat_n.hpp
+++ b/include/stl2/view/repeat_n.hpp
@@ -25,12 +25,16 @@ STL2_OPEN_NAMESPACE {
 
 	namespace view::ext {
 		struct __repeat_n_fn {
+		private:
+		template<class T> using V = __stl2::ext::repeat_n_view<__uncvref<T>>;
+		public:
 			template<class T>
 			constexpr auto operator()(T&& t, std::ptrdiff_t const n) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
-				STL2_EXPECT(n >= 0),
-				__stl2::ext::repeat_n_view<__uncvref<T>>{repeat(static_cast<T&&>(t)), n}
-			)
+			noexcept(noexcept(V<T>{repeat(static_cast<T&&>(t)), n}))
+			requires requires { V<T>{repeat(static_cast<T&&>(t)), n}; } {
+				STL2_EXPECT(n >= 0);
+				return V<T>{repeat(static_cast<T&&>(t)), n};
+			}
 		};
 
 		inline constexpr __repeat_n_fn repeat_n {};

--- a/include/stl2/view/single.hpp
+++ b/include/stl2/view/single.hpp
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 		struct __single_fn {
 			template<class T>
 			constexpr auto operator()(T&& t) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				single_view{std::forward<T>(t)}
 			)
 		};

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -318,11 +318,8 @@ STL2_OPEN_NAMESPACE {
 	namespace view {
 		struct __split_fn {
 			template<class E, class F>
-			requires requires(E&& e, F&& f) {
-				split_view{static_cast<E&&>(e), static_cast<F&&>(f)};
-			}
 			constexpr auto operator()(E&& e, F&& f) const
-			STL2_NOEXCEPT_RETURN(
+			STL2_REQUIRES_RETURN(
 				split_view{static_cast<E&&>(e), static_cast<F&&>(f)}
 			)
 

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -116,7 +116,10 @@ STL2_OPEN_NAMESPACE {
 		iterator_t<__maybe_const<Const, Rng>> current_ {};
 	};
 
-	template<class Rng, class Pattern>
+	template<InputRange Rng, ForwardRange Pattern>
+	requires View<Rng> && View<Pattern> &&
+		IndirectlyComparable<iterator_t<Rng>, iterator_t<Pattern>, equal_to> &&
+		(ForwardRange<Rng> || _TinyRange<Pattern>)
 	template<bool Const>
 	struct split_view<Rng, Pattern>::__outer_iterator
 	: private __split_view_outer_base<Rng, Const> {
@@ -211,7 +214,10 @@ STL2_OPEN_NAMESPACE {
 		{ return !(y == x);	}
 	};
 
-	template<class Rng, class Pattern>
+	template<InputRange Rng, ForwardRange Pattern>
+	requires View<Rng> && View<Pattern> &&
+		IndirectlyComparable<iterator_t<Rng>, iterator_t<Pattern>, equal_to> &&
+		(ForwardRange<Rng> || _TinyRange<Pattern>)
 	template<bool Const>
 	struct split_view<Rng, Pattern>::__outer_iterator<Const>::value_type {
 	private:
@@ -228,7 +234,10 @@ STL2_OPEN_NAMESPACE {
 		{ return default_sentinel{}; }
 	};
 
-	template<class Rng, class Pattern>
+	template<InputRange Rng, ForwardRange Pattern>
+	requires View<Rng> && View<Pattern> &&
+		IndirectlyComparable<iterator_t<Rng>, iterator_t<Pattern>, equal_to> &&
+		(ForwardRange<Rng> || _TinyRange<Pattern>)
 	template<bool Const>
 	struct split_view<Rng, Pattern>::__inner_iterator {
 	private:

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 	template<Range R>
 	take_view(R&&, iter_difference_t<iterator_t<R>>) -> take_view<all_view<R>>;
 
-	template<class R>
+	template<View R>
 	template<bool Const>
 	struct take_view<R>::__sentinel {
 	private:

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -121,7 +121,7 @@ STL2_OPEN_NAMESPACE {
 		struct __take_fn {
 			template<Range Rng>
 			constexpr auto operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				take_view{view::all(static_cast<Rng&&>(rng)), count}
 			)
 

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -107,14 +107,14 @@ STL2_OPEN_NAMESPACE {
 		struct __take_exactly_fn : detail::__pipeable<__take_exactly_fn> {
 			template<class V>
 			auto operator()(V&& view, iter_difference_t<iterator_t<V>> const n) const
-			STL2_NOEXCEPT_REQUIRES_RETURN
-			(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::take_exactly_view(all(std::forward<V>(view)), n)
 			)
 
 			template<Integral D>
-			constexpr auto operator()(D count) const
-			{ return detail::view_closure(*this, static_cast<D>(count)); }
+			constexpr auto operator()(D count) const {
+				return detail::view_closure(*this, static_cast<D>(count));
+			}
 		};
 
 		inline constexpr __take_exactly_fn take_exactly {};

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -105,7 +105,7 @@ STL2_OPEN_NAMESPACE {
 		struct __take_while_fn : detail::__pipeable<__take_while_fn> {
 			template<class Rng, class Pred>
 			constexpr auto operator()(Rng&& rng, Pred&& pred) const
-			STL2_NOEXCEPT_REQUIRES_RETURN(
+			STL2_REQUIRES_RETURN(
 				__stl2::ext::take_while_view{view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
 			)
 

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -72,7 +72,9 @@ STL2_OPEN_NAMESPACE {
 		template<class R, class Pred>
 		take_while_view(R&&, Pred) -> take_while_view<all_view<R>, Pred>;
 
-		template<class R, class Pred>
+		template<View R, class Pred>
+		requires InputRange<R> && std::is_object_v<Pred> &&
+			IndirectUnaryPredicate<const Pred, iterator_t<R>>
 		template<bool Const>
 		class take_while_view<R, Pred>::__sentinel {
 			friend __sentinel<false>;

--- a/include/stl2/view/transform.hpp
+++ b/include/stl2/view/transform.hpp
@@ -91,7 +91,8 @@ STL2_OPEN_NAMESPACE {
 	template<class R, class F>
 	transform_view(R&& r, F fun) -> transform_view<all_view<R>, F>;
 
-	template<class R, class F>
+	template<InputRange R, CopyConstructible F>
+	requires View<R> && Invocable<F&, iter_reference_t<iterator_t<R>>>
 	template<bool Const>
 	class transform_view<R, F>::__iterator {
 	private:
@@ -217,7 +218,8 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.current_, y.current_); }
 	};
 
-	template<class R, class F>
+	template<InputRange R, CopyConstructible F>
+	requires View<R> && Invocable<F&, iter_reference_t<iterator_t<R>>>
 	template<bool Const>
 	class transform_view<R, F>::__sentinel {
 	private:

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -695,8 +695,8 @@ namespace libstdcpp_tests
 	}
 
 	#define COMMON_TYPE_TEST_2_IMPL(type1, type2, type3, uid) \
-		typedef common_type<type1, type2>::type  	JOIN(JOIN(test, uid),_t1); \
-		typedef common_type<type2, type1>::type  	JOIN(JOIN(test, uid),_t2); \
+		typedef common_type<type1, type2>::type JOIN(JOIN(test, uid),_t1); \
+		typedef common_type<type2, type1>::type JOIN(JOIN(test, uid),_t2); \
 		CHECK( (is_same<JOIN(JOIN(test, uid),_t1), type3>::value) ); \
 		CHECK( (is_same<JOIN(JOIN(test, uid),_t2), type3>::value) )
 

--- a/test/concepts/core.cpp
+++ b/test/concepts/core.cpp
@@ -106,12 +106,14 @@ result f(A) {
 	return result::exact;
 }
 
-result f(__stl2::ConvertibleTo<A>) {
+template<__stl2::ConvertibleTo<A> T>
+result f(T) {
 	std::cout << "Convertible to A\n";
 	return result::convertible;
 }
 
-result f(auto) {
+template<class T>
+result f(T) {
 	std::cout << "Nothing to do with A\n";
 	return result::unrelated;
 }

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -354,10 +354,11 @@ void test_fl() {
 	static_assert(ranges::ForwardRange<Rng>);
 	static_assert(ranges::Common<S, I>);
 	static_assert(ranges::Same<ranges::common_type_t<S, I>, I>);
-	// TODO replace with view::common:
-	// static_assert(ranges::Same<
-	// 	ranges::subrange<I, I>,
-	// 	decltype(ranges::ext::make_common_range(list.begin(), list.end()))>);
+#if 0 // TODO replace with view::common:
+	static_assert(ranges::Same<
+		ranges::subrange<I, I>,
+		decltype(ranges::ext::make_common_range(list.begin(), list.end()))>);
+#endif
 	std::cout << list << '\n';
 	*ranges::front_inserter(list) = 3.14;
 	std::cout << list << '\n';

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -323,6 +323,7 @@ void test_copy() {
 			A(int i) : value{i} {}
 			A(const A& that) :
 				value{that.value} {}
+			A& operator=(const A&) = default;
 		};
 		A a[] = {0,1,2,3}, b[] = {4,5,6,7};
 		CHECK(!copy(ranges::begin(a) + 1, ranges::end(a) - 1, ranges::begin(b) + 1));
@@ -409,8 +410,7 @@ void test_iter_swap2() {
 template<class T>
 constexpr bool has_category = false;
 template<class T>
-requires
-	requires { typename T::iterator_category; }
+requires requires { typename T::iterator_category; }
 constexpr bool has_category<T> = true;
 
 void test_std_traits() {

--- a/test/iterator/unreachable.cpp
+++ b/test/iterator/unreachable.cpp
@@ -13,24 +13,6 @@
 #include <algorithm>
 #include "../simple_test.hpp"
 
-// Believe it or not, this generates reasonable code:
-// _Z11strlen_testPKc:
-// .LFB9467:
-// 	.cfi_startproc
-// 	cmpb	$0, (%rdi)
-// 	movq	%rdi, %rax
-// 	je	.L4
-// 	.p2align 4,,10
-// 	.p2align 3
-// .L5:
-// 	addq	$1, %rax
-// 	cmpb	$0, (%rax)
-// 	jne	.L5
-// .L4:
-// 	subq	%rdi, %rax
-// 	ret
-// 	.cfi_endproc
-
 int strlen_test(const char* p) noexcept {
 	using C = __stl2::common_iterator<const char*, __stl2::unreachable>;
 	return __stl2::distance(C{p}, std::find(C{p}, C{__stl2::unreachable{}}, '\0'));

--- a/test/view/common_view.cpp
+++ b/test/view/common_view.cpp
@@ -38,5 +38,5 @@ int main() {
 		static_assert(!BidirectionalRange<decltype(x)>);
 		static_assert(Same<decltype(x), decltype(view::common(x))>);
 	}
- 	return test_result();
+	return test_result();
 }

--- a/test/view/counted_view.cpp
+++ b/test/view/counted_view.cpp
@@ -36,5 +36,5 @@ int main() {
 		static_assert(ForwardRange<decltype(x)>);
 		static_assert(!BidirectionalRange<decltype(x)>);
 	}
- 	return test_result();
+	return test_result();
 }

--- a/test/view/drop_view.cpp
+++ b/test/view/drop_view.cpp
@@ -75,16 +75,16 @@ int main()
 		CHECK(*(b+1) == 21);
 	}
 
-	// Test DISABLED while view::take(n) | view::reverse isn't possible.
-	// {
-	// 	auto rng = view::iota(10) | view::drop(10) | view::take(10) | view::reverse;
-	// 	static_assert(ranges::View<decltype(rng)>);
-	// 	static_assert(ranges::SizedRange<decltype(rng)>);
-	// 	static_assert(!ranges::is_infinite<decltype(rng5)>::value, "");
-	// 	CHECK_EQUAL(rng, {29, 28, 27, 26, 25, 24, 23, 22, 21, 20});
-	// 	CHECK(ranges::size(rng) == 10u);
-	// }
-
+#if 0 // Test DISABLED while view::take(n) | view::reverse isn't possible.
+	{
+		auto rng = view::iota(10) | view::drop(10) | view::take(10) | view::reverse;
+		static_assert(ranges::View<decltype(rng)>);
+		static_assert(ranges::SizedRange<decltype(rng)>);
+		static_assert(!ranges::is_infinite<decltype(rng5)>::value, "");
+		CHECK_EQUAL(rng, {29, 28, 27, 26, 25, 24, 23, 22, 21, 20});
+		CHECK(ranges::size(rng) == 10u);
+	}
+#endif
 	{
 		// consolation for the above not being possible
 		auto rng = view::iota(10) | view::drop(10) | view::take(10);
@@ -102,52 +102,53 @@ int main()
 		CHECK(ranges::size(rng2) == 0u);
 	}
 
-	// Test DISABLED until view::chunk becomes available.
-	// {
-	// 	// Regression test for https://github.com/ericniebler/range-v3/issues/413
-	// 	auto skips = [](std::vector<int> xs) -> std::vector<std::vector<int>> {
-	// 		return view::iota(0, (int)xs.size())
-	// 			  | view::transform([&](int n) {
-	// 					 return xs | view::chunk(n + 1)
-	// 								  | view::transform(view::drop(n))
-	// 								  | view::join;
-	// 				 });
-	// 	};
-	// 	auto skipped = skips({1,2,3,4,5,6,7,8});
-	// 	CHECK(skipped.size() == 8u);
-	// 	if(skipped.size() >= 8u)
-	// 	{
-	// 		CHECK_EQUAL(skipped[0], {1,2,3,4,5,6,7,8});
-	// 		CHECK_EQUAL(skipped[1], {2,4,6,8});
-	// 		CHECK_EQUAL(skipped[2], {3,6});
-	// 		CHECK_EQUAL(skipped[3], {4,8});
-	// 		CHECK_EQUAL(skipped[4], {5});
-	// 		CHECK_EQUAL(skipped[5], {6});
-	// 		CHECK_EQUAL(skipped[6], {7});
-	// 		CHECK_EQUAL(skipped[7], {8});
-	// 	}
-	// }
+#if 0 // Test DISABLED pending view implementations.
+	{
+		// Regression test for https://github.com/ericniebler/range-v3/issues/413
+		auto skips = [](std::vector<int> xs) -> std::vector<std::vector<int>> {
+			return view::iota(0, (int)xs.size())
+				  | view::transform([&](int n) {
+						 return xs | view::chunk(n + 1)
+									  | view::transform(view::drop(n))
+									  | view::join;
+					 });
+		};
+		auto skipped = skips({1,2,3,4,5,6,7,8});
+		CHECK(skipped.size() == 8u);
+		if(skipped.size() >= 8u)
+		{
+			CHECK_EQUAL(skipped[0], {1,2,3,4,5,6,7,8});
+			CHECK_EQUAL(skipped[1], {2,4,6,8});
+			CHECK_EQUAL(skipped[2], {3,6});
+			CHECK_EQUAL(skipped[3], {4,8});
+			CHECK_EQUAL(skipped[4], {5});
+			CHECK_EQUAL(skipped[5], {6});
+			CHECK_EQUAL(skipped[6], {7});
+			CHECK_EQUAL(skipped[7], {8});
+		}
+	}
 
-	// {
-	// 	static int const some_ints[] = {0,1,2,3};
-	// 	auto rng = debug_input_view<int const>{some_ints} | view::drop(2);
-	// 	using R = decltype(rng);
-	// 	CONCEPT_ASSERT(InputView<R>());
-	// 	CONCEPT_ASSERT(!ForwardRange<R>());
-	// 	CONCEPT_ASSERT(Same<int const&, ranges::iter_reference_t<R>>());
-	// 	CHECK_EQUAL(rng, {2,3});
-	// }
+	{
+		static int const some_ints[] = {0,1,2,3};
+		auto rng = debug_input_view<int const>{some_ints} | view::drop(2);
+		using R = decltype(rng);
+		CONCEPT_ASSERT(InputView<R>());
+		CONCEPT_ASSERT(!ForwardRange<R>());
+		CONCEPT_ASSERT(Same<int const&, ranges::iter_reference_t<R>>());
+		CHECK_EQUAL(rng, {2,3});
+	}
 
-	// {
-	// 	// regression test for ericniebler/range-v3#728
-	// 	auto rng1 = view::iota(1) | view::chunk(6) | view::take(3);
-	// 	int i = 2;
-	// 	for (auto o1 : rng1) {
-	// 		auto rng2 = o1 | view::drop(1);
-	// 		CHECK_EQUAL(rng2, {i, i+1, i+2, i+3, i+4});
-	// 		i += 6;
-	// 	}
-	// }
+	{
+		// regression test for ericniebler/range-v3#728
+		auto rng1 = view::iota(1) | view::chunk(6) | view::take(3);
+		int i = 2;
+		for (auto o1 : rng1) {
+			auto rng2 = o1 | view::drop(1);
+			CHECK_EQUAL(rng2, {i, i+1, i+2, i+3, i+4});
+			i += 6;
+		}
+	}
+#endif
 
 	{
 		// regression test for ericniebler/range-v3#813

--- a/test/view/indirect_view.cpp
+++ b/test/view/indirect_view.cpp
@@ -26,19 +26,21 @@ int main()
 	CHECK(&*begin(rng) == vp[0].get());
 	CHECK_EQUAL(rng, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-	// {
-	// 	int const some_ints[] = {0,1,2,3};
-	// 	int const *some_int_pointers[] = {
-	// 		some_ints + 0, some_ints + 1, some_ints + 2, some_ints + 3
-	// 	};
-	// 	auto make_range = [&]{
-	// 		return debug_input_view<int const *>{some_int_pointers} | view::indirect;
-	// 	};
-	// 	auto rng = make_range();
-	// 	CHECK_EQUAL(rng, some_ints);
-	// 	rng = make_range();
-	// 	CHECK(&*begin(rng) == some_ints + 0);
-	// }
+#if 0
+	{
+		int const some_ints[] = {0,1,2,3};
+		int const *some_int_pointers[] = {
+			some_ints + 0, some_ints + 1, some_ints + 2, some_ints + 3
+		};
+		auto make_range = [&]{
+			return debug_input_view<int const *>{some_int_pointers} | view::indirect;
+		};
+		auto rng = make_range();
+		CHECK_EQUAL(rng, some_ints);
+		rng = make_range();
+		CHECK(&*begin(rng) == some_ints + 0);
+	}
+#endif
 
 	return ::test_result();
 }

--- a/test/view/reverse_view.cpp
+++ b/test/view/reverse_view.cpp
@@ -39,5 +39,5 @@ int main() {
 		static_assert(BidirectionalRange<decltype(x)>);
 		static_assert(!RandomAccessRange<decltype(x)>);
 	}
- 	return test_result();
+	return test_result();
 }

--- a/test/view/take_while_view.cpp
+++ b/test/view/take_while_view.cpp
@@ -36,19 +36,16 @@ int main()
 	static_assert(ranges::RandomAccessRange<decltype(rng1)>);
 	CHECK_EQUAL(rng1, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-	/////////////////////////////////////////////////////////////////////////////////////////////////
-	//																															  //
-	// 								DISABLED until generate is migrated to cmcstl2.							  //
-	//																															  //
-	/////////////////////////////////////////////////////////////////////////////////////////////////
-	// {
-	// 	auto ns = view::generate([]() mutable {
-	// 		static int N;
-	// 		return ++N;
-	// 	});
-	// 	auto rng = ns | view::take_while([](int i) { return i < 5; });
-	// 	CHECK_EQUAL(rng, {1,2,3,4});
-	// }
+#if 0 // DISABLED until generate is migrated to cmcstl2.
+	{
+		auto ns = view::generate([]() mutable {
+			static int N;
+			return ++N;
+		});
+		auto rng = ns | view::take_while([](int i) { return i < 5; });
+		CHECK_EQUAL(rng, {1,2,3,4});
+	}
+#endif
 
 	return ::test_result();
 }


### PR DESCRIPTION
Mostly "bugs" in cmcstl2 where it doesn't agree with C++20 concepts, with a couple of commits to get GCC trunk working. And a workaround for [LLVM#37556](https://bugs.llvm.org/show_bug.cgi?id=37556) for `tagged`.