### PR TITLE
fixes for begin/end/cbegin/cend/cdata and subrange/ref_view/iota_view

### DIFF
--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T> void end(T&&) = delete;
 
 		template<class T>
-		void end(std::initializer_list<T>) = delete;
+		void end(std::initializer_list<T>) = delete; // TODO: file LWG issue
 
 		template<class R>
 		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -26,6 +26,17 @@
 // Range access [range.access]
 //
 STL2_OPEN_NAMESPACE {
+	inline constexpr struct __as_const_fn {
+		template<class T>
+		constexpr const T& operator()(T& t) const noexcept {
+			return t;
+		}
+		template<class T>
+		constexpr const T&& operator()(T&& t) const noexcept {
+			return (T&&)t;
+		}
+	} __as_const {};
+
 	// begin
 	namespace __begin {
 		// Poison pill for std::begin. (See the detailed discussion at
@@ -33,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T> void begin(T&&) = delete;
 
 		template<class T>
-		void begin(std::initializer_list<T>&&) = delete;
+		void begin(std::initializer_list<T>) = delete;
 
 		template<class R>
 		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
@@ -69,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 			// Handle basic_string_view directly to implement P0970 non-intrusively
 			template<class CharT, class Traits>
 			constexpr auto operator()(
-				const std::basic_string_view<CharT, Traits>& sv) const noexcept {
+				std::basic_string_view<CharT, Traits> sv) const noexcept {
 				return sv.begin();
 			}
 
@@ -98,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T> void end(T&&) = delete;
 
 		template<class T>
-		void end(std::initializer_list<T>&&) = delete;
+		void end(std::initializer_list<T>) = delete;
 
 		template<class R>
 		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
@@ -136,17 +147,9 @@ STL2_OPEN_NAMESPACE {
 			// Handle basic_string_view directly to implement P0970 non-intrusively
 			template<class CharT, class Traits>
 			constexpr auto operator()(
-				const std::basic_string_view<CharT, Traits>& sv) const noexcept {
+				std::basic_string_view<CharT, Traits> sv) const noexcept {
 				return sv.end();
 			}
-
-			// Prefer member if it returns Sentinel.
-			template<class R>
-			requires has_member<R&>
-			constexpr auto operator()(R& r) const
-			STL2_NOEXCEPT_RETURN(
-				r.end()
-			)
 
 			// Use ADL if it returns Sentinel.
 			template<class R>
@@ -169,14 +172,9 @@ STL2_OPEN_NAMESPACE {
 	// cbegin
 	struct __cbegin_fn {
 		template<class R>
-		constexpr auto operator()(const R& r) const
+		constexpr auto operator()(R&& r) const
 		STL2_NOEXCEPT_REQUIRES_RETURN(
-			begin(r)
-		)
-		template<class R>
-		constexpr auto operator()(const R&& r) const
-		STL2_NOEXCEPT_REQUIRES_RETURN(
-			begin(static_cast<const R&&>(r))
+			begin(__as_const((R&&)r))
 		)
 	};
 	inline namespace __cpos {
@@ -186,14 +184,9 @@ STL2_OPEN_NAMESPACE {
 	// cend
 	struct __cend_fn {
 		template<class R>
-		constexpr auto operator()(const R& r) const
+		constexpr auto operator()(R&& r) const
 		STL2_NOEXCEPT_REQUIRES_RETURN(
-			end(r)
-		)
-		template<class R>
-		constexpr auto operator()(const R&& r) const
-		STL2_NOEXCEPT_REQUIRES_RETURN(
-			end(static_cast<const R&&>(r))
+			end(__as_const((R&&)r))
 		)
 	};
 	inline namespace __cpos {
@@ -322,14 +315,9 @@ STL2_OPEN_NAMESPACE {
 	// crbegin
 	struct __crbegin_fn {
 		template<class R>
-		constexpr auto operator()(const R& r) const
+		constexpr auto operator()(R&& r) const
 		STL2_NOEXCEPT_REQUIRES_RETURN(
-			rbegin(r)
-		)
-		template<class R>
-		constexpr auto operator()(const R&& r) const
-		STL2_NOEXCEPT_REQUIRES_RETURN(
-			rbegin(static_cast<const R&&>(r))
+			rbegin(__as_const((R&&)r))
 		)
 	};
 	inline namespace __cpos {
@@ -339,14 +327,9 @@ STL2_OPEN_NAMESPACE {
 	// crend
 	struct __crend_fn {
 		template<class R>
-		constexpr auto operator()(const R& r) const
+		constexpr auto operator()(R&& r) const
 		STL2_NOEXCEPT_REQUIRES_RETURN(
-			rend(r)
-		)
-		template<class R>
-		constexpr auto operator()(const R&& r) const
-		STL2_NOEXCEPT_REQUIRES_RETURN(
-			rend(static_cast<const R&&>(r))
+			rend(__as_const((R&&)r))
 		)
 	};
 	inline namespace __cpos {
@@ -544,15 +527,9 @@ STL2_OPEN_NAMESPACE {
 	// cdata
 	struct __cdata_fn {
 		template<class R>
-		constexpr auto operator()(const R& r) const
+		constexpr auto operator()(R&& r) const
 		STL2_NOEXCEPT_REQUIRES_RETURN(
-			data(r)
-		)
-
-		template<class R>
-		constexpr auto operator()(const R&& r) const
-		STL2_NOEXCEPT_REQUIRES_RETURN(
-			data(static_cast<R&&>(r))
+			data(__as_const((R&&)r))
 		)
 	};
 	inline namespace __cpos {

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -151,7 +151,6 @@ STL2_OPEN_NAMESPACE {
 				return sv.end();
 			}
 
-			// Use ADL if it returns Sentinel.
 			template<class R>
 			requires has_member<R> || has_non_member<R>
 			constexpr auto operator()(R&& r) const {

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T> void begin(T&&) = delete;
 
 		template<class T>
-		void begin(std::initializer_list<T>) = delete;
+		void begin(std::initializer_list<T>) = delete; // TODO: file LWG issue
 
 		template<class R>
 		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&

--- a/include/stl2/view/ref.hpp
+++ b/include/stl2/view/ref.hpp
@@ -32,7 +32,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __ref_view_detail {
 		struct __adl_hook {};
 
-		// Not to spec (yet);
+		// Not to spec: should be hidden friends.
 		template<class R>
 		constexpr iterator_t<R> begin(ref_view<R> r) {
 			return r.begin();

--- a/include/stl2/view/ref.hpp
+++ b/include/stl2/view/ref.hpp
@@ -24,10 +24,30 @@
 
 STL2_OPEN_NAMESPACE {
 	// ref_view [ranges.view.ref]
-	// Not an extension: P1252 makes this user-visible
 	template<Range R>
 	requires std::is_object_v<R>
-	struct ref_view : view_interface<ref_view<R>> {
+	struct ref_view;
+
+	// Not an extension: P1252 makes this user-visible
+	namespace __ref_view_detail {
+		struct __adl_hook {};
+
+		// Not to spec (yet);
+		template<class R>
+		constexpr iterator_t<R> begin(ref_view<R> r) {
+			return r.begin();
+		}
+		template<class R>
+		constexpr sentinel_t<R> end(ref_view<R> r) {
+			return r.end();
+		}
+	}
+
+	template<Range R>
+	requires std::is_object_v<R>
+	struct ref_view
+	: private __ref_view_detail::__adl_hook
+	, view_interface<ref_view<R>> {
 	private:
 		R* r_ = nullptr;
 
@@ -62,9 +82,6 @@ STL2_OPEN_NAMESPACE {
 		constexpr auto data() const requires ContiguousRange<R> {
 			return __stl2::data(*r_);
 		}
-
-		friend constexpr iterator_t<R> begin(ref_view r) { return r.begin(); }
-		friend constexpr sentinel_t<R> end(ref_view r) { return r.end(); }
 	};
 
 	// This deduction guide is the P/R for LWG 3173

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -76,12 +76,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Not to spec: these should be hidden friends
 		template<class I, class S, subrange_kind K>
-		constexpr I begin(subrange<I, S, K>&& r)
+		constexpr I begin(subrange<I, S, K> r)
 		noexcept(std::is_nothrow_copy_constructible_v<I>) {
 			return r.begin();
 		}
 		template<class I, class S, subrange_kind K>
-		constexpr S end(subrange<I, S, K>&& r)
+		constexpr S end(subrange<I, S, K> r)
 		noexcept(std::is_nothrow_copy_constructible_v<S>) {
 			return r.end();
 		}

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -12,8 +12,12 @@
 //
 #include <stl2/iterator.hpp>
 #include <stl2/detail/algorithm/find.hpp>
+#include <stl2/view/subrange.hpp>
+#include <stl2/view/ref.hpp>
+#include <stl2/view/iota.hpp>
 #include <iostream>
 #include <vector>
+#include <utility>
 #include "simple_test.hpp"
 
 namespace ranges = __stl2;
@@ -77,6 +81,12 @@ namespace begin_testing {
 			ranges::begin((R&&)r);
 		};
 
+	template<class R>
+	STL2_CONCEPT CanCBegin =
+		requires(R&& r) {
+			ranges::cbegin((R&&)r);
+		};
+
 	struct A {
 		int* begin();
 		int* end();
@@ -93,6 +103,11 @@ namespace begin_testing {
 	struct D : A {};
 	char* begin(D&);
 
+	struct S {
+		friend int* begin(S&&);
+		friend int* end(S&&);
+	};
+
 	void test() {
 		// Valid
 		static_assert(CanBegin<int(&)[2]>);
@@ -100,30 +115,46 @@ namespace begin_testing {
 		static_assert(CanBegin<const int(&)[2]>);
 		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const int(&)[2]>())), const int*>);
 
+		static_assert(CanCBegin<int(&)[2]>);
+		static_assert(ranges::Same<decltype(ranges::cbegin(std::declval<int(&)[2]>())), const int*>);
+		static_assert(CanCBegin<const int(&)[2]>);
+		static_assert(ranges::Same<decltype(ranges::cbegin(std::declval<const int(&)[2]>())), const int*>);
+
 		// Ill-formed: array rvalue
 		static_assert(!CanBegin<int(&&)[2]>);
+		static_assert(!CanBegin<const int(&&)[2]>);
+
+		static_assert(!CanCBegin<int(&&)[2]>);
+		static_assert(!CanCBegin<const int(&&)[2]>);
 
 		// Valid: only member begin
 		static_assert(CanBegin<A&>);
 		static_assert(!CanBegin<A>);
 		static_assert(ranges::Same<decltype(ranges::begin(std::declval<A&>())), int*>);
 		static_assert(CanBegin<const A&>);
+		static_assert(!CanBegin<const A>);
 		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const A&>())), const int*>);
 
 		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
 		static_assert(CanBegin<B&>);
+		static_assert(!CanBegin<B>);
 		static_assert(ranges::Same<decltype(ranges::begin(std::declval<B&>())), int*>);
 		static_assert(CanBegin<const B&>);
+		static_assert(!CanBegin<const B>);
 		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const B&>())), const int*>);
 
 		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
 		static_assert(CanBegin<C&>);
+		static_assert(!CanBegin<C>);
 		static_assert(CanBegin<const C&>);
+		static_assert(!CanBegin<const C>);
 
 		// Valid: Prefer member begin
 		static_assert(CanBegin<D&>);
+		static_assert(!CanBegin<D>);
 		static_assert(ranges::Same<int*, decltype(ranges::begin(std::declval<D&>()))>);
 		static_assert(CanBegin<const D&>);
+		static_assert(!CanBegin<const D>);
 		static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<const D&>()))>);
 
 		{
@@ -131,10 +162,39 @@ namespace begin_testing {
 			// Valid: begin accepts lvalue initializer_list
 			static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<T&>()))>);
 			static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<const T&>()))>);
+			static_assert(!CanBegin<std::initializer_list<int>>);
+			static_assert(!CanBegin<const std::initializer_list<int>>);
 		}
 
 		static_assert(CanBegin<ranges::subrange<int*, int*>&>);
-		static_assert(CanBegin<ranges::subrange<int*, int*>&&>);
+		static_assert(CanBegin<const ranges::subrange<int*, int*>&>);
+		static_assert(CanBegin<ranges::subrange<int*, int*>>);
+		static_assert(CanBegin<const ranges::subrange<int*, int*>>);
+
+		static_assert(CanCBegin<ranges::subrange<int*, int*>&>);
+		static_assert(CanCBegin<const ranges::subrange<int*, int*>&>);
+		static_assert(CanCBegin<ranges::subrange<int*, int*>>);
+		static_assert(CanCBegin<const ranges::subrange<int*, int*>>);
+
+		static_assert(CanBegin<ranges::ref_view<int[5]>&>);
+		static_assert(CanBegin<const ranges::ref_view<int[5]>&>);
+		static_assert(CanBegin<ranges::ref_view<int[5]>>);
+		static_assert(CanBegin<const ranges::ref_view<int[5]>>);
+
+		static_assert(CanCBegin<ranges::ref_view<int[5]>&>);
+		static_assert(CanCBegin<const ranges::ref_view<int[5]>&>);
+		static_assert(CanCBegin<ranges::ref_view<int[5]>>);
+		static_assert(CanCBegin<const ranges::ref_view<int[5]>>);
+
+		static_assert(CanBegin<ranges::iota_view<int, int>&>);
+		static_assert(CanBegin<const ranges::iota_view<int, int>&>);
+		static_assert(CanBegin<ranges::iota_view<int, int>>);
+		static_assert(CanBegin<const ranges::iota_view<int, int>>);
+
+		static_assert(CanCBegin<ranges::iota_view<int, int>&>);
+		static_assert(CanCBegin<const ranges::iota_view<int, int>&>);
+		static_assert(CanCBegin<ranges::iota_view<int, int>>);
+		static_assert(CanCBegin<const ranges::iota_view<int, int>>);
 	}
 } // namespace begin_testing
 

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -103,11 +103,6 @@ namespace begin_testing {
 	struct D : A {};
 	char* begin(D&);
 
-	struct S {
-		friend int* begin(S&&);
-		friend int* end(S&&);
-	};
-
 	void test() {
 		// Valid
 		static_assert(CanBegin<int(&)[2]>);


### PR DESCRIPTION
IMO, we should spec the rvalue `begin`/`end` overloads for `subrange`, `iota_view`, and `ref_view` to be non-friend function templates, or else as hidden friend function templates using this pattern:

```c++
template<class A, class B> concept same-ish = Same<A const, B const>;

template <...>
struct subrange {
    friend I begin(same-ish<subrange> auto&& x) {
        return x.begin();
    }
};
```

I think this should work, but I can't test it because of the constrained friends gcc bug. With gcc, this overload is ambiguous with the poison-pill overload since the constraints get ignored.