### PR TITLE
Partially implement P1065R0

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			return (*this)(
 				begin(r), end(r),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/all_of.hpp
+++ b/include/stl2/detail/algorithm/all_of.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool operator()(R&& rng, Pred pred, Proj proj = {}) const
 		{
 			return (*this)(begin(rng), end(rng),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/any_of.hpp
+++ b/include/stl2/detail/algorithm/any_of.hpp
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool operator()(R&& rng, Pred pred, Proj proj = {}) const
 		{
 			return (*this)(begin(rng), end(rng),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/binary_search.hpp
+++ b/include/stl2/detail/algorithm/binary_search.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 		Proj proj = {})
 	{
 		auto result = __stl2::lower_bound(__stl2::move(first), last, value,
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 		return result != last && !__stl2::invoke(comp, value, __stl2::invoke(proj, *result));
 	}
 
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 	bool binary_search(Rng&& rng, const T& value, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::binary_search(
-			begin(rng), end(rng), value, std::ref(comp), std::ref(proj));
+			begin(rng), end(rng), value, __stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 			return (*this)(
 				begin(r), end(r),
 				std::move(result),
-				std::ref(pred),
-				std::ref(proj));
+				__stl2::ref(pred),
+				__stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(R&& r, const T& value, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				value, std::ref(proj));
+				value, __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr iter_difference_t<iterator_t<R>>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/equal_range.hpp
+++ b/include/stl2/detail/algorithm/equal_range.hpp
@@ -47,10 +47,10 @@ STL2_OPEN_NAMESPACE {
 							return {
 								ext::lower_bound_n(
 									std::move(first), half, value,
-									std::ref(comp), std::ref(proj)),
+									__stl2::ref(comp), __stl2::ref(proj)),
 								ext::upper_bound_n(__stl2::next(middle),
 									dist - (half + 1), value,
-									std::ref(comp), std::ref(proj))
+									__stl2::ref(comp), __stl2::ref(proj))
 							};
 						}
 					} while (0 != dist);
@@ -71,7 +71,7 @@ STL2_OPEN_NAMESPACE {
 			if constexpr (SizedSentinel<S, I>) {
 				auto len = __stl2::distance(first, std::move(last));
 				return ext::equal_range_n(std::move(first), len, value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			} else {
 				// Probe exponentially for either end-of-range, an iterator that
 				// is past the equal range (i.e., denotes an element greater
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 						// at the end of the input range
 						return ext::equal_range_n(
 							std::move(first), dist - d, value,
-							std::ref(comp), std::ref(proj));
+							__stl2::ref(comp), __stl2::ref(proj));
 					}
 					auto&& v = *mid;
 					auto&& pv = __stl2::invoke(proj, std::forward<decltype(v)>(v));
@@ -94,14 +94,14 @@ STL2_OPEN_NAMESPACE {
 					if (__stl2::invoke(comp, value, pv)) {
 						return ext::equal_range_n(
 							std::move(first), dist, value,
-							std::ref(comp), std::ref(proj));
+							__stl2::ref(comp), __stl2::ref(proj));
 					} else if (!__stl2::invoke(comp, pv, value)) {
 						// *mid == value: the lower bound is <= mid, and the upper bound is > mid.
 						return {
 							ext::lower_bound_n(std::move(first), dist, value,
-								std::ref(comp), std::ref(proj)),
+								__stl2::ref(comp), __stl2::ref(proj)),
 							__stl2::upper_bound(std::move(mid), std::move(last),
-								value, std::ref(comp), std::ref(proj))
+								value, __stl2::ref(comp), __stl2::ref(proj))
 						};
 					}
 					// *mid < value, mid is before the target range.
@@ -118,10 +118,10 @@ STL2_OPEN_NAMESPACE {
 		operator()(Rng&& rng, const T& value, Comp comp = {}, Proj proj = {}) const {
 			if constexpr (SizedRange<Rng>) {
 				return ext::equal_range_n(begin(rng), size(rng), value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			} else {
 				return (*this)(begin(rng), end(rng), value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 		requires IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, const T& value, Proj proj = {}) const {
-			return (*this)(begin(r), end(r), value, std::ref(proj));
+			return (*this)(begin(r), end(r), value, __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -111,7 +111,7 @@ STL2_OPEN_NAMESPACE {
 			return (*this)(
 				begin(r1), end(r1),
 				begin(r2), end(r2),
-				std::ref(pred), std::ref(proj1), std::ref(proj2));
+				__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -51,8 +51,8 @@ STL2_OPEN_NAMESPACE {
 			return (*this)(
 				begin(r1), end(r1),
 				begin(r2), end(r2),
-				std::ref(pred), std::ref(proj1),
-				std::ref(proj2));
+				__stl2::ref(pred), __stl2::ref(proj1),
+				__stl2::ref(proj2));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/find_if.hpp
+++ b/include/stl2/detail/algorithm/find_if.hpp
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr safe_iterator_t<R> operator()(R&& r, Pred pred, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/find_if_not.hpp
+++ b/include/stl2/detail/algorithm/find_if_not.hpp
@@ -27,14 +27,14 @@ STL2_OPEN_NAMESPACE {
 			IndirectUnaryPredicate<projected<I, Proj>> Pred>
 		constexpr I operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			return __stl2::find_if(std::move(first), std::move(last),
-				__stl2::not_fn(std::ref(pred)), std::ref(proj));
+				__stl2::not_fn(__stl2::ref(pred)), __stl2::ref(proj));
 		}
 
 		template<InputRange R, class Proj = identity,
 			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr safe_iterator_t<R> operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return __stl2::find_if(begin(r), end(r),
-				__stl2::not_fn(std::ref(pred)), std::ref(proj));
+				__stl2::not_fn(__stl2::ref(pred)), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/for_each.hpp
+++ b/include/stl2/detail/algorithm/for_each.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(R&& r, F fun, Proj proj = {}) const
 		{
 			return {(*this)(begin(r), end(r),
-				std::ref(fun), std::ref(proj)).in(), std::move(fun)};
+				__stl2::ref(fun), __stl2::ref(proj)).in(), std::move(fun)};
 		}
 	};
 

--- a/include/stl2/detail/algorithm/forward_sort.hpp
+++ b/include/stl2/detail/algorithm/forward_sort.hpp
@@ -66,8 +66,8 @@ STL2_OPEN_NAMESPACE {
 					__stl2::make_move_iterator(end(vec)),
 					__stl2::make_move_iterator(counted_iterator{std::move(f1), n1}),
 					move_sentinel<default_sentinel>{},
-					std::move(f0), std::ref(comp),
-					std::ref(proj), std::ref(proj)).out();
+					std::move(f0), __stl2::ref(comp),
+					__stl2::ref(proj), __stl2::ref(proj)).out();
 			}
 
 			template<class I, class Comp, class Proj>
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 				n0_0 = n0 / 2;
 				f0_1 = __stl2::next(f0_0, n0_0);
 				f1_1 = __stl2::ext::lower_bound_n(f1, n1, __stl2::invoke(proj, *f0_1),
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 				f1_0 = __stl2::rotate(f0_1, f1, f1_1).begin();
 				n0_1 = __stl2::distance(f0_1, f1_0);
 				f1_0 = __stl2::next(f1_0);
@@ -112,7 +112,7 @@ STL2_OPEN_NAMESPACE {
 				n0_1 = n1 / 2;
 				f1_1 = __stl2::next(f1, n0_1);
 				f0_1 = __stl2::ext::upper_bound_n(f0, n0, __stl2::invoke(proj, *f1_1),
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 				f1_1 = __stl2::next(f1_1);
 				f1_0 = __stl2::rotate(f0_1, f1, f1_1).begin();
 				n0_0 = __stl2::distance(f0_0, f0_1);

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -1,6 +1,6 @@
 // cmcstl2 - A concept-enabled C++ standard library
 //
-//  Copyright Casey Carter 2015
+//  Copyright Casey Carter 2015-present
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -20,17 +20,18 @@
 // generate_n [alg.generate]
 //
 STL2_OPEN_NAMESPACE {
-	template<class F, Iterator O>
-	requires
-		Invocable<F&> &&
-		Writable<O, result_of_t<F&()>>
-	O generate_n(O first, iter_difference_t<O> n, F gen)
-	{
-		for (; n > 0; ++first, --n) {
-			*first = gen();
+	struct __generate_n_fn : private __niebloid {
+		template<Iterator O, CopyConstructible F>
+		requires Invocable<F&> && Writable<O, invoke_result_t<F&>>
+		constexpr O operator()(O first, iter_difference_t<O> n, F gen) const {
+			for (; n > 0; (void)++first, --n) {
+				*first = gen();
+			}
+			return first;
 		}
-		return first;
-	}
+	};
+
+	inline constexpr __generate_n_fn generate_n {};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/includes.hpp
+++ b/include/stl2/detail/algorithm/includes.hpp
@@ -59,9 +59,9 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::includes(
 			begin(rng1), end(rng1),
 			begin(rng2), end(rng2),
-			std::ref(comp),
-			std::ref(proj1),
-			std::ref(proj2));
+			__stl2::ref(comp),
+			__stl2::ref(proj1),
+			__stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/inplace_merge.hpp
+++ b/include/stl2/detail/algorithm/inplace_merge.hpp
@@ -63,8 +63,8 @@ STL2_OPEN_NAMESPACE {
 						__stl2::make_move_iterator(end(vec)),
 						__stl2::make_move_iterator(std::move(middle)),
 						__stl2::make_move_iterator(std::move(last)),
-						std::move(first), std::ref(pred),
-						std::ref(proj), std::ref(proj));
+						std::move(first), __stl2::ref(pred),
+						__stl2::ref(proj), __stl2::ref(proj));
 				} else {
 					__stl2::move(middle, last, __stl2::back_inserter(vec));
 					using RBi = reverse_iterator<I>;
@@ -74,8 +74,8 @@ STL2_OPEN_NAMESPACE {
 						__stl2::make_move_iterator(rbegin(vec)),
 						__stl2::make_move_iterator(rend(vec)),
 						RBi{std::move(last)},
-						__stl2::not_fn(std::ref(pred)),
-						std::ref(proj), std::ref(proj));
+						__stl2::not_fn(__stl2::ref(pred)),
+						__stl2::ref(proj), __stl2::ref(proj));
 				}
 			}
 
@@ -127,7 +127,7 @@ STL2_OPEN_NAMESPACE {
 						len21 = len2 / 2;
 						m2 = __stl2::next(middle, len21);
 						m1 = __stl2::upper_bound(begin, middle, __stl2::invoke(proj, *m2),
-							std::ref(pred), std::ref(proj));
+							__stl2::ref(pred), __stl2::ref(proj));
 						len11 = __stl2::distance(begin, m1);
 					} else {
 						if (len1 == 1) {
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 						len11 = len1 / 2;
 						m1 = __stl2::next(begin, len11);
 						m2 = __stl2::lower_bound(middle, end, __stl2::invoke(proj, *m1),
-							std::ref(pred), std::ref(proj));
+							__stl2::ref(pred), __stl2::ref(proj));
 						len21 = __stl2::distance(middle, m2);
 					}
 					D len12 = len1 - len11;  // distance(m1, middle)
@@ -152,14 +152,14 @@ STL2_OPEN_NAMESPACE {
 					// merge smaller range with recursive call and larger with tail recursion elimination
 					if(len11 + len21 < len12 + len22) {
 						(*this)(std::move(begin), std::move(m1), middle, len11, len21, buf,
-										std::ref(pred), std::ref(proj));
+										__stl2::ref(pred), __stl2::ref(proj));
 						begin = std::move(middle);
 						middle = std::move(m2);
 						len1 = len12;
 						len2 = len22;
 					} else {
 						(*this)(middle, std::move(m2), std::move(end), len12, len22, buf,
-										std::ref(pred), std::ref(proj));
+										__stl2::ref(pred), __stl2::ref(proj));
 						end = std::move(middle);
 						middle = std::move(m1);
 						len1 = len11;
@@ -181,7 +181,7 @@ STL2_OPEN_NAMESPACE {
 			{
 				temporary_buffer<iter_value_t<I>> no_buffer;
 				merge_adaptive(std::move(begin), std::move(middle), std::move(end),
-					len1, len2, no_buffer, std::ref(pred), std::ref(proj));
+					len1, len2, no_buffer, __stl2::ref(pred), __stl2::ref(proj));
 			}
 		};
 
@@ -202,7 +202,7 @@ STL2_OPEN_NAMESPACE {
 			buf = detail::temporary_buffer<iter_value_t<I>>{buf_size};
 		}
 		detail::merge_adaptive(std::move(first), std::move(middle), len2_and_end.end(),
-			len1, len2_and_end.count(), buf, std::ref(comp), std::ref(proj));
+			len1, len2_and_end.count(), buf, __stl2::ref(comp), __stl2::ref(proj));
 		return len2_and_end.end();
 	}
 
@@ -213,7 +213,7 @@ STL2_OPEN_NAMESPACE {
 	inplace_merge(Rng&& rng, iterator_t<Rng> middle, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::inplace_merge(begin(rng), std::move(middle),
-			end(rng), std::ref(comp), std::ref(proj));
+			end(rng), __stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/is_heap.hpp
+++ b/include/stl2/detail/algorithm/is_heap.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 	bool is_heap(I first, S last, Comp comp = {}, Proj proj = {})
 	{
 		return last == __stl2::is_heap_until(std::move(first), last,
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 
 	template<RandomAccessRange Rng, class Comp = less, class Proj = identity>
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 	bool is_heap(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return end(rng) ==
-			__stl2::is_heap_until(rng, std::ref(comp), std::ref(proj));
+			__stl2::is_heap_until(rng, __stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/is_heap_until.hpp
+++ b/include/stl2/detail/algorithm/is_heap_until.hpp
@@ -69,7 +69,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		auto n = __stl2::distance(first, std::move(last));
 		return detail::is_heap_until_n(std::move(first), n,
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 
 	template<RandomAccessRange Rng, class Comp = less, class Proj = identity>
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 	is_heap_until(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return detail::is_heap_until_n(begin(rng), __stl2::distance(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/is_partitioned.hpp
+++ b/include/stl2/detail/algorithm/is_partitioned.hpp
@@ -30,9 +30,9 @@ STL2_OPEN_NAMESPACE {
 	bool is_partitioned(I first, S last, Pred pred, Proj proj = {})
 	{
 		first = __stl2::find_if_not(std::move(first), last,
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 		return __stl2::none_of(std::move(first), std::move(last),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 
 	template<InputRange Rng, class Pred, class Proj = identity>
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 	bool is_partitioned(Rng&& rng, Pred pred, Proj proj = {})
 	{
 		return __stl2::is_partitioned(begin(rng), end(rng),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -132,18 +132,18 @@ STL2_OPEN_NAMESPACE {
 			// If for some j in [first1, i.base()), *j == e, we've already
 			// validated the counts of elements equal to e.
 			auto match = __stl2::find_if(counted_iterator{first1, n - i.count()},
-				default_sentinel{}, match_predicate, std::ref(proj1));
+				default_sentinel{}, match_predicate, __stl2::ref(proj1));
 			++i;
 			if (match.count()) continue;
 
 			// Count number of e in [first2, n)
 			const auto c2 = __stl2::count_if(counted_iterator{first2, n},
-				default_sentinel{}, match_predicate, std::ref(proj2));
+				default_sentinel{}, match_predicate, __stl2::ref(proj2));
 			if (c2 == 0) return false;
 
 			// Count number of e in [i, default_sentinel)
 			const auto c1 = __stl2::count_if(i, default_sentinel{},
-				match_predicate, std::ref(proj1));
+				match_predicate, __stl2::ref(proj1));
 
 			// If the number of e in [first2, n) is not equal to
 			// the number of e in [first1, n), we don't have a permutation.
@@ -162,7 +162,7 @@ STL2_OPEN_NAMESPACE {
 		auto [counted, mid2] = __stl2::mismatch(
 			counted_iterator{std::move(first1), n}, default_sentinel{},
 			std::move(first2), unreachable{},
-			std::ref(pred), std::ref(proj1), std::ref(proj2));
+			__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 
 		// TODO: trim equal suffixes from bidirectional sequences?
 
@@ -184,7 +184,7 @@ STL2_OPEN_NAMESPACE {
 			// shorten sequences by removing equal prefixes
 			auto [mid1, mid2] = __stl2::mismatch(std::move(first1), last1,
 				std::move(first2), unreachable{},
-				std::ref(pred), std::ref(proj1), std::ref(proj2));
+				__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 
 			auto count = __stl2::distance(mid1, std::move(last1));
 			return __stl2::__is_permutation_tail(std::move(mid1), std::move(mid2),
@@ -208,7 +208,7 @@ STL2_OPEN_NAMESPACE {
 			} else {
 				return (*this)(
 					begin(r1), end(r1), std::move(first2),
-					std::ref(pred), std::ref(proj1), std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 			}
 		}
 
@@ -235,7 +235,7 @@ STL2_OPEN_NAMESPACE {
 				// shorten sequences by removing equal prefixes
 				auto [mid1, mid2] = __stl2::mismatch(
 					std::move(first1), last1, std::move(first2), last2,
-					std::ref(pred), std::ref(proj1), std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 
 				auto [same_length, count] =
 					__stl2::__common_range_length(mid1, std::move(last1), mid2, std::move(last2));
@@ -269,7 +269,7 @@ STL2_OPEN_NAMESPACE {
 				return (*this)(
 					begin(r1), end(r1),
 					begin(r2), end(r2),
-					std::ref(pred), std::ref(proj1), std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/is_sorted.hpp
+++ b/include/stl2/detail/algorithm/is_sorted.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	bool is_sorted(I first, S last, Comp comp = {}, Proj proj = {})
 	{
 		return last == __stl2::is_sorted_until(std::move(first), last,
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 
 	template<ForwardRange Rng, class Comp = less, class Proj = identity>
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return end(rng) ==
 			__stl2::is_sorted_until(begin(rng), end(rng),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/is_sorted_until.hpp
+++ b/include/stl2/detail/algorithm/is_sorted_until.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 	is_sorted_until(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::is_sorted_until(begin(rng), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/lexicographical_compare.hpp
+++ b/include/stl2/detail/algorithm/lexicographical_compare.hpp
@@ -52,9 +52,9 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::lexicographical_compare(
 			begin(rng1), end(rng1),
 			begin(rng2), end(rng2),
-			std::ref(comp),
-			std::ref(proj1),
-			std::ref(proj2));
+			__stl2::ref(comp),
+			__stl2::ref(proj1),
+			__stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/lower_bound.hpp
+++ b/include/stl2/detail/algorithm/lower_bound.hpp
@@ -33,7 +33,7 @@ STL2_OPEN_NAMESPACE {
 					return __stl2::invoke(comp, i, value);
 				};
 				return __stl2::ext::partition_point_n(
-					std::forward<I>(first), n, pred, std::ref(proj));
+					std::forward<I>(first), n, pred, __stl2::ref(proj));
 			}
 		};
 
@@ -50,13 +50,13 @@ STL2_OPEN_NAMESPACE {
 				auto first_ = std::forward<I>(first);
 				auto n = __stl2::distance(first_, std::forward<S>(last));
 				return __stl2::ext::lower_bound_n(std::move(first_), n, value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			} else {
 				auto pred = [&](auto&& i) -> bool {
 					return __stl2::invoke(comp, i, value);
 				};
 				return __stl2::partition_point(
-					std::forward<I>(first), std::forward<S>(last), pred, std::ref(proj));
+					std::forward<I>(first), std::forward<S>(last), pred, __stl2::ref(proj));
 			}
 		}
 
@@ -68,10 +68,10 @@ STL2_OPEN_NAMESPACE {
 			if constexpr (SizedRange<Rng>) {
 				return __stl2::ext::lower_bound_n(
 					begin(rng), __stl2::distance(rng), value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			} else {
 				return (*this)(begin(rng), end(rng), value,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/make_heap.hpp
+++ b/include/stl2/detail/algorithm/make_heap.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 				// start from the first parent, there is no need to consider children
 				for (auto start = (n - 2) / 2; start >= 0; --start) {
 					detail::sift_down_n(first, n, first + start,
-						std::ref(comp), std::ref(proj));
+						__stl2::ref(comp), __stl2::ref(proj));
 				}
 			}
 		}
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 	I make_heap(I first, S last, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(first, std::move(last));
-		detail::make_heap_n(first, n, std::ref(comp), std::ref(proj));
+		detail::make_heap_n(first, n, __stl2::ref(comp), __stl2::ref(proj));
 		return first + n;
 	}
 
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 	make_heap(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(rng);
-		detail::make_heap_n(begin(rng), n, std::ref(comp), std::ref(proj));
+		detail::make_heap_n(begin(rng), n, __stl2::ref(comp), __stl2::ref(proj));
 		return begin(rng) + n;
 	}
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 			iter_value_t<iterator_t<R>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
-				if (__invoke::impl(comp, __invoke::impl(proj, result), __invoke::impl(proj, tmp))) {
+				if (__stl2::invoke(comp, __stl2::invoke(proj, result), __stl2::invoke(proj, tmp))) {
 					result = (decltype(tmp)&&)tmp;
 				}
 			}
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr const T&
 		operator()(const T& a, const T& b, Comp comp = {}, Proj proj = {}) const
 		{
-			return !__invoke::impl(comp, __invoke::impl(proj, a), __invoke::impl(proj, b)) ? a : b;
+			return !__stl2::invoke(comp, __stl2::invoke(proj, a), __stl2::invoke(proj, b)) ? a : b;
 		}
 
 		template<InputRange R, class Proj = identity,
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr iter_value_t<iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
-			return __max_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __max_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<Copyable T, class Proj = identity,
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr T
 		operator()(std::initializer_list<T> r, Comp comp = {}, Proj proj = {}) const
 		{
-			return __max_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __max_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/max_element.hpp
+++ b/include/stl2/detail/algorithm/max_element.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -77,8 +77,8 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::merge(
 			begin(rng1), end(rng1),
 			begin(rng2), end(rng2),
-			std::forward<O>(result), std::ref(comp),
-			std::ref(proj1), std::ref(proj2));
+			std::forward<O>(result), __stl2::ref(comp),
+			__stl2::ref(proj1), __stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 			iter_value_t<iterator_t<R>> result = *first;
 			while (++first != last) {
 				auto&& tmp = *first;
-				if (__invoke::impl(comp, __invoke::impl(proj, tmp), __invoke::impl(proj, result))) {
+				if (__stl2::invoke(comp, __stl2::invoke(proj, tmp), __stl2::invoke(proj, result))) {
 					result = (decltype(tmp)&&)tmp;
 				}
 			}
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr const T& operator()(const T& a, const T& b, Comp comp = {},
 			Proj proj = {}) const
 		{
-			return __invoke::impl(comp, __invoke::impl(proj, b), __invoke::impl(proj, a)) ? b : a;
+			return __stl2::invoke(comp, __stl2::invoke(proj, b), __stl2::invoke(proj, a)) ? b : a;
 		}
 
 		template<InputRange R, class Proj = identity,
@@ -58,7 +58,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr iter_value_t<iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
-			return __min_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __min_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<Copyable T, class Proj = identity,
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr T operator()(std::initializer_list<T> r,
 			Comp comp = {}, Proj proj = {}) const
 		{
-			return __min_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __min_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/min_element.hpp
+++ b/include/stl2/detail/algorithm/min_element.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 			if (++first != last) {
 				{
 					auto&& tmp = *first;
-					if (__invoke::impl(comp, __invoke::impl(proj, tmp), __invoke::impl(proj, result.first))) {
+					if (__stl2::invoke(comp, __stl2::invoke(proj, tmp), __stl2::invoke(proj, result.first))) {
 						result.first = (decltype(tmp)&&)tmp;
 					} else {
 						result.second = (decltype(tmp)&&)tmp;
@@ -52,27 +52,27 @@ STL2_OPEN_NAMESPACE {
 				while (++first != last) {
 					auto tmp1 = V{*first};
 					if (++first == last) {
-						if (__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.first))) {
+						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.first))) {
 							result.first = std::move(tmp1);
-						} else if (!__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.second))) {
+						} else if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.second))) {
 							result.second = std::move(tmp1);
 						}
 						break;
 					}
 
 					auto&& tmp2 = *first;
-					if (__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, tmp1))) {
-						if (__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, result.first))) {
+					if (__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, tmp1))) {
+						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, result.first))) {
 							result.first = (decltype(tmp2)&&)tmp2;
 						}
-						if (!__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.second))) {
+						if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.second))) {
 							result.second = std::move(tmp1);
 						}
 					} else {
-						if (__invoke::impl(comp, __invoke::impl(proj, tmp1), __invoke::impl(proj, result.first))) {
+						if (__stl2::invoke(comp, __stl2::invoke(proj, tmp1), __stl2::invoke(proj, result.first))) {
 							result.first = std::move(tmp1);
 						}
-						if (!__invoke::impl(comp, __invoke::impl(proj, tmp2), __invoke::impl(proj, result.second))) {
+						if (!__stl2::invoke(comp, __stl2::invoke(proj, tmp2), __stl2::invoke(proj, result.second))) {
 							result.second = (decltype(tmp2)&&)tmp2;
 						}
 					}
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr tagged_pair<tag::min(const T&), tag::max(const T&)>
 		operator()(const T& a, const T& b, Comp comp = {}, Proj proj = {}) const
 		{
-			if (__invoke::impl(comp, __invoke::impl(proj, b), __invoke::impl(proj, a))) {
+			if (__stl2::invoke(comp, __stl2::invoke(proj, b), __stl2::invoke(proj, a))) {
 				return {b, a};
 			} else {
 				return {a, b};
@@ -100,7 +100,7 @@ STL2_OPEN_NAMESPACE {
 			tag::max(iter_value_t<iterator_t<R>>)>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
-			return __minmax_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __minmax_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<Copyable T, class Proj = identity,
@@ -108,7 +108,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr tagged_pair<tag::min(T), tag::max(T)>
 		operator()(std::initializer_list<T>&& r, Comp comp = {}, Proj proj = {}) const
 		{
-			return __minmax_fn::impl(r, std::ref(comp), std::ref(proj));
+			return __minmax_fn::impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/minmax_element.hpp
+++ b/include/stl2/detail/algorithm/minmax_element.hpp
@@ -79,7 +79,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -73,8 +73,8 @@ STL2_OPEN_NAMESPACE {
 			auto first2 = std::forward<I2>(first2_);
 			return (*this)(
 				begin(rng1), end(rng1),
-				std::move(first2), std::ref(pred),
-				std::ref(proj1), std::ref(proj2));
+				std::move(first2), __stl2::ref(pred),
+				__stl2::ref(proj1), __stl2::ref(proj2));
 		}
 
 		template<InputRange R1, InputRange R2,
@@ -88,9 +88,9 @@ STL2_OPEN_NAMESPACE {
 			return (*this)(
 				begin(r1), end(r1),
 				begin(r2), end(r2),
-				std::ref(pred),
-				std::ref(proj1),
-				std::ref(proj2));
+				__stl2::ref(pred),
+				__stl2::ref(proj1),
+				__stl2::ref(proj2));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/next_permutation.hpp
+++ b/include/stl2/detail/algorithm/next_permutation.hpp
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 	bool next_permutation(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::next_permutation(begin(rng), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/none_of.hpp
+++ b/include/stl2/detail/algorithm/none_of.hpp
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool operator()(R&& r, Pred pred, Proj proj = {}) const
 		{
 			return (*this)(begin(r), end(r),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -71,7 +71,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			STL2_EXPECT(begin != end);
 			for (I lm1 = __stl2::prev(end); begin != lm1; ++begin) {
-				I i = __stl2::min_element(begin, end, std::ref(comp), std::ref(proj));
+				I i = __stl2::min_element(begin, end, __stl2::ref(comp), __stl2::ref(proj));
 				if (i != begin) {
 					__stl2::iter_swap(begin, i);
 				}
@@ -266,7 +266,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::nth_element(
 			begin(rng), std::move(nth), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/partial_sort.hpp
+++ b/include/stl2/detail/algorithm/partial_sort.hpp
@@ -31,16 +31,16 @@ STL2_OPEN_NAMESPACE {
 		Sortable<I, Comp, Proj>
 	I partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {})
 	{
-		__stl2::make_heap(first, middle, std::ref(comp), std::ref(proj));
+		__stl2::make_heap(first, middle, __stl2::ref(comp), __stl2::ref(proj));
 		const auto len = __stl2::distance(first, middle);
 		I i = middle;
 		for(; i != last; ++i) {
 			if(__stl2::invoke(comp, __stl2::invoke(proj, *i), __stl2::invoke(proj, *first))) {
 				__stl2::iter_swap(i, first);
-				detail::sift_down_n(first, len, first, std::ref(comp), std::ref(proj));
+				detail::sift_down_n(first, len, first, __stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
-		__stl2::sort_heap(first, middle, std::ref(comp), std::ref(proj));
+		__stl2::sort_heap(first, middle, __stl2::ref(comp), __stl2::ref(proj));
 		return i;
 	}
 
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::partial_sort(
 			begin(rng), std::move(middle), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -46,17 +46,17 @@ STL2_OPEN_NAMESPACE {
 			first = std::move(cresult.in);
 			r = std::move(cresult.out);
 
-			__stl2::make_heap(result_first, r, std::ref(comp), std::ref(proj2));
+			__stl2::make_heap(result_first, r, __stl2::ref(comp), __stl2::ref(proj2));
 			const auto len = __stl2::distance(result_first, r);
 			for(; first != last; ++first) {
 				iter_reference_t<I1>&& x = *first;
 				if(__stl2::invoke(comp, __stl2::invoke(proj1, x), __stl2::invoke(proj2, *result_first))) {
 					*result_first = std::forward<iter_reference_t<I1>>(x);
 					detail::sift_down_n(result_first, len, result_first,
-						std::ref(comp), std::ref(proj2));
+						__stl2::ref(comp), __stl2::ref(proj2));
 				}
 			}
-			__stl2::sort_heap(result_first, r, std::ref(comp), std::ref(proj2));
+			__stl2::sort_heap(result_first, r, __stl2::ref(comp), __stl2::ref(proj2));
 		}
 		return r;
 	}
@@ -76,8 +76,8 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::partial_sort_copy(
 			begin(rng), end(rng),
 			begin(result_rng), end(result_rng),
-			std::ref(comp),
-			std::ref(proj1), std::ref(proj2));
+			__stl2::ref(comp),
+			__stl2::ref(proj1), __stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/partition.hpp
+++ b/include/stl2/detail/algorithm/partition.hpp
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 				}
 			} else {
 				first = __stl2::find_if_not(std::move(first), last_,
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 				if (first != last_) {
 					for (auto m = first; ++m != last_;) {
 						if (__stl2::invoke(pred, __stl2::invoke(proj, *m))) {
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng),
-				std::ref(pred), std::ref(proj));
+				__stl2::ref(pred), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/partition_copy.hpp
+++ b/include/stl2/detail/algorithm/partition_copy.hpp
@@ -67,7 +67,7 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::partition_copy(
 			begin(rng), end(rng),
 			std::forward<O1>(out_true), std::forward<O2>(out_false),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/partition_point.hpp
+++ b/include/stl2/detail/algorithm/partition_point.hpp
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		auto n = __stl2::distance(first, std::move(last));
 		return __stl2::ext::partition_point_n(std::move(first), n,
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 
 	template<ForwardRange Rng, class Pred, class Proj = identity>
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 	partition_point(Rng&& rng, Pred pred, Proj proj = {})
 	{
 		return __stl2::partition_point(begin(rng), end(rng),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 
 	template<ForwardRange Rng, class Pred, class Proj = identity>
@@ -110,7 +110,7 @@ STL2_OPEN_NAMESPACE {
 	partition_point(Rng&& rng, Pred pred, Proj proj = {})
 	{
 		return ext::partition_point_n(begin(rng), __stl2::distance(rng),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/pop_heap.hpp
+++ b/include/stl2/detail/algorithm/pop_heap.hpp
@@ -40,8 +40,8 @@ STL2_OPEN_NAMESPACE {
 		{
 			if (n > 1) {
 				__stl2::iter_swap(first, first + (n - 1));
-				detail::sift_down_n(first, n - 1, first, std::ref(comp),
-					std::ref(proj));
+				detail::sift_down_n(first, n - 1, first, __stl2::ref(comp),
+					__stl2::ref(proj));
 			}
 		}
 	}
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	I pop_heap(I first, S last, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(first, std::move(last));
-		detail::pop_heap_n(first, n, std::ref(comp), std::ref(proj));
+		detail::pop_heap_n(first, n, __stl2::ref(comp), __stl2::ref(proj));
 		return first + n;
 	}
 
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 	pop_heap(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(rng);
-		detail::pop_heap_n(begin(rng), n, std::ref(comp), std::ref(proj));
+		detail::pop_heap_n(begin(rng), n, __stl2::ref(comp), __stl2::ref(proj));
 		return begin(rng) + n;
 	}
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/algorithm/prev_permutation.hpp
+++ b/include/stl2/detail/algorithm/prev_permutation.hpp
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 	bool prev_permutation(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::prev_permutation(begin(rng), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/push_heap.hpp
+++ b/include/stl2/detail/algorithm/push_heap.hpp
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 	I push_heap(I first, S&& last, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(first, std::forward<S>(last));
-		detail::sift_up_n(first, n, std::ref(comp), std::ref(proj));
+		detail::sift_up_n(first, n, __stl2::ref(comp), __stl2::ref(proj));
 		return first + n;
 	}
 
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 	push_heap(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(rng);
-		detail::sift_up_n(begin(rng), n, std::ref(comp), std::ref(proj));
+		detail::sift_up_n(begin(rng), n, __stl2::ref(comp), __stl2::ref(proj));
 		return begin(rng) + n;
 	}
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 			equal_to, projected<I, Proj>, const T*>
 	I remove(I first, S last, const T& value, Proj proj = {})
 	{
-		first = __stl2::find(std::move(first), last, value, std::ref(proj));
+		first = __stl2::find(std::move(first), last, value, __stl2::ref(proj));
 		if (first != last) {
 			for (auto m = __stl2::next(first); m != last; ++m) {
 				if (__stl2::invoke(proj, *m) != value) {
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 	safe_iterator_t<Rng>
 	remove(Rng&& rng, const T& value, Proj proj = {})
 	{
-		return __stl2::remove(begin(rng), end(rng), value, std::ref(proj));
+		return __stl2::remove(begin(rng), end(rng), value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 	remove_copy(Rng&& rng, O&& result, const T& value, Proj proj = {})
 	{
 		return __stl2::remove_copy(begin(rng), end(rng),
-			std::forward<O>(result), value, std::ref(proj));
+			std::forward<O>(result), value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/remove_copy_if.hpp
+++ b/include/stl2/detail/algorithm/remove_copy_if.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::remove_copy_if(
 			begin(rng), end(rng), std::forward<O>(result),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/remove_if.hpp
+++ b/include/stl2/detail/algorithm/remove_if.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	I remove_if(I first, S last, Pred pred, Proj proj = {})
 	{
 		first = __stl2::find_if(std::move(first), last,
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 		if (first != last) {
 			for (auto m = __stl2::next(first); m != last; ++m) {
 				if (!__stl2::invoke(pred, __stl2::invoke(proj, *m))) {
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::remove_if(
 			begin(rng), end(rng),
-			std::ref(pred), std::ref(proj));
+			__stl2::ref(pred), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::replace(
 			begin(rng), end(rng),
-			old_value, new_value, std::ref(proj));
+			old_value, new_value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::replace_copy(
 			begin(rng), end(rng), std::forward<O>(result),
-			old_value, new_value, std::ref(proj));
+			old_value, new_value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/replace_copy_if.hpp
+++ b/include/stl2/detail/algorithm/replace_copy_if.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::replace_copy_if(
 			begin(rng), end(rng), std::forward<O>(result),
-			std::ref(pred), new_value, std::ref(proj));
+			__stl2::ref(pred), new_value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/replace_if.hpp
+++ b/include/stl2/detail/algorithm/replace_if.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 		Proj proj = {})
 	{
 		return __stl2::replace_if(begin(rng), end(rng),
-			std::ref(pred), new_value, std::ref(proj));
+			__stl2::ref(pred), new_value, __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -27,8 +27,7 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT constraint =
 			InputIterator<I> && Sentinel<S, I> && WeaklyIncrementable<O> &&
 			IndirectlyCopyable<I, O> &&
-			UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-			ConvertibleTo<result_of_t<Gen&()>, iter_difference_t<I>>;
+			UniformRandomNumberGenerator<remove_reference_t<Gen>>;
 
 		template<class I, class S, class O, class Gen>
 		requires

--- a/include/stl2/detail/algorithm/search.hpp
+++ b/include/stl2/detail/algorithm/search.hpp
@@ -112,12 +112,12 @@ STL2_OPEN_NAMESPACE {
 				return sized(
 					first1, last1, last1 - first1,
 					first2, last2, last2 - first2,
-					std::ref(pred), std::ref(proj1),
-					std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1),
+					__stl2::ref(proj2));
 			} else {
 				return unsized(first1, last1, first2, last2,
-					std::ref(pred), std::ref(proj1),
-					std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1),
+					__stl2::ref(proj2));
 			}
 		}
 
@@ -130,14 +130,14 @@ STL2_OPEN_NAMESPACE {
 				return sized(
 					begin(rng1), end(rng1), __stl2::distance(rng1),
 					begin(rng2), end(rng2), __stl2::distance(rng2),
-					std::ref(pred), std::ref(proj1),
-					std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1),
+					__stl2::ref(proj2));
 			} else {
 				return unsized(
 					begin(rng1), end(rng1),
 					begin(rng2), end(rng2),
-					std::ref(pred), std::ref(proj1),
-					std::ref(proj2));
+					__stl2::ref(pred), __stl2::ref(proj1),
+					__stl2::ref(proj2));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/search_n.hpp
+++ b/include/stl2/detail/algorithm/search_n.hpp
@@ -100,10 +100,10 @@ STL2_OPEN_NAMESPACE {
 			if constexpr (SizedSentinel<S, I>) {
 				auto n = static_cast<iter_difference_t<I>>(last - first);
 				return sized(std::move(first), std::move(last),
-					n, count, value, std::ref(pred), std::ref(proj));
+					n, count, value, __stl2::ref(pred), __stl2::ref(proj));
 			} else {
 				return unsized(std::move(first), std::move(last),
-					count, value, std::ref(pred), std::ref(proj));
+					count, value, __stl2::ref(pred), __stl2::ref(proj));
 			}
 		}
 
@@ -114,10 +114,10 @@ STL2_OPEN_NAMESPACE {
 			const T& value, Pred pred = {}, Proj proj = {}) const {
 			if constexpr (SizedRange<Rng>) {
 				return sized(begin(rng), end(rng),
-					__stl2::distance(rng), count, value, std::ref(pred), std::ref(proj));
+					__stl2::distance(rng), count, value, __stl2::ref(pred), __stl2::ref(proj));
 			} else {
 				return unsized(begin(rng), end(rng), count, value,
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 				begin(r1), end(r1),
 				begin(r2), end(r2),
 				std::move(result),
-				std::ref(comp), std::ref(proj1), std::ref(proj2));
+				__stl2::ref(comp), __stl2::ref(proj1), __stl2::ref(proj2));
 		}
 	};
 

--- a/include/stl2/detail/algorithm/set_intersection.hpp
+++ b/include/stl2/detail/algorithm/set_intersection.hpp
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::set_intersection(begin(rng1), end(rng1),
 			begin(rng2), end(rng2), std::forward<O>(result),
-			std::ref(comp), std::ref(proj1), std::ref(proj2));
+			__stl2::ref(comp), __stl2::ref(proj1), __stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -85,7 +85,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::set_symmetric_difference(begin(rng1), end(rng1),
 			begin(rng2), end(rng2), std::forward<O>(result),
-			std::ref(comp), std::ref(proj1), std::ref(proj2));
+			__stl2::ref(comp), __stl2::ref(proj1), __stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -76,8 +76,8 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::set_union(
 			begin(rng1), end(rng1),
 			begin(rng2), end(rng2),
-			std::forward<O>(result), std::ref(comp),
-			std::ref(proj1), std::ref(proj2));
+			std::forward<O>(result), __stl2::ref(comp),
+			__stl2::ref(proj1), __stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -28,8 +28,7 @@ STL2_OPEN_NAMESPACE {
 		class Gen = detail::default_random_engine&, class D = iter_difference_t<I>>
 	requires
 		Permutable<I> &&
-		UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-		ConvertibleTo<result_of_t<Gen&()>, D>
+		UniformRandomNumberGenerator<remove_reference_t<Gen>>
 	I shuffle(I const first, S const last, Gen&& g = detail::get_random_engine())
 	{
 		auto mid = first;
@@ -50,8 +49,7 @@ STL2_OPEN_NAMESPACE {
 		class D = iter_difference_t<iterator_t<Rng>>>
 	requires
 		Permutable<iterator_t<Rng>> &&
-		UniformRandomNumberGenerator<remove_reference_t<Gen>> &&
-		ConvertibleTo<result_of_t<Gen&()>, D>
+		UniformRandomNumberGenerator<remove_reference_t<Gen>>
 	inline safe_iterator_t<Rng> shuffle(
 		Rng&& rng, Gen&& g = detail::get_random_engine())
 	{

--- a/include/stl2/detail/algorithm/sort.hpp
+++ b/include/stl2/detail/algorithm/sort.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 	safe_iterator_t<Rng> sort(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		return __stl2::sort(begin(rng), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 
 	namespace ext {
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 		safe_iterator_t<Rng> sort(Rng&& rng, Comp comp = {}, Proj proj = {})
 		{
 			return __stl2::sort(begin(rng), end(rng),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 #else  // STL2_WORKAROUND_GCC_79591
 		using __stl2::sort;
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			auto n = __stl2::distance(first, std::move(last));
 			return detail::fsort::sort_n(std::move(first), n,
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<ForwardRange Rng, class Comp = less, class Proj = identity>
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 		safe_iterator_t<Rng> sort(Rng&& rng, Comp comp = {}, Proj proj = {})
 		{
 			return detail::fsort::sort_n(begin(rng), __stl2::distance(rng),
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 	} // namespace ext
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/algorithm/sort_heap.hpp
+++ b/include/stl2/detail/algorithm/sort_heap.hpp
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			for (auto i = n; i > 1; --i) {
-				detail::pop_heap_n(first, i, std::ref(comp), std::ref(proj));
+				detail::pop_heap_n(first, i, __stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
 	}
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 	I sort_heap(I first, S last, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(first, std::move(last));
-		detail::sort_heap_n(first, n, std::ref(comp), std::ref(proj));
+		detail::sort_heap_n(first, n, __stl2::ref(comp), __stl2::ref(proj));
 		return first + n;
 	}
 
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 	sort_heap(Rng&& rng, Comp comp = {}, Proj proj = {})
 	{
 		auto n = __stl2::distance(rng);
-		detail::sort_heap_n(begin(rng), n, std::ref(comp), std::ref(proj));
+		detail::sort_heap_n(begin(rng), n, __stl2::ref(comp), __stl2::ref(proj));
 		return begin(rng) + n;
 	}
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 						__stl2::make_move_iterator(std::move(counted)),
 						move_sentinel<default_sentinel>{},
 						std::move(first), __stl2::back_inserter(vec),
-						std::ref(pred), std::ref(proj)).out1();
+						__stl2::ref(pred), __stl2::ref(proj)).out1();
 				auto last = __stl2::move(vec, pp).out();
 				return {std::move(pp), std::move(last)};
 			}
@@ -147,8 +147,8 @@ STL2_OPEN_NAMESPACE {
 					__stl2::make_move_iterator(last),
 					std::move(first),
 					__stl2::back_inserter(vec),
-					std::ref(pred),
-					std::ref(proj)).out1();
+					__stl2::ref(pred),
+					__stl2::ref(proj)).out1();
 				*middle = __stl2::iter_move(last);
 				++middle;
 				__stl2::move(vec, middle);
@@ -227,7 +227,7 @@ STL2_OPEN_NAMESPACE {
 					auto bound = __stl2::next(first, n);
 					return (*this)(
 						std::move(first), std::move(bound), n,
-						std::ref(pred), std::ref(proj));
+						__stl2::ref(pred), __stl2::ref(proj));
 				} else {
 					// Either prove all true or find first false
 					skip_true(first, n, pred, proj);
@@ -287,12 +287,12 @@ STL2_OPEN_NAMESPACE {
 				auto bound = ext::enumerate(first, std::move(last));
 				return ext::stable_partition_n(
 					std::move(first), std::move(bound.end()), bound.count(),
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			} else {
 				auto n = __stl2::distance(first, std::move(last));
 				return ext::stable_partition_n(
 					std::move(first), n,
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			}
 		}
 
@@ -305,11 +305,11 @@ STL2_OPEN_NAMESPACE {
 				auto bound = ext::enumerate(rng);
 				return ext::stable_partition_n(
 					begin(rng), std::move(bound.end()), bound.count(),
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			} else {
 				return ext::stable_partition_n(
 					begin(rng), __stl2::distance(rng),
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/stable_sort.hpp
+++ b/include/stl2/detail/algorithm/stable_sort.hpp
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 				inplace_stable_sort(middle, last, pred, proj);
 				detail::inplace_merge_no_buffer(first, middle, last,
 					middle - first, last - middle,
-					std::ref(pred), std::ref(proj));
+					__stl2::ref(pred), __stl2::ref(proj));
 			}
 		}
 
@@ -81,8 +81,8 @@ STL2_OPEN_NAMESPACE {
 					__stl2::make_move_iterator(first + step_size),
 					__stl2::make_move_iterator(first + step_size),
 					__stl2::make_move_iterator(first + two_step),
-					result, std::ref(pred),
-					std::ref(proj), std::ref(proj)).out();
+					result, __stl2::ref(pred),
+					__stl2::ref(proj), __stl2::ref(proj)).out();
 				first += two_step;
 			}
 			step_size = __stl2::min(iter_difference_t<I>(last - first), step_size);
@@ -91,8 +91,8 @@ STL2_OPEN_NAMESPACE {
 				__stl2::make_move_iterator(first + step_size),
 				__stl2::make_move_iterator(first + step_size),
 				__stl2::make_move_iterator(last),
-				result, std::ref(pred),
-				std::ref(proj), std::ref(proj));
+				result, __stl2::ref(pred),
+				__stl2::ref(proj), __stl2::ref(proj));
 		}
 
 		template<RandomAccessIterator I, class C, class P>
@@ -143,7 +143,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			detail::merge_adaptive(first, middle, last,
 				middle - first, last - middle, buf,
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		// Extension: Supports forward iterators.
@@ -163,7 +163,7 @@ STL2_OPEN_NAMESPACE {
 			} else {
 				auto n = __stl2::distance(first, std::forward<S>(last_));
 				return detail::fsort::sort_n(std::move(first), n,
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
 
@@ -173,10 +173,10 @@ STL2_OPEN_NAMESPACE {
 		safe_iterator_t<Rng> operator()(Rng&& rng, Comp comp = {}, Proj proj = {}) const {
 			if constexpr (RandomAccessRange<Rng>) {
 				return (*this)(begin(rng), end(rng),
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			} else {
 				return detail::fsort::sort_n(begin(rng), __stl2::distance(rng),
-					std::ref(comp), std::ref(proj));
+					__stl2::ref(comp), __stl2::ref(proj));
 			}
 		}
 	};

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 	{
 		return __stl2::transform(
 			begin(r), end(r), std::move(result),
-			std::ref(op), std::ref(proj));
+			__stl2::ref(op), __stl2::ref(proj));
 	}
 
 	template<InputIterator I1, Sentinel<I1> S1, class I2, WeaklyIncrementable O,
@@ -88,8 +88,8 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::transform(
 			begin(r1), end(r1),
 			std::move(first2), std::move(result),
-			std::ref(op), std::ref(proj1),
-			std::ref(proj2));
+			__stl2::ref(op), __stl2::ref(proj1),
+			__stl2::ref(proj2));
 	}
 
 	template<InputIterator I1, Sentinel<I1> S1,
@@ -128,9 +128,9 @@ STL2_OPEN_NAMESPACE {
 		return __stl2::transform(
 			begin(r1), end(r1),
 			begin(r2), end(r2),
-			std::move(result), std::ref(op),
-			std::ref(proj1),
-			std::ref(proj2));
+			std::move(result), __stl2::ref(op),
+			__stl2::ref(proj1),
+			__stl2::ref(proj2));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 	I unique(I first, S last, R comp = {}, Proj proj = {})
 	{
 		first = __stl2::adjacent_find(
-			std::move(first), last, std::ref(comp), std::ref(proj));
+			std::move(first), last, __stl2::ref(comp), __stl2::ref(proj));
 		if (first != last) {
 			for (auto m = __stl2::next(first, 2); m != last; ++m) {
 				if (!__stl2::invoke(comp, __stl2::invoke(proj, *first), __stl2::invoke(proj, *m))) {
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	unique(Rng&& rng, R comp = {}, Proj proj = {})
 	{
 		return __stl2::unique(begin(rng), end(rng),
-			std::ref(comp), std::ref(proj));
+			__stl2::ref(comp), __stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -104,8 +104,8 @@ STL2_OPEN_NAMESPACE {
 			ext::priority_tag<2>{},
 			std::move(first), std::move(last),
 			std::move(result),
-			std::ref(comp),
-			std::ref(proj));
+			__stl2::ref(comp),
+			__stl2::ref(proj));
 	}
 
 	template<InputRange Rng, WeaklyIncrementable O, class R = equal_to,
@@ -123,8 +123,8 @@ STL2_OPEN_NAMESPACE {
 			ext::priority_tag<2>{},
 			begin(rng), end(rng),
 			std::move(result),
-			std::ref(comp),
-			std::ref(proj));
+			__stl2::ref(comp),
+			__stl2::ref(proj));
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/upper_bound.hpp
+++ b/include/stl2/detail/algorithm/upper_bound.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr __f<I> operator()(I&& first, iter_difference_t<__f<I>> n, const T& value,
 				Comp comp = {}, Proj proj = {}) const {
 				auto pred = [&](auto&& i) { return !__stl2::invoke(comp, value, i); };
-				return ext::partition_point_n(std::forward<I>(first), n, pred, std::ref(proj));
+				return ext::partition_point_n(std::forward<I>(first), n, pred, __stl2::ref(proj));
 			}
 		};
 
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 			Comp comp = {}, Proj proj = {}) const {
 			auto pred = [&](auto&& i) { return !__stl2::invoke(comp, value, i); };
 			return __stl2::partition_point(std::forward<I>(first),
-				std::forward<S>(last), pred, std::ref(proj));
+				std::forward<S>(last), pred, __stl2::ref(proj));
 		}
 
 		template<class I, class S, class T, class Comp = less, class Proj = identity>
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 			auto first = std::forward<I>(first_);
 			auto n = __stl2::distance(first, std::forward<S>(last));
 			return ext::upper_bound_n(std::move(first), n, value,
-				std::ref(comp), std::ref(proj));
+				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<ForwardRange Rng, class T, class Comp = less, class Proj = identity>
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, const T& value, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng),
-				value, std::ref(comp), std::ref(proj));
+				value, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
 		template<ForwardRange Rng, class T, class Comp = less, class Proj = identity>
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, const T& value, Comp comp = {}, Proj proj = {}) const {
 			return ext::upper_bound_n(begin(rng), __stl2::distance(rng),
-				value, std::ref(comp), std::ref(proj));
+				value, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	};
 

--- a/include/stl2/detail/concepts/core.hpp
+++ b/include/stl2/detail/concepts/core.hpp
@@ -48,6 +48,11 @@ STL2_OPEN_NAMESPACE {
 	STL2_CONCEPT _SpecializationOf = meta::is<__uncvref<U>, T>::value;
 #endif
 
+	template<class T>
+	using __with_reference = T&;
+	template<class T>
+	STL2_CONCEPT __can_reference = requires { typename __with_reference<T>; };
+
 	///////////////////////////////////////////////////////////////////////////
 	// Same
 	//

--- a/include/stl2/detail/concepts/function.hpp
+++ b/include/stl2/detail/concepts/function.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 	template<class F, class... Args>
 	STL2_CONCEPT Invocable =
 		requires(F&& f, Args&&... args) {
-			__invoke::impl((F&&)f, (Args&&)args...);
+			__stl2::invoke((F&&)f, (Args&&)args...);
 		};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class F, class... Args>
 	STL2_CONCEPT Predicate =
-		RegularInvocable<F, Args...> &&
-			Boolean<result_of_t<F&&(Args&&...)>>;
+		RegularInvocable<F, Args...> && Boolean<invoke_result_t<F, Args...>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Relation [concepts.lib.callables.relation]

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -31,10 +31,6 @@
 //
 STL2_OPEN_NAMESPACE {
 	template<class T>
-	using __with_reference = T&;
-	template<class T>
-	STL2_CONCEPT __can_reference = requires { typename __with_reference<T>; };
-	template<class T>
 	STL2_CONCEPT __dereferenceable = requires(T& t) {
 		// { *t } -> __can_reference;
 		*t; typename __with_reference<decltype(*t)>;

--- a/include/stl2/detail/randutils.hpp
+++ b/include/stl2/detail/randutils.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 				template<RandomAccessIterator I, SizedSentinel<I> S>
 				void generate(I first, S last) const {
 					std::random_device rd{};
-					__stl2::generate(first, last, std::ref(rd));
+					__stl2::generate(first, last, __stl2::ref(rd));
 				}
 
 				static constexpr std::size_t size() noexcept { return ~std::size_t{0}; }

--- a/include/stl2/functional.hpp
+++ b/include/stl2/functional.hpp
@@ -29,6 +29,8 @@ STL2_OPEN_NAMESPACE {
 	template<_Decayed T>
 	struct __unwrap_<T> { using type = T; };
 	template<class T>
+	struct __unwrap_<__stl2::reference_wrapper<T>> { using type = T&; };
+	template<class T>
 	struct __unwrap_<std::reference_wrapper<T>> { using type = T&; };
 	template<class T>
 	using __unwrap = meta::_t<__unwrap_<T>>;

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 			auto cached = static_cast<bool>(begin_);
 			iterator_t<V> first = cached
 				? begin_.get(base_)
-				: __stl2::find_if(base_, std::ref(pred_.get()));
+				: __stl2::find_if(base_, __stl2::ref(pred_.get()));
 			if(!cached)
 				begin_.set(base_, first);
 			return __iterator{*this, std::move(first)};
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 		{
 			const auto last = __stl2::end(parent_->base_);
 			STL2_ASSERT(current_ != last);
-			current_ = __stl2::find_if(++current_, last, std::ref(parent_->pred_.get()));
+			current_ = __stl2::find_if(++current_, last, __stl2::ref(parent_->pred_.get()));
 			return *this;
 		}
 

--- a/test/algorithm/generate.cpp
+++ b/test/algorithm/generate.cpp
@@ -39,7 +39,7 @@ void test() {
 	const unsigned n = 4;
 	int ia[n] = {0};
 	auto f = gen_test{1};
-	auto res1 = ranges::generate(Iter(ia), Sent(ia + n), std::ref(f));
+	auto res1 = ranges::generate(Iter(ia), Sent(ia + n), ranges::ref(f));
 	CHECK(ia[0] == 1);
 	CHECK(ia[1] == 2);
 	CHECK(ia[2] == 3);
@@ -48,7 +48,7 @@ void test() {
 	CHECK(f.i_ == 5);
 
 	auto rng = ranges::subrange(Iter(ia), Sent(ia + n));
-	auto res2 = ranges::generate(rng, std::ref(f));
+	auto res2 = ranges::generate(rng, ranges::ref(f));
 	CHECK(ia[0] == 5);
 	CHECK(ia[1] == 6);
 	CHECK(ia[2] == 7);
@@ -56,7 +56,7 @@ void test() {
 	CHECK(res2 == Iter(ia + n));
 	CHECK(f.i_ == 9);
 
-	auto res3 = ranges::generate(std::move(rng), std::ref(f));
+	auto res3 = ranges::generate(std::move(rng), ranges::ref(f));
 	CHECK(ia[0] == 9);
 	CHECK(ia[1] == 10);
 	CHECK(ia[2] == 11);

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -163,7 +163,7 @@ static_assert(is_same<common_reference_t<void, void>, void>());
 static_assert(Common<void, void>);
 static_assert(is_same<common_type_t<void, void>, void>());
 
-static_assert(is_same<common_type_t<std::reference_wrapper<int>, int>, int>::value);
+static_assert(is_same<common_type_t<reference_wrapper<int>, int>, int>::value);
 
 // Test cases taken from libc++
 //===----------------------------------------------------------------------===//

--- a/test/functional/invoke.cpp
+++ b/test/functional/invoke.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include "../simple_test.hpp"
 
-namespace stl2 = __stl2;
+namespace ranges = __stl2;
 
 constexpr struct {
 	template<class T>
@@ -32,102 +32,100 @@ constexpr int f() noexcept { return 13; }
 constexpr int g(int i) { return 2 * i + 1; }
 
 int main() {
-	CHECK(stl2::invoke(f) == 13);
-	CHECK(noexcept(stl2::invoke(f) == 13));
-	CHECK(stl2::invoke(g, 2) == 5);
-	CHECK(stl2::invoke(h, 42) == 42);
-	CHECK(noexcept(stl2::invoke(h, 42) == 42));
+	CHECK(ranges::invoke(f) == 13);
+	CHECK(noexcept(ranges::invoke(f) == 13));
+	CHECK(ranges::invoke(g, 2) == 5);
+	CHECK(ranges::invoke(h, 42) == 42);
+	CHECK(noexcept(ranges::invoke(h, 42) == 42));
 	{
 		int i = 13;
-		CHECK(&stl2::invoke(h, i) == &i);
-		CHECK(noexcept(&stl2::invoke(h, i) == &i));
+		CHECK(&ranges::invoke(h, i) == &i);
+		CHECK(noexcept(&ranges::invoke(h, i) == &i));
 	}
 
-	CHECK(stl2::invoke(&A::f, A{}) == 42);
-	CHECK(noexcept(stl2::invoke(&A::f, A{}) == 42));
-	CHECK(stl2::invoke(&A::g, A{}, 2) == 4);
+	CHECK(ranges::invoke(&A::f, A{}) == 42);
+	CHECK(noexcept(ranges::invoke(&A::f, A{}) == 42));
+	CHECK(ranges::invoke(&A::g, A{}, 2) == 4);
 	{
 		A a;
 		const auto& ca = a;
-		CHECK(stl2::invoke(&A::f, a) == 42);
-		CHECK(noexcept(stl2::invoke(&A::f, a) == 42));
-		CHECK(stl2::invoke(&A::f, ca) == 42);
-		CHECK(noexcept(stl2::invoke(&A::f, ca) == 42));
-		CHECK(stl2::invoke(&A::g, a, 2) == 4);
+		CHECK(ranges::invoke(&A::f, a) == 42);
+		CHECK(noexcept(ranges::invoke(&A::f, a) == 42));
+		CHECK(ranges::invoke(&A::f, ca) == 42);
+		CHECK(noexcept(ranges::invoke(&A::f, ca) == 42));
+		CHECK(ranges::invoke(&A::g, a, 2) == 4);
 	}
 
 	{
 		A a;
 		const auto& ca = a;
-		CHECK(stl2::invoke(&A::f, &a) == 42);
-		CHECK(noexcept(stl2::invoke(&A::f, &a) == 42));
-		CHECK(stl2::invoke(&A::f, &ca) == 42);
-		CHECK(noexcept(stl2::invoke(&A::f, &ca) == 42));
-		CHECK(stl2::invoke(&A::g, &a, 2) == 4);
+		CHECK(ranges::invoke(&A::f, &a) == 42);
+		CHECK(noexcept(ranges::invoke(&A::f, &a) == 42));
+		CHECK(ranges::invoke(&A::f, &ca) == 42);
+		CHECK(noexcept(ranges::invoke(&A::f, &ca) == 42));
+		CHECK(ranges::invoke(&A::g, &a, 2) == 4);
 	}
 	{
 		auto up = std::make_unique<A>();
-		CHECK(stl2::invoke(&A::f, up) == 42);
-		CHECK(stl2::invoke(&A::g, up, 2) == 4);
+		CHECK(ranges::invoke(&A::f, up) == 42);
+		CHECK(ranges::invoke(&A::g, up, 2) == 4);
 	}
 	{
 		auto sp = std::make_shared<A>();
-		CHECK(stl2::invoke(&A::f, sp) == 42);
-		CHECK(noexcept(stl2::invoke(&A::f, sp) == 42));
-		CHECK(stl2::invoke(&A::g, sp, 2) == 4);
+		CHECK(ranges::invoke(&A::f, sp) == 42);
+		CHECK(noexcept(ranges::invoke(&A::f, sp) == 42));
+		CHECK(ranges::invoke(&A::g, sp, 2) == 4);
 	}
 
-	CHECK(stl2::invoke(&A::i, A{}) == 13);
-	CHECK(noexcept(stl2::invoke(&A::i, A{}) == 13));
-	{ int&& tmp = stl2::invoke(&A::i, A{}); (void)tmp; }
+	CHECK(ranges::invoke(&A::i, A{}) == 13);
+	CHECK(noexcept(ranges::invoke(&A::i, A{}) == 13));
+	{ int&& tmp = ranges::invoke(&A::i, A{}); (void)tmp; }
 
 	{
 		A a;
 		const auto& ca = a;
-		CHECK(stl2::invoke(&A::i, a) == 13);
-		CHECK(noexcept(stl2::invoke(&A::i, a) == 13));
-		CHECK(stl2::invoke(&A::i, ca) == 13);
-		CHECK(noexcept(stl2::invoke(&A::i, ca) == 13));
-		CHECK(stl2::invoke(&A::i, &a) == 13);
-		CHECK(noexcept(stl2::invoke(&A::i, &a) == 13));
-		CHECK(stl2::invoke(&A::i, &ca) == 13);
-		CHECK(noexcept(stl2::invoke(&A::i, &ca) == 13));
+		CHECK(ranges::invoke(&A::i, a) == 13);
+		CHECK(noexcept(ranges::invoke(&A::i, a) == 13));
+		CHECK(ranges::invoke(&A::i, ca) == 13);
+		CHECK(noexcept(ranges::invoke(&A::i, ca) == 13));
+		CHECK(ranges::invoke(&A::i, &a) == 13);
+		CHECK(noexcept(ranges::invoke(&A::i, &a) == 13));
+		CHECK(ranges::invoke(&A::i, &ca) == 13);
+		CHECK(noexcept(ranges::invoke(&A::i, &ca) == 13));
 
-		stl2::invoke(&A::i, a) = 0;
+		ranges::invoke(&A::i, a) = 0;
 		CHECK(a.i == 0);
-		stl2::invoke(&A::i, &a) = 1;
+		ranges::invoke(&A::i, &a) = 1;
 		CHECK(a.i == 1);
-		static_assert(stl2::Same<decltype(stl2::invoke(&A::i, ca)), const int&>);
-		static_assert(stl2::Same<decltype(stl2::invoke(&A::i, &ca)), const int&>);
+		static_assert(ranges::Same<decltype(ranges::invoke(&A::i, ca)), const int&>);
+		static_assert(ranges::Same<decltype(ranges::invoke(&A::i, &ca)), const int&>);
 	}
 
 	{
 		auto up = std::make_unique<A>();
-		CHECK(stl2::invoke(&A::i, up) == 13);
-		stl2::invoke(&A::i, up) = 0;
+		CHECK(ranges::invoke(&A::i, up) == 13);
+		ranges::invoke(&A::i, up) = 0;
 		CHECK(up->i == 0);
 	}
 
 	{
 		auto sp = std::make_shared<A>();
-		CHECK(stl2::invoke(&A::i, sp) == 13);
-		stl2::invoke(&A::i, sp) = 0;
+		CHECK(ranges::invoke(&A::i, sp) == 13);
+		ranges::invoke(&A::i, sp) = 0;
 		CHECK(sp->i == 0);
 	}
 
-	// constexpr tests (invoke is only constexpr when STL2_CONSTEXPR_EXTENSIONS
-	// is defined; __invoke::impl is constexpr regardless.)
 	{
 		struct B { int i = 42; constexpr int f() const { return i; } };
 		constexpr B b;
 		static_assert(b.i == 42);
 		static_assert(b.f() == 42);
-		static_assert(stl2::__invoke::impl(&B::i, b) == 42);
-		static_assert(stl2::__invoke::impl(&B::i, &b) == 42);
-		static_assert(stl2::__invoke::impl(&B::i, B{}) == 42);
-		static_assert(stl2::__invoke::impl(&B::f, b) == 42);
-		static_assert(stl2::__invoke::impl(&B::f, &b) == 42);
-		static_assert(stl2::__invoke::impl(&B::f, B{}) == 42);
+		static_assert(ranges::invoke(&B::i, b) == 42);
+		static_assert(ranges::invoke(&B::i, &b) == 42);
+		static_assert(ranges::invoke(&B::i, B{}) == 42);
+		static_assert(ranges::invoke(&B::f, b) == 42);
+		static_assert(ranges::invoke(&B::f, &b) == 42);
+		static_assert(ranges::invoke(&B::f, B{}) == 42);
 	}
 
 	return ::test_result();

--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -148,8 +148,8 @@ public:
 		}
 	};
 
-	std::reference_wrapper<T> operator*() const {
-		return std::reference_wrapper<T>{**ptr_};
+	ranges::reference_wrapper<T> operator*() const {
+		return ranges::reference_wrapper<T>{**ptr_};
 	}
 
 	bool operator==(const proxy_iterator& that) const {
@@ -166,7 +166,7 @@ public:
 		return *this;
 	}
 	readable_proxy operator++(int) & {
-		readable_proxy tmp{__stl2::iter_move(*ptr_)};
+		readable_proxy tmp{ranges::iter_move(*ptr_)};
 		++*this;
 		return tmp;
 	}
@@ -188,11 +188,11 @@ void test_proxy_iterator() {
 	static_assert(
 		ranges::Same<
 			ranges::iter_reference_t<proxy_iterator<A>>,
-			std::reference_wrapper<A>>);
+			ranges::reference_wrapper<A>>);
 	static_assert(
 		ranges::Same<
 			ranges::iter_reference_t<const proxy_iterator<A>>,
-			std::reference_wrapper<A>>);
+			ranges::reference_wrapper<A>>);
 	static_assert(
 		ranges::Same<
 			ranges::iter_rvalue_reference_t<proxy_iterator<A>>,

--- a/test/tagged.cpp
+++ b/test/tagged.cpp
@@ -191,7 +191,7 @@ void test_tagged_tuple_creation_para_4_example() {
 	using namespace __stl2;
 	int i;
 	float j;
-	auto t = __stl2::make_tagged_tuple<tag::in1, tag::in2, tag::out>(1, std::ref(i), std::cref(j));
+	auto t = make_tagged_tuple<tag::in1, tag::in2, tag::out>(1, ref(i), cref(j));
 	static_assert(Same<decltype(t), tagged_tuple<tag::in1(int), tag::in2(int&), tag::out(const float&)>>);
 	CHECK(t.in1() == 1);
 	CHECK(&t.in2() == &i);


### PR DESCRIPTION
* `invoke` is `constexpr`

* implement `constexpr`-ified `reference_wrapper` and friends, replace calls of `std::c?ref` with `__stl2::c?ref`

* `not_fn` is `constexpr`

Drive-by:
* Replace `result_of(_t)?` with `invoke_result(_t)?`
* `generate`, `generate_n`: sync to working draft
* Remove trivially satisfied requirement that the URBG returns an integral type convertible to some other integral type in `sample` and `shuffle`
* Promote `__can_reference` and `__with_reference` from `concepts/iterator.hpp` to `concepts/core.hpp` so I can use them to constrain `reference_wrapper`