### PR TITLE
Add missing std:: qualifications for entities declared in std

### DIFF
--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
 		requires Copyable<iter_value_t<iterator_t<R>>>
 		constexpr iter_value_t<iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<Copyable T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = ranges::less>
+			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
 		constexpr T operator()(std::initializer_list<T> r,
 			Comp comp = {}, Proj proj = {}) const
 		{

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -104,7 +104,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<Copyable T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = ranges::less>
+			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
 		constexpr tagged_pair<tag::min(T), tag::max(T)>
 		operator()(std::initializer_list<T>&& r, Comp comp = {}, Proj proj = {}) const
 		{

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -146,7 +146,7 @@ STL2_OPEN_NAMESPACE {
 	template <Permutable I>
 	subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<iter_value_t<I>>()) {
+		if (std::is_trivially_move_assignable_v<iter_value_t<I>>) {
 			if (next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}
@@ -159,7 +159,7 @@ STL2_OPEN_NAMESPACE {
 	requires Permutable<I>
 	subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<iter_value_t<I>>()) {
+		if (std::is_trivially_move_assignable_v<iter_value_t<I>>) {
 			if (next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}
@@ -175,7 +175,7 @@ STL2_OPEN_NAMESPACE {
 	requires Permutable<I>
 	subrange<I> __rotate(I first, I middle, I last)
 	{
-		if (is_trivially_move_assignable<iter_value_t<I>>()) {
+		if (std::is_trivially_move_assignable_v<iter_value_t<I>>) {
 			if (next(first) == middle) {
 				return __stl2::__rotate_left(std::move(first), std::move(last));
 			}

--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -27,16 +27,15 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT constraint =
 			InputIterator<I> && Sentinel<S, I> && WeaklyIncrementable<O> &&
 			IndirectlyCopyable<I, O> &&
-			UniformRandomNumberGenerator<remove_reference_t<Gen>>;
+			UniformRandomNumberGenerator<std::remove_reference_t<Gen>>;
 
 		template<class I, class S, class O, class Gen>
-		requires
-			constraint<I, S, O, Gen>
+		requires constraint<I, S, O, Gen>
 		tagged_pair<tag::in(I), tag::out(O)>
 		sized_impl(I first, S last, iter_difference_t<I> pop_size,
 			O out, iter_difference_t<I> n, Gen& gen)
 		{
-			uniform_int_distribution<iter_difference_t<I>> dist;
+			std::uniform_int_distribution<iter_difference_t<I>> dist;
 			using param_t = typename decltype(dist)::param_type;
 			if (n > pop_size) {
 				n = pop_size;
@@ -84,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			out[i] = *first;
 		}
-		uniform_int_distribution<iter_difference_t<I>> dist;
+		std::uniform_int_distribution<iter_difference_t<I>> dist;
 		using param_t = typename decltype(dist)::param_type;
 		for (auto pop_size = n; first != last; (void)++first, ++pop_size) {
 			auto const i = dist(gen, param_t{0, pop_size});

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -28,15 +28,15 @@ STL2_OPEN_NAMESPACE {
 		class Gen = detail::default_random_engine&, class D = iter_difference_t<I>>
 	requires
 		Permutable<I> &&
-		UniformRandomNumberGenerator<remove_reference_t<Gen>>
+		UniformRandomNumberGenerator<std::remove_reference_t<Gen>>
 	I shuffle(I const first, S const last, Gen&& g = detail::get_random_engine())
 	{
 		auto mid = first;
 		if (mid == last) {
 			return mid;
 		}
-		auto dist = uniform_int_distribution<D>{};
-		using param_t = typename uniform_int_distribution<D>::param_type;
+		auto dist = std::uniform_int_distribution<D>{};
+		using param_t = typename std::uniform_int_distribution<D>::param_type;
 		while (++mid != last) {
 			if (auto const i = dist(g, param_t{0, mid - first})) {
 				iter_swap(mid - i, mid);
@@ -49,11 +49,11 @@ STL2_OPEN_NAMESPACE {
 		class D = iter_difference_t<iterator_t<Rng>>>
 	requires
 		Permutable<iterator_t<Rng>> &&
-		UniformRandomNumberGenerator<remove_reference_t<Gen>>
+		UniformRandomNumberGenerator<std::remove_reference_t<Gen>>
 	inline safe_iterator_t<Rng> shuffle(
 		Rng&& rng, Gen&& g = detail::get_random_engine())
 	{
-		return  __stl2::shuffle(begin(rng), end(rng),
+		return __stl2::shuffle(begin(rng), end(rng),
 			std::forward<Gen>(g));
 	}
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/cached_position.hpp
+++ b/include/stl2/detail/cached_position.hpp
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		private:
 			meta::if_c<_ForwardingRange<R>,
-				optional<iterator_t<R>>,
+				std::optional<iterator_t<R>>,
 				non_propagating_cache<iterator_t<R>>> cache_;
 		};
 		template<RandomAccessRange R, class Tag>

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -28,9 +28,9 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class B>
 	STL2_CONCEPT Boolean =
-		Movable<decay_t<B>> &&
-		requires(const remove_reference_t<B>& b1,
-					const remove_reference_t<B>& b2, const bool a) {
+		Movable<std::decay_t<B>> &&
+		requires(const std::remove_reference_t<B>& b1,
+			     const std::remove_reference_t<B>& b2, const bool a) {
 			// Requirements common to both Boolean and BooleanTestable.
 			{ b1 } -> ConvertibleTo<bool>&&;
 			{ !b1 } -> ConvertibleTo<bool>&&;
@@ -64,8 +64,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T, class U>
 	STL2_CONCEPT WeaklyEqualityComparable =
-		requires(const remove_reference_t<T>& t,
-				 const remove_reference_t<U>& u) {
+		requires(const std::remove_reference_t<T>& t,
+				 const std::remove_reference_t<U>& u) {
 			{ t == u } -> Boolean&&;
 			{ t != u } -> Boolean&&;
 			{ u == t } -> Boolean&&;
@@ -85,20 +85,20 @@ STL2_OPEN_NAMESPACE {
 		EqualityComparable<U> &&
 		WeaklyEqualityComparable<T, U> &&
 		CommonReference<
-			const remove_reference_t<T>&,
-			const remove_reference_t<U>&> &&
+			const std::remove_reference_t<T>&,
+			const std::remove_reference_t<U>&> &&
 		EqualityComparable<
 			common_reference_t<
-				const remove_reference_t<T>&,
-				const remove_reference_t<U>&>>;
+				const std::remove_reference_t<T>&,
+				const std::remove_reference_t<U>&>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// StrictTotallyOrdered [concepts.lib.compare.stricttotallyordered]
 	//
 	template<class T, class U>
 	STL2_CONCEPT __totally_ordered =
-		requires(const remove_reference_t<T>& t,
-		         const remove_reference_t<U>& u) {
+		requires(const std::remove_reference_t<T>& t,
+		         const std::remove_reference_t<U>& u) {
 			{ t <  u } -> Boolean&&;
 			{ t >  u } -> Boolean&&;
 			{ t <= u } -> Boolean&&;
@@ -124,12 +124,12 @@ STL2_OPEN_NAMESPACE {
 		__totally_ordered<T, U> &&
 		__totally_ordered<U, T> &&
 		CommonReference<
-			const remove_reference_t<T>&,
-			const remove_reference_t<U>&> &&
+			const std::remove_reference_t<T>&,
+			const std::remove_reference_t<U>&> &&
 		StrictTotallyOrdered<
 			common_reference_t<
-				const remove_reference_t<T>&,
-				const remove_reference_t<U>&>>;
+				const std::remove_reference_t<T>&,
+				const std::remove_reference_t<U>&>>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/function.hpp
+++ b/include/stl2/detail/concepts/function.hpp
@@ -36,8 +36,7 @@ STL2_OPEN_NAMESPACE {
 	// RegularInvocable [concepts.lib.callables.regularcallable]
 	//
 	template<class F, class... Args>
-	STL2_CONCEPT RegularInvocable =
-		Invocable<F, Args...>;
+	STL2_CONCEPT RegularInvocable = Invocable<F, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Predicate [concepts.lib.callables.predicate]
@@ -56,23 +55,22 @@ STL2_OPEN_NAMESPACE {
 		Predicate<R, T, U> &&
 		Predicate<R, U, T> &&
 		CommonReference<
-			const remove_reference_t<T>&,
-			const remove_reference_t<U>&> &&
+			const std::remove_reference_t<T>&,
+			const std::remove_reference_t<U>&> &&
 		Predicate<
 			R,
 			common_reference_t<
-				const remove_reference_t<T>&,
-				const remove_reference_t<U>&>,
+				const std::remove_reference_t<T>&,
+				const std::remove_reference_t<U>&>,
 			common_reference_t<
-				const remove_reference_t<T>&,
-				const remove_reference_t<U>&>>;
+				const std::remove_reference_t<T>&,
+				const std::remove_reference_t<U>&>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// StrictWeakOrder [concepts.lib.callables.strictweakorder]
 	//
 	template<class R, class T, class U>
-	STL2_CONCEPT StrictWeakOrder =
-		Relation<R, T, U>;
+	STL2_CONCEPT StrictWeakOrder = Relation<R, T, U>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/fundamental.hpp
+++ b/include/stl2/detail/concepts/fundamental.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT Scalar =
-			_Is<T, is_scalar> && Regular<T>;
+			_Is<T, std::is_scalar> && Regular<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT Arithmetic =
-			_Is<T, is_arithmetic> && Scalar<T> && StrictTotallyOrdered<T>;
+			_Is<T, std::is_arithmetic> && Scalar<T> && StrictTotallyOrdered<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT FloatingPoint =
-			_Is<T, is_floating_point> && Arithmetic<T>;
+			_Is<T, std::is_floating_point> && Arithmetic<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T>
 	STL2_CONCEPT Integral =
-		_Is<T, is_integral> && ext::Arithmetic<T>;
+		_Is<T, std::is_integral> && ext::Arithmetic<T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// SignedIntegral [concepts.lib.corelang.signedintegral]

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -49,8 +49,8 @@ STL2_OPEN_NAMESPACE {
 	// the decayed type can in fact be constructed from the actual type.
 	//
 	template<class T>
-		requires Constructible<decay_t<T>, T>
-	using __f = decay_t<T>;
+		requires Constructible<std::decay_t<T>, T>
+	using __f = std::decay_t<T>;
 
 	namespace ext {
 		///////////////////////////////////////////////////////////////////////////
@@ -76,40 +76,40 @@ STL2_OPEN_NAMESPACE {
 		//
 		template<class T>
 		STL2_CONCEPT TriviallyDestructible =
-			Destructible<T> && _Is<T, is_trivially_destructible>;
+			Destructible<T> && _Is<T, std::is_trivially_destructible>;
 
 		template<class T, class... Args>
 		STL2_CONCEPT TriviallyConstructible =
 			Constructible<T, Args...> &&
-			_Is<T, is_trivially_constructible, Args...>;
+			_Is<T, std::is_trivially_constructible, Args...>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyDefaultConstructible =
 			DefaultConstructible<T> &&
-			_Is<T, is_trivially_default_constructible>;
+			_Is<T, std::is_trivially_default_constructible>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyMoveConstructible =
-			MoveConstructible<T> && _Is<T, is_trivially_move_constructible>;
+			MoveConstructible<T> && _Is<T, std::is_trivially_move_constructible>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyCopyConstructible =
 			CopyConstructible<T> &&
 			TriviallyMoveConstructible<T> &&
-			_Is<T, is_trivially_copy_constructible>;
+			_Is<T, std::is_trivially_copy_constructible>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyMovable =
 			Movable<T> &&
 			TriviallyMoveConstructible<T> &&
-			_Is<T, is_trivially_move_assignable>;
+			_Is<T, std::is_trivially_move_assignable>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyCopyable =
 			Copyable<T> &&
 			TriviallyMovable<T> &&
 			TriviallyCopyConstructible<T> &&
-			_Is<T, is_trivially_copy_assignable>;
+			_Is<T, std::is_trivially_copy_assignable>;
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -24,12 +24,12 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T, class U>
 	STL2_CONCEPT Assignable =
-		_Is<T, is_lvalue_reference> &&
+		_Is<T, std::is_lvalue_reference> &&
 		CommonReference<
-			const remove_reference_t<T>&,
-			const remove_reference_t<U>&> &&
+			const std::remove_reference_t<T>&,
+			const std::remove_reference_t<U>&> &&
 		requires(T t, U&& u) {
-			{ t = (U&&)u } -> Same<T>&&;
+			{ t = static_cast<U&&>(u) } -> Same<T>&&;
 		};
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -31,14 +31,14 @@ STL2_OPEN_NAMESPACE {
 	// Destructible [concept.destructible]
 	//
 	template<class T>
-	STL2_CONCEPT Destructible = _Is<T, is_nothrow_destructible>;
+	STL2_CONCEPT Destructible = _Is<T, std::is_nothrow_destructible>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Constructible [concept.constructible]
 	//
 	template<class T, class... Args>
 	STL2_CONCEPT Constructible =
-		Destructible<T> && _Is<T, is_constructible, Args...>;
+		Destructible<T> && _Is<T, std::is_constructible, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// DefaultConstructible [concept.defaultconstructible]

--- a/include/stl2/detail/construct_destruct.hpp
+++ b/include/stl2/detail/construct_destruct.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 			template<class T, class... Args>
 			requires Constructible<T, Args...>
 			void operator()(T& t, Args&&... args) const
-			noexcept(is_nothrow_constructible<T, Args...>::value)
+			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			{
 				::new(static_cast<void*>(&t))
 					T{std::forward<Args>(args)...};

--- a/include/stl2/detail/functional/comparisons.hpp
+++ b/include/stl2/detail/functional/comparisons.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) == std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) != std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) > std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) < std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) >= std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t) <= std::forward<U>(u);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class T>
-		constexpr bool IsValueType = !is_void<T>::value;
+		constexpr bool IsValueType = !std::is_void<T>::value;
 	} // namespace detail
 	template<class T>
 	requires
@@ -149,7 +149,7 @@ STL2_OPEN_NAMESPACE {
 		requires
 			!detail::MemberValueType<C> && requires { typename reference_t<C>; }
 		struct value_type<C> {
-			using type = decay_t<reference_t<C>>;
+			using type = std::decay_t<reference_t<C>>;
 			static_assert(detail::IsValueType<type>,
 				"Cursor's reference type does not decay to a value type.");
 		};
@@ -169,9 +169,9 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT Cursor =
 			requires {
 				typename difference_type_t<C>;
-				typename mixin_t<remove_cv_t<C>>;
+				typename mixin_t<std::remove_cv_t<C>>;
 			} &&
-			_Cursor<remove_cv_t<C>, mixin_t<remove_cv_t<C>>>;
+			_Cursor<std::remove_cv_t<C>, mixin_t<std::remove_cv_t<C>>>;
 
 		template<class C>
 		STL2_CONCEPT Readable =
@@ -238,9 +238,9 @@ STL2_OPEN_NAMESPACE {
 			Readable<C>
 		struct rvalue_reference<C> {
 			using type = meta::if_<
-				is_reference<reference_t<C>>,
-				remove_reference_t<reference_t<C>>&&,
-				decay_t<reference_t<C>>>;
+				std::is_reference<reference_t<C>>,
+				std::remove_reference_t<reference_t<C>>&&,
+				std::decay_t<reference_t<C>>>;
 		};
 		template<class C>
 		requires
@@ -279,7 +279,7 @@ STL2_OPEN_NAMESPACE {
 		STL2_CONCEPT Contiguous =
 			RandomAccess<C> &&
 			contiguous<C> &&
-			is_lvalue_reference<reference_t<C>>::value;
+			std::is_lvalue_reference<reference_t<C>>::value;
 
 		template<class From, class To>
 		STL2_CONCEPT ConvertibleTo =
@@ -510,11 +510,11 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool is_writable = true;
 		template<class C>
 		requires
-			cursor::Readable<remove_cv_t<C>>
+			cursor::Readable<std::remove_cv_t<C>>
 		constexpr bool is_writable<C> = false;
 		template<class C>
 		requires
-			cursor::Readable<remove_cv_t<C>> &&
+			cursor::Readable<std::remove_cv_t<C>> &&
 			cursor::Writable<C, cursor::value_type_t<C>&&>
 		constexpr bool is_writable<C> = true;
 
@@ -648,21 +648,21 @@ STL2_OPEN_NAMESPACE {
 
 		template<cursor::ConvertibleTo<C> O>
 		constexpr basic_iterator& operator=(basic_iterator<O>&& that) &
-		noexcept(is_nothrow_assignable<C&, O>::value)
+		noexcept(std::is_nothrow_assignable<C&, O>::value)
 		{
 			get() = __stl2::get_cursor(std::move(that));
 			return *this;
 		}
 		template<cursor::ConvertibleTo<C> O>
 		constexpr basic_iterator& operator=(const basic_iterator<O>& that) &
-		noexcept(is_nothrow_assignable<C&, const O&>::value)
+		noexcept(std::is_nothrow_assignable<C&, const O&>::value)
 		{
 			get() = __stl2::get_cursor(that);
 			return *this;
 		}
 		template<class T>
 		requires
-			!Same<decay_t<T>, basic_iterator> && !cursor::Next<C> &&
+			!Same<std::decay_t<T>, basic_iterator> && !cursor::Next<C> &&
 			cursor::Writable<C, T>
 		constexpr basic_iterator& operator=(T&& t)
 		noexcept(noexcept(
@@ -675,10 +675,10 @@ STL2_OPEN_NAMESPACE {
 		// http://wg21.link/P0186
 		template<class O>
 		requires
-			!Same<decay_t<O>, basic_iterator> &&
+			!Same<std::decay_t<O>, basic_iterator> &&
 			Assignable<C&, O>
 		constexpr basic_iterator& operator=(O&& o) &
-		noexcept(is_nothrow_assignable<C&, O>::value)
+		noexcept(std::is_nothrow_assignable<C&, O>::value)
 		{
 			get() = std::forward<O>(o);
 			return *this;
@@ -741,8 +741,8 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		constexpr basic_iterator operator++(int) &
-		noexcept(is_nothrow_copy_constructible<basic_iterator>::value &&
-			is_nothrow_move_constructible<basic_iterator>::value &&
+		noexcept(std::is_nothrow_copy_constructible<basic_iterator>::value &&
+			std::is_nothrow_move_constructible<basic_iterator>::value &&
 			noexcept(++std::declval<basic_iterator&>()))
 		{
 			auto tmp(*this);
@@ -781,8 +781,8 @@ STL2_OPEN_NAMESPACE {
 			return *this;
 		}
 		constexpr basic_iterator operator--(int) &
-		noexcept(is_nothrow_copy_constructible<basic_iterator>::value &&
-			is_nothrow_move_constructible<basic_iterator>::value &&
+		noexcept(std::is_nothrow_copy_constructible<basic_iterator>::value &&
+			std::is_nothrow_move_constructible<basic_iterator>::value &&
 			noexcept(--std::declval<basic_iterator&>()))
 		requires cursor::Bidirectional<C>
 		{
@@ -886,8 +886,8 @@ STL2_OPEN_NAMESPACE {
 	template<class C>
 	constexpr basic_iterator<C> operator+(
 		const basic_iterator<C>& i, cursor::difference_type_t<C> n)
-	noexcept(is_nothrow_copy_constructible<basic_iterator<C>>::value &&
-		is_nothrow_move_constructible<basic_iterator<C>>::value &&
+	noexcept(std::is_nothrow_copy_constructible<basic_iterator<C>>::value &&
+		std::is_nothrow_move_constructible<basic_iterator<C>>::value &&
 		noexcept(std::declval<basic_iterator<C>&>() += n))
 	requires cursor::RandomAccess<C>
 	{

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -216,7 +216,7 @@ STL2_OPEN_NAMESPACE {
 		decltype(auto) operator->() const
 		requires Readable<const I> &&
 			(_HasArrow<const I> ||
-			 is_reference_v<iter_reference_t<I>> ||
+			 std::is_reference_v<iter_reference_t<I>> ||
 			 Constructible<iter_value_t<I>, iter_reference_t<I>>)
 		{
 			if constexpr (std::is_pointer_v<I> || _HasArrow<const I>)

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -52,8 +52,7 @@ STL2_OPEN_NAMESPACE {
 		template<class>
 		constexpr bool has_customization = false;
 		template<class R>
-		requires
-			__dereferenceable<R> &&
+		requires __dereferenceable<R> &&
 			requires(R&& r) {
 				// { iter_move(static_cast<R&&>(r)) ->__can_reference;
 				iter_move(static_cast<R&&>(r));
@@ -63,20 +62,18 @@ STL2_OPEN_NAMESPACE {
 
 		template<class R>
 		using rvalue =
-			meta::if_<is_reference<R>, remove_reference_t<R>&&, decay_t<R>>;
+			meta::if_<std::is_reference<R>, std::remove_reference_t<R>&&, std::decay_t<R>>;
 
 		struct fn {
 			template<class R>
-			requires
-				__dereferenceable<R> && has_customization<R>
+			requires __dereferenceable<R> && has_customization<R>
 			constexpr decltype(auto) operator()(R&& r) const
 			STL2_NOEXCEPT_RETURN(
 				iter_move((R&&)r)
 			)
 
 			template<class R>
-			requires
-				__dereferenceable<R>
+			requires __dereferenceable<R>
 			constexpr rvalue<iter_reference_t<R>> operator()(R&& r) const
 			STL2_NOEXCEPT_RETURN(
 				static_cast<rvalue<iter_reference_t<R>>>(*r)
@@ -118,11 +115,11 @@ STL2_OPEN_NAMESPACE {
 		using type = std::remove_cv_t<T>;
 	};
 
-	template<_Is<is_array> T>
-	struct readable_traits<T> : readable_traits<decay_t<T>> {};
+	template<_Is<std::is_array> T>
+	struct readable_traits<T> : readable_traits<std::decay_t<T>> {};
 
 	template<class I>
-	struct readable_traits<I const> : readable_traits<decay_t<I>> {};
+	struct readable_traits<I const> : readable_traits<std::decay_t<I>> {};
 
 	template<detail::MemberValueType T>
 	struct readable_traits<T> {};
@@ -224,9 +221,9 @@ STL2_OPEN_NAMESPACE {
 	template<class Out, IndirectlyMovableStorable<Out> In>
 	constexpr bool is_nothrow_indirectly_movable_storable_v<In, Out> =
 		is_nothrow_indirectly_movable_v<In, Out> &&
-		is_nothrow_assignable<iter_reference_t<Out>, iter_value_t<In>>::value &&
-		is_nothrow_constructible<iter_value_t<In>, iter_rvalue_reference_t<In>>::value &&
-		is_nothrow_assignable<iter_value_t<In>&, iter_rvalue_reference_t<In>>::value;
+		std::is_nothrow_assignable<iter_reference_t<Out>, iter_value_t<In>>::value &&
+		std::is_nothrow_constructible<iter_value_t<In>, iter_rvalue_reference_t<In>>::value &&
+		std::is_nothrow_assignable<iter_value_t<In>&, iter_rvalue_reference_t<In>>::value;
 
 	///////////////////////////////////////////////////////////////////////////
 	// IndirectlyCopyable [commonalgoreq.indirectlycopyable]
@@ -258,23 +255,20 @@ STL2_OPEN_NAMESPACE {
 		template<class, class>
 		constexpr bool has_customization = false;
 		template<class R1, class R2>
-		requires
-			requires(R1&& r1, R2&& r2) {
-				iter_swap((R1&&)r1, (R2&&)r2);
-			}
+		requires requires(R1&& r1, R2&& r2) {
+			iter_swap((R1&&)r1, (R2&&)r2);
+		}
 		constexpr bool has_customization<R1, R2> = true;
 
 		template<class R1, class R2>
-		requires
-			SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>>
+		requires SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>>
 		constexpr void impl(R1&& r1, R2&& r2)
 		STL2_NOEXCEPT_RETURN(
 			__stl2::swap(*r1, *r2)
 		)
 
 		template<class R1, class R2>
-		requires
-			!SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>> &&
+		requires !SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>> &&
 			IndirectlyMovableStorable<R1, R2> &&
 			IndirectlyMovableStorable<R2, R1>
 		constexpr void impl(R1& r1, R2& r2)
@@ -290,8 +284,8 @@ STL2_OPEN_NAMESPACE {
 		struct fn {
 			template<class R1, class R2>
 			requires
-				Readable<remove_reference_t<R1>> &&
-				Readable<remove_reference_t<R2>> &&
+				Readable<std::remove_reference_t<R1>> &&
+				Readable<std::remove_reference_t<R2>> &&
 				has_customization<R1, R2>
 			constexpr void operator()(R1&& r1, R2&& r2) const
 			STL2_NOEXCEPT_RETURN(
@@ -300,8 +294,8 @@ STL2_OPEN_NAMESPACE {
 
 			template<class R1, class R2>
 			requires
-				Readable<remove_reference_t<R1>> &&
-				Readable<remove_reference_t<R2>> &&
+				Readable<std::remove_reference_t<R1>> &&
+				Readable<std::remove_reference_t<R2>> &&
 				!has_customization<R1&, R2&> &&
 				requires(R1& r1, R2& r2) {
 					__iter_swap::impl(r1, r2);
@@ -456,7 +450,7 @@ STL2_OPEN_NAMESPACE {
 	template<class S, class I>
 	STL2_CONCEPT SizedSentinel =
 		Sentinel<S, I> &&
-		!disable_sized_sentinel<remove_cv_t<S>, remove_cv_t<I>> &&
+		!disable_sized_sentinel<std::remove_cv_t<S>, std::remove_cv_t<I>> &&
 		requires(const I i, const S s) {
 			{ s - i } -> Same<iter_difference_t<I>>&&;
 			{ i - s } -> Same<iter_difference_t<I>>&&;
@@ -555,7 +549,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<InputIterator I>
 	struct __pointer_type {
-		using type = add_pointer_t<iter_reference_t<I>>;
+		using type = std::add_pointer_t<iter_reference_t<I>>;
 	};
 
 	template<InputIterator I>

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -297,7 +297,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<Iterator I>
 		constexpr auto uncounted(const I& i)
-		noexcept(is_nothrow_copy_constructible<I>::value) {
+		noexcept(std::is_nothrow_copy_constructible<I>::value) {
 			return i;
 		}
 
@@ -309,7 +309,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<Iterator I>
 		constexpr auto recounted(const I&, const I& i, iter_difference_t<I> = 0)
-		noexcept(is_nothrow_copy_constructible<I>::value)
+		noexcept(std::is_nothrow_copy_constructible<I>::value)
 		{
 			return i;
 		}

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -52,13 +52,13 @@ STL2_OPEN_NAMESPACE {
 
 	template<class T>
 		requires !detail::MemberDifferenceType<T> &&
-			_IsNot<T, is_pointer> && // Avoid GCC PR 78173 (See above)
+			_IsNot<T, std::is_pointer> && // Avoid GCC PR 78173 (See above)
 			requires(const T& a, const T& b) {
 				// { a - b } -> Integral;
 				a - b; requires Integral<decltype(a - b)>;
 			}
 	struct incrementable_traits<T>
-	: make_signed<decltype(std::declval<const T>() - std::declval<const T>())> {};
+	: std::make_signed<decltype(std::declval<const T>() - std::declval<const T>())> {};
 
 	template<class T>
 	using iter_difference_t = meta::_t<incrementable_traits<T>>;

--- a/include/stl2/detail/iterator/istream_iterator.hpp
+++ b/include/stl2/detail/iterator/istream_iterator.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			using difference_type = Distance;
 			using value_type = T;
 			using istream_type = std::basic_istream<charT, traits>;
-			using single_pass = true_type;
+			using single_pass = std::true_type;
 
 			class mixin : protected basic_mixin<istream_cursor> {
 				using base_t = basic_mixin<istream_cursor>;
@@ -66,14 +66,14 @@ STL2_OPEN_NAMESPACE {
 			};
 
 			constexpr istream_cursor()
-			noexcept(is_nothrow_default_constructible<T>::value) = default;
+			noexcept(std::is_nothrow_default_constructible<T>::value) = default;
 
 			istream_cursor(istream_type& s)
 			: stream_{std::addressof(s)}
 			{ next(); }
 
 			constexpr istream_cursor(default_sentinel)
-			noexcept(is_nothrow_default_constructible<T>::value)
+			noexcept(std::is_nothrow_default_constructible<T>::value)
 			: istream_cursor{}
 			{}
 

--- a/include/stl2/detail/iterator/istreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/istreambuf_iterator.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 			using streambuf_type = std::basic_streambuf<charT, traits>;
 			using istream_type = std::basic_istream<charT, traits>;
 			using int_type = typename traits::int_type;
-			using single_pass = true_type;
+			using single_pass = std::true_type;
 
 			class pointer {
 			public:
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 				friend cursor;
 
 				explicit constexpr pointer(const cursor& i)
-				noexcept(is_nothrow_move_constructible<charT>::value)
+				noexcept(std::is_nothrow_move_constructible<charT>::value)
 				: keep_{i.current()}
 				{}
 
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 				using value_type = charT;
 
 				constexpr charT operator*() const
-				noexcept(is_nothrow_copy_constructible<charT>::value)
+				noexcept(std::is_nothrow_copy_constructible<charT>::value)
 				{
 					return keep_;
 				}
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 
 				constexpr __proxy() noexcept = default;
 				constexpr __proxy(charT c, streambuf_type* sbuf)
-				noexcept(is_nothrow_move_constructible<charT>::value)
+				noexcept(std::is_nothrow_move_constructible<charT>::value)
 				: keep_{std::move(c)}, sbuf_{sbuf}
 				{}
 

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 				using base_t::base_t;
 
 				constexpr I base() const
-				noexcept(is_nothrow_copy_constructible<I>::value)
+				noexcept(std::is_nothrow_copy_constructible<I>::value)
 				{
 					return base_t::get().current_;
 				}
@@ -76,16 +76,16 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr cursor() = default;
 			constexpr explicit cursor(I&& i)
-			noexcept(is_nothrow_move_constructible<I>::value)
+			noexcept(std::is_nothrow_move_constructible<I>::value)
 			: current_{std::move(i)}
 			{}
 			constexpr explicit cursor(const I& i)
-			noexcept(is_nothrow_copy_constructible<I>::value)
+			noexcept(std::is_nothrow_copy_constructible<I>::value)
 			: current_{i}
 			{}
 			template<ConvertibleTo<I> U>
 			constexpr cursor(const cursor<U>& u)
-			noexcept(is_nothrow_constructible<I, const U&>::value)
+			noexcept(std::is_nothrow_constructible<I, const U&>::value)
 			: current_{access::current(u)}
 			{}
 
@@ -231,37 +231,36 @@ STL2_OPEN_NAMESPACE {
 		using box_t = detail::ebo_box<S, move_sentinel<S>>;
 	public:
 		constexpr move_sentinel()
-		noexcept(is_nothrow_default_constructible<S>::value)
+		noexcept(std::is_nothrow_default_constructible<S>::value)
 		: box_t{}
 		{}
 		explicit constexpr move_sentinel(S s)
-		noexcept(is_nothrow_move_constructible<S>::value)
+		noexcept(std::is_nothrow_move_constructible<S>::value)
 		: box_t(std::move(s))
 		{}
 		template<class T>
 		requires ConvertibleTo<const T&, S>
 		constexpr move_sentinel(const move_sentinel<T>& s)
-		noexcept(is_nothrow_constructible<S, const T&>::value)
+		noexcept(std::is_nothrow_constructible<S, const T&>::value)
 		: box_t{__move_iterator::access::sentinel(s)}
 		{}
 
 		template<class T>
 		requires Assignable<S&, const T&>
 		constexpr move_sentinel& operator=(const move_sentinel<T>& s) &
-		noexcept(is_nothrow_assignable<S&, const T&>::value)
+		noexcept(std::is_nothrow_assignable<S&, const T&>::value)
 		{
 			box_t::get() = __move_iterator::access::sentinel(s);
 			return *this;
 		}
 
 		constexpr S base() const
-		noexcept(is_nothrow_copy_constructible<S>::value)
+		noexcept(std::is_nothrow_copy_constructible<S>::value)
 		{ return box_t::get(); }
 	};
 
 	template<class S>
-	requires
-		Semiregular<__f<S>>
+	requires Semiregular<__f<S>>
 	constexpr auto make_move_sentinel(S&& s)
 	STL2_NOEXCEPT_RETURN(
 		move_sentinel<__f<S>>(std::forward<S>(s))

--- a/include/stl2/detail/iterator/ostream_iterator.hpp
+++ b/include/stl2/detail/iterator/ostream_iterator.hpp
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 			return *this;
 		}
 	private:
-		detail::raw_ptr<basic_ostream<charT, traits>> out_stream_{nullptr};
+		detail::raw_ptr<std::basic_ostream<charT, traits>> out_stream_{nullptr};
 		const charT* delim_{nullptr};
 	};
 

--- a/include/stl2/detail/iterator/reverse_iterator.hpp
+++ b/include/stl2/detail/iterator/reverse_iterator.hpp
@@ -61,18 +61,18 @@ STL2_OPEN_NAMESPACE {
 				using base_t::base_t;
 
 				constexpr I base() const
-				noexcept(is_nothrow_copy_constructible<I>::value)
+				noexcept(std::is_nothrow_copy_constructible<I>::value)
 				{ return base_t::get().current_; }
 			};
 
 			constexpr cursor() = default;
 			constexpr explicit cursor(I x)
-			noexcept(is_nothrow_move_constructible<I>::value)
+			noexcept(std::is_nothrow_move_constructible<I>::value)
 			: current_{std::move(x)}
 			{}
 			template<ConvertibleTo<I> U>
 			constexpr cursor(const cursor<U>& u)
-			noexcept(is_nothrow_constructible<I, const U&>::value)
+			noexcept(std::is_nothrow_constructible<I, const U&>::value)
 			: current_{access::current(u)}
 			{}
 

--- a/include/stl2/detail/non_propagating_cache.hpp
+++ b/include/stl2/detail/non_propagating_cache.hpp
@@ -22,7 +22,7 @@ STL2_OPEN_NAMESPACE {
 		template<ext::DestructibleObject T, class Tag = void, bool Enable = true>
 		struct non_propagating_cache : std::optional<T> {
 			non_propagating_cache() = default;
-			constexpr non_propagating_cache(nullopt_t) noexcept
+			constexpr non_propagating_cache(std::nullopt_t) noexcept
 			{}
 			constexpr non_propagating_cache(non_propagating_cache const &) noexcept
 			: std::optional<T>{}

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -141,10 +141,10 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class R>
 	STL2_CONCEPT ContiguousRange =
-		_Is<iter_reference_t<iterator_t<R>>, is_reference> &&
+		_Is<iter_reference_t<iterator_t<R>>, std::is_reference> &&
 		Same<iter_value_t<iterator_t<R>>, __uncvref<iter_reference_t<iterator_t<R>>>> &&
 		requires(R& r) {
-			{ data(r) } -> Same<add_pointer_t<iter_reference_t<iterator_t<R>>>>;
+			{ data(r) } -> Same<std::add_pointer_t<iter_reference_t<iterator_t<R>>>>;
 		};
 
 	namespace ext {

--- a/include/stl2/detail/tagged.hpp
+++ b/include/stl2/detail/tagged.hpp
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 	// Not to spec: Kill with fire.
 	//
 	template<ext::DestructibleObject Base, TagSpecifier... Tags>
-	requires sizeof...(Tags) <= tuple_size<Base>::value
+	requires sizeof...(Tags) <= std::tuple_size<Base>::value
 	struct tagged
 	: meta::_t<__tagged::chain<Base, 0, Tags...>>
 #if STL2_WORKAROUND_CLANG_37556
@@ -142,7 +142,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<class U>
-		requires !Same<decay_t<U>, tagged> && Assignable<Base&, U>
+		requires !Same<std::decay_t<U>, tagged> && Assignable<Base&, U>
 		constexpr tagged& operator=(U&& u) &
 		noexcept(std::is_nothrow_assignable<Base&, U&&>::value)
 		{

--- a/include/stl2/detail/temporary_vector.hpp
+++ b/include/stl2/detail/temporary_vector.hpp
@@ -31,10 +31,10 @@ STL2_OPEN_NAMESPACE {
 
 		template<class T>
 		class temporary_buffer {
-			unique_ptr<T, temporary_buffer_deleter> alloc_;
+			std::unique_ptr<T, temporary_buffer_deleter> alloc_;
 			std::ptrdiff_t size_ = 0;
 
-			temporary_buffer(pair<T*, std::ptrdiff_t> buf) :
+			temporary_buffer(std::pair<T*, std::ptrdiff_t> buf) :
 				alloc_{buf.first}, size_{buf.second} {}
 
 		public:
@@ -54,14 +54,14 @@ STL2_OPEN_NAMESPACE {
 		template<class T>
 		requires alignof(T) > alignof(std::max_align_t)
 		class temporary_buffer<T> {
-			unique_ptr<unsigned char, temporary_buffer_deleter> alloc_;
+			std::unique_ptr<unsigned char, temporary_buffer_deleter> alloc_;
 			T* aligned_ = nullptr;
 			std::ptrdiff_t size_ = 0;
 
 			static_assert((alignof(T) & (alignof(T) - 1)) == 0,
 				"Alignment must be a power of two.");
 
-			temporary_buffer(pair<unsigned char*, std::ptrdiff_t> buf)
+			temporary_buffer(std::pair<unsigned char*, std::ptrdiff_t> buf)
 			: alloc_{buf.first}
 			{
 				if (buf.second > 0 && static_cast<std::size_t>(buf.second) >= sizeof(T)) {
@@ -145,18 +145,18 @@ STL2_OPEN_NAMESPACE {
 			template<class... Args>
 			requires Constructible<T, Args...>
 			void emplace_back(Args&&... args)
-			noexcept(is_nothrow_constructible<T, Args...>::value)
+			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			{
 				STL2_EXPECT(end_ < alloc_);
 				detail::construct(*end_, std::forward<Args>(args)...);
 				++end_;
 			}
 			void push_back(const T& t)
-			noexcept(is_nothrow_copy_constructible<T>::value)
+			noexcept(std::is_nothrow_copy_constructible<T>::value)
 			requires CopyConstructible<T>
 			{ emplace_back(t); }
 			void push_back(T&& t)
-			noexcept(is_nothrow_move_constructible<T>::value)
+			noexcept(std::is_nothrow_move_constructible<T>::value)
 			requires MoveConstructible<T>
 			{ emplace_back(std::move(t)); }
 		};

--- a/include/stl2/functional.hpp
+++ b/include/stl2/functional.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 			return std::forward<T>(t);
 		}
 
-		using is_transparent = true_type;
+		using is_transparent = std::true_type;
 	};
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/tuple.hpp
+++ b/include/stl2/tuple.hpp
@@ -22,7 +22,7 @@ STL2_OPEN_NAMESPACE {
 	// tagged_tuple
 	template<TaggedType... Types>
 	using tagged_tuple =
-		tagged<tuple<__tagged::element<Types>...>, __tagged::specifier<Types>...>;
+		tagged<std::tuple<__tagged::element<Types>...>, __tagged::specifier<Types>...>;
 
 	// make_tagged_tuple
 	template<TagSpecifier... Tags, class... Types>

--- a/include/stl2/utility.hpp
+++ b/include/stl2/utility.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<TaggedType F, TaggedType S>
 	using tagged_pair =
-		tagged<pair<__tagged::element<F>, __tagged::element<S>>,
+		tagged<std::pair<__tagged::element<F>, __tagged::element<S>>,
 			__tagged::specifier<F>, __tagged::specifier<S>>;
 
 	////////////////////////////////////////////////////////////////////////////

--- a/include/stl2/view/drop.hpp
+++ b/include/stl2/view/drop.hpp
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 
 			template<class X>
 			static constexpr auto begin_impl(X& x) {
-				if constexpr (RandomAccessRange<__maybe_const<is_const_v<X>, R>>) {
+				if constexpr (RandomAccessRange<__maybe_const<std::is_const_v<X>, R>>) {
 					return __stl2::ext::nth_iterator(x.base_, x.count_);
 				} else {
 					using cache_t = typename drop_view::cached_position;

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -94,7 +94,7 @@ STL2_OPEN_NAMESPACE {
 		// Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		template<class II = iterator_t<V>>
 		constexpr iterator_t<V> operator->() const
-		requires is_pointer_v<iterator_t<V>> ||
+		requires std::is_pointer_v<iterator_t<V>> ||
 			requires(II i) { i.operator->(); }
 		{
 			return current_;

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 		template<View Rng>
 		requires
 			InputRange<Rng> &&
-			Readable<remove_reference_t<iter_reference_t<iterator_t<Rng>>>>
+			Readable<std::remove_reference_t<iter_reference_t<iterator_t<Rng>>>>
 		class indirect_view
 		: public view_interface<indirect_view<Rng>>
 		, private detail::ebo_box<Rng, indirect_view<Rng>> {

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -45,8 +45,8 @@ STL2_OPEN_NAMESPACE {
 		!std::is_reference_v<T> && requires {
 			typename std::tuple_size<T>::type;
 			requires DerivedFrom<std::tuple_size<T>, std::integral_constant<std::size_t, 2>>;
-			typename std::tuple_element_t<0, remove_const_t<T>>;
-			typename std::tuple_element_t<1, remove_const_t<T>>;
+			typename std::tuple_element_t<0, std::remove_const_t<T>>;
+			typename std::tuple_element_t<1, std::remove_const_t<T>>;
 			requires _PairLikeGCCBugs<T>; // Separate named concept to avoid
 			                              // premature substitution.
 		};

--- a/test/iterator/counted_iterator.cpp
+++ b/test/iterator/counted_iterator.cpp
@@ -17,7 +17,7 @@
 #include "../test_iterators.hpp"
 #include "../simple_test.hpp"
 
-namespace ranges = std::experimental::ranges;
+namespace ranges = __stl2;
 
 constexpr bool test_constexpr() {
 	int some_ints[] = {0,1,2,3};
@@ -85,7 +85,7 @@ static_assert(test_constexpr());
 
 int main()
 {
-	using namespace std::experimental::ranges;
+	using namespace ranges;
 
 	{
 		int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/test/iterator/operations.cpp
+++ b/test/iterator/operations.cpp
@@ -14,7 +14,7 @@
 #include <stl2/view/take_exactly.hpp>
 #include <stl2/detail/iterator/basic_iterator.hpp>
 
-namespace ranges = std::experimental::ranges;
+namespace ranges = __stl2;
 
 namespace {
     template<class T, std::size_t N, bool Bidi = true>

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include "../simple_test.hpp"
 
-namespace ranges = std::experimental::ranges;
+namespace ranges = __stl2;
 using ranges::ext::span;
 using ranges::ext::__span::narrow_cast;
 using ranges::ext::make_span;


### PR DESCRIPTION
... and remove extraneous `ranges::` qualifiers for types in this library that leaked in from the working draft.