### PR TITLE
Use variable templates directly in constraints instead of _Is

### DIFF
--- a/include/stl2/detail/cheap_storage.hpp
+++ b/include/stl2/detail/cheap_storage.hpp
@@ -29,11 +29,11 @@ STL2_OPEN_NAMESPACE {
 		requires
 			CopyConstructible<T> &&
 			std::is_trivially_copyable<T>::value &&
-			((_Is<T, std::is_empty> && !_Is<T, std::is_final>) ||
+			((std::is_empty_v<T> && !std::is_final_v<T>) ||
 				sizeof(T) <= cheap_copy_size)
 		constexpr bool cheaply_copyable<T> = true;
 
-		template<_Is<std::is_object> T, class Tag = void>
+		template<ext::Object T, class Tag = void>
 		class ref_box {
 		public:
 			ref_box() = default;
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		// Note: promotes to CopyConstructible
-		template<_Is<std::is_object> T, class Tag = void>
+		template<ext::Object T, class Tag = void>
 		using cheap_reference_box_t = meta::if_c<
 			cheaply_copyable<remove_cv_t<T>>,
 			ebo_box<remove_cv_t<T>, Tag>,

--- a/include/stl2/detail/concepts/core.hpp
+++ b/include/stl2/detail/concepts/core.hpp
@@ -27,8 +27,10 @@ STL2_OPEN_NAMESPACE {
 	template<bool B>
 	inline constexpr bool __bool = B;
 
+#if 0 // UNUSED
 	template<class U, template<class...> class T, class... V>
 	STL2_CONCEPT _Is = _Valid<T, U, V...> && __bool<T<U, V...>::value>;
+#endif
 
 	template<class U, template<class...> class T, class... V>
 	STL2_CONCEPT _IsNot = _Valid<T, U, V...> && __bool<!T<U, V...>::value>;
@@ -37,8 +39,10 @@ STL2_OPEN_NAMESPACE {
 	template<class U, template<class...> class T>
 	STL2_CONCEPT _SpecializationOf = __bool<meta::is<__uncvref<U>, T>::value>;
 #else
+#if 0 // UNUSED
 	template<class U, template<class...> class T, class... V>
 	STL2_CONCEPT _Is = _Valid<T, U, V...> && T<U, V...>::value;
+#endif
 
 	template<class U, template<class...> class T, class... V>
 	STL2_CONCEPT _IsNot = _Valid<T, U, V...> && !T<U, V...>::value;

--- a/include/stl2/detail/concepts/fundamental.hpp
+++ b/include/stl2/detail/concepts/fundamental.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT Scalar =
-			_Is<T, std::is_scalar> && Regular<T>;
+			std::is_scalar_v<T> && Regular<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT Arithmetic =
-			_Is<T, std::is_arithmetic> && Scalar<T> && StrictTotallyOrdered<T>;
+			std::is_arithmetic_v<T> && Scalar<T> && StrictTotallyOrdered<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		STL2_CONCEPT FloatingPoint =
-			_Is<T, std::is_floating_point> && Arithmetic<T>;
+			std::is_floating_point_v<T> && Arithmetic<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T>
 	STL2_CONCEPT Integral =
-		_Is<T, std::is_integral> && ext::Arithmetic<T>;
+		std::is_integral_v<T> && ext::Arithmetic<T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// SignedIntegral [concepts.lib.corelang.signedintegral]

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -76,40 +76,40 @@ STL2_OPEN_NAMESPACE {
 		//
 		template<class T>
 		STL2_CONCEPT TriviallyDestructible =
-			Destructible<T> && _Is<T, std::is_trivially_destructible>;
+			Destructible<T> && std::is_trivially_destructible_v<T>;
 
 		template<class T, class... Args>
 		STL2_CONCEPT TriviallyConstructible =
 			Constructible<T, Args...> &&
-			_Is<T, std::is_trivially_constructible, Args...>;
+			std::is_trivially_constructible_v<T, Args...>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyDefaultConstructible =
 			DefaultConstructible<T> &&
-			_Is<T, std::is_trivially_default_constructible>;
+			std::is_trivially_default_constructible_v<T>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyMoveConstructible =
-			MoveConstructible<T> && _Is<T, std::is_trivially_move_constructible>;
+			MoveConstructible<T> && std::is_trivially_move_constructible_v<T>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyCopyConstructible =
 			CopyConstructible<T> &&
 			TriviallyMoveConstructible<T> &&
-			_Is<T, std::is_trivially_copy_constructible>;
+			std::is_trivially_copy_constructible_v<T>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyMovable =
 			Movable<T> &&
 			TriviallyMoveConstructible<T> &&
-			_Is<T, std::is_trivially_move_assignable>;
+			std::is_trivially_move_assignable_v<T>;
 
 		template<class T>
 		STL2_CONCEPT TriviallyCopyable =
 			Copyable<T> &&
 			TriviallyMovable<T> &&
 			TriviallyCopyConstructible<T> &&
-			_Is<T, std::is_trivially_copy_assignable>;
+			std::is_trivially_copy_assignable_v<T>;
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -22,14 +22,18 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// Assignable [concepts.lib.corelang.assignable]
 	//
-	template<class T, class U>
+	template<class LHS, class RHS>
 	STL2_CONCEPT Assignable =
-		_Is<T, std::is_lvalue_reference> &&
+		std::is_lvalue_reference_v<LHS> &&
+#if 0 // TODO: investigate making this change
+		CommonReference<LHS, RHS> &&
+#else
 		CommonReference<
-			const std::remove_reference_t<T>&,
-			const std::remove_reference_t<U>&> &&
-		requires(T t, U&& u) {
-			{ t = static_cast<U&&>(u) } -> Same<T>&&;
+			const std::remove_reference_t<LHS>&,
+			const std::remove_reference_t<RHS>&> &&
+#endif
+		requires(LHS lhs, RHS&& rhs) {
+			{ lhs = static_cast<RHS&&>(rhs) } -> Same<LHS>&&;
 		};
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object/movable.hpp
+++ b/include/stl2/detail/concepts/object/movable.hpp
@@ -24,10 +24,8 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T>
 	STL2_CONCEPT Movable =
-		ext::Object<T> &&
-		MoveConstructible<T> &&
-		Assignable<T&, T> &&
-		Swappable<T>;
+		std::is_object_v<T> && MoveConstructible<T> &&
+		Assignable<T&, T> && Swappable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -24,21 +24,21 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT Object = _Is<T, std::is_object>;
+		STL2_CONCEPT Object = std::is_object_v<T>;
 	} // namespace ext
 
 	///////////////////////////////////////////////////////////////////////////
 	// Destructible [concept.destructible]
 	//
 	template<class T>
-	STL2_CONCEPT Destructible = _Is<T, std::is_nothrow_destructible>;
+	STL2_CONCEPT Destructible = std::is_nothrow_destructible_v<T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Constructible [concept.constructible]
 	//
 	template<class T, class... Args>
 	STL2_CONCEPT Constructible =
-		Destructible<T> && _Is<T, std::is_constructible, Args...>;
+		Destructible<T> && std::is_constructible_v<T, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// DefaultConstructible [concept.defaultconstructible]

--- a/include/stl2/detail/concepts/object/regular.hpp
+++ b/include/stl2/detail/concepts/object/regular.hpp
@@ -22,8 +22,7 @@ STL2_OPEN_NAMESPACE {
 	// Regular [concepts.lib.object.regular]
 	//
 	template<class T>
-	STL2_CONCEPT Regular =
-		Semiregular<T> && EqualityComparable<T>;
+	STL2_CONCEPT Regular = Semiregular<T> && EqualityComparable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/semiregular.hpp
+++ b/include/stl2/detail/concepts/object/semiregular.hpp
@@ -27,28 +27,22 @@ STL2_OPEN_NAMESPACE {
 	template<class T>
 	STL2_CONCEPT CopyConstructible =
 		MoveConstructible<T> &&
-		Constructible<T, T&> &&
-		Constructible<T, const T&> &&
-		Constructible<T, const T> &&
-		ConvertibleTo<T&, T> &&
-		ConvertibleTo<const T&, T> &&
-		ConvertibleTo<const T, T>;
+		Constructible<T, T&> && ConvertibleTo<T&, T> &&
+		Constructible<T, const T&> && ConvertibleTo<const T&, T> &&
+		Constructible<T, const T> && ConvertibleTo<const T, T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Copyable [concepts.lib.object.copyable]
 	//
 	template<class T>
 	STL2_CONCEPT Copyable =
-		CopyConstructible<T> &&
-		Movable<T> &&
-		Assignable<T&, const T&>;
+		CopyConstructible<T> && Movable<T> && Assignable<T&, const T&>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Semiregular [concepts.lib.object.semiregular]
 	//
 	template<class T>
-	STL2_CONCEPT Semiregular =
-		Copyable<T> && DefaultConstructible<T>;
+	STL2_CONCEPT Semiregular = Copyable<T> && DefaultConstructible<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/functional/invoke.hpp
+++ b/include/stl2/detail/functional/invoke.hpp
@@ -50,7 +50,8 @@ STL2_OPEN_NAMESPACE {
 		)
 	}
 
-	template<_Is<std::is_function> F, class T, class T1, class... Args>
+	template<class F, class T, class T1, class... Args>
+	requires std::is_function_v<F>
 	constexpr decltype(auto) invoke(F (T::*f), T1&& t1, Args&&... args)
 	STL2_NOEXCEPT_REQUIRES_RETURN(
 		(__invoke::coerce<T>(static_cast<T1&&>(t1)).*f)(static_cast<Args&&>(args)...)

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -107,16 +107,16 @@ STL2_OPEN_NAMESPACE {
 		struct difference_type {
 			using type = std::ptrdiff_t;
 		};
-		template<detail::MemberDifferenceType C>
+		template<class C>
+		requires requires { typename C::difference_type; }
 		struct difference_type<C> {
 			using type = typename C::difference_type;
 			static_assert(SignedIntegral<type>,
 				"Cursor's member difference_type is not a signed integer type.");
 		};
 		template<class C>
-		requires
-			!detail::MemberDifferenceType<C> &&
-			requires(const C& lhs, const C& rhs) { rhs.distance_to(lhs); }
+		requires (!requires { typename C::difference_type; } &&
+			requires(const C& lhs, const C& rhs) { rhs.distance_to(lhs); })
 		struct difference_type<C> {
 			using type =
 				decltype(std::declval<const C&>().distance_to(std::declval<const C&>()));
@@ -870,7 +870,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class C>
 	struct incrementable_traits<basic_iterator<C>> {
-		using type = cursor::difference_type_t<C>;
+		using difference_type = cursor::difference_type_t<C>;
 	};
 
 	template<cursor::Input C>
@@ -880,7 +880,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<cursor::Input C>
 	struct readable_traits<basic_iterator<C>> {
-		using type = cursor::value_type_t<C>;
+		using value_type = cursor::value_type_t<C>;
 	};
 
 	template<class C>

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -265,12 +265,12 @@ STL2_OPEN_NAMESPACE {
 
 	template<class I, class S>
 	struct incrementable_traits<common_iterator<I, S>> {
-		using type = iter_difference_t<I>;
+		using difference_type = iter_difference_t<I>;
 	};
 
 	template<Readable I, class S>
 	struct readable_traits<common_iterator<I, S>> {
-		using type = iter_value_t<I>;
+		using value_type = iter_value_t<I>;
 	};
 
 	template<InputIterator I, class S>

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -115,7 +115,8 @@ STL2_OPEN_NAMESPACE {
 		using type = std::remove_cv_t<T>;
 	};
 
-	template<_Is<std::is_array> T>
+	template<class T>
+	requires std::is_array_v<T>
 	struct readable_traits<T> : readable_traits<std::decay_t<T>> {};
 
 	template<class I>

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -93,67 +93,48 @@ STL2_OPEN_NAMESPACE {
 		decltype(iter_move(std::declval<R&>()));
 
 	///////////////////////////////////////////////////////////////////////////
-	// value_type [readable.iterators]
-	// Not to spec:
-	// * Implements https://github.com/ericniebler/stl2/issues/423
+	// readable_traits [readable.traits]
 	//
 	namespace detail {
 		template<class T>
 		STL2_CONCEPT MemberValueType =
 			requires { typename T::value_type; };
-
-		template<class T>
-		STL2_CONCEPT MemberElementType =
-			requires { typename T::element_type; };
 	}
 
-	template<class>
-	struct readable_traits {};
-
-	template<ext::Object T>
-	struct readable_traits<T*> {
-		using type = std::remove_cv_t<T>;
+	template<class T> struct __cond_value_type {};
+	template<class T>
+	requires std::is_object_v<T>
+	struct __cond_value_type<T> {
+		using value_type = std::remove_cv_t<T>;
 	};
 
+	template<class> struct readable_traits {};
+
 	template<class T>
-	requires std::is_array_v<T>
-	struct readable_traits<T> : readable_traits<std::decay_t<T>> {};
+	struct readable_traits<T*> : __cond_value_type<T> {};
 
 	template<class I>
-	struct readable_traits<I const> : readable_traits<std::decay_t<I>> {};
-
-	template<detail::MemberValueType T>
-	struct readable_traits<T> {};
-
-	template<detail::MemberValueType T>
-	requires ext::Object<typename T::value_type>
-	struct readable_traits<T> {
-		using type = typename T::value_type;
+	requires std::is_array_v<I>
+	struct readable_traits<I> {
+		using value_type = std::remove_cv_t<std::remove_extent_t<I>>;
 	};
 
-	template<detail::MemberElementType T>
-	struct readable_traits<T> {};
+	template<class I>
+	struct readable_traits<I const> : readable_traits<I> {};
 
-	template<detail::MemberElementType T>
-	requires ext::Object<typename T::element_type>
-	struct readable_traits<T> {
-		using type = std::remove_cv_t<typename T::element_type>;
-	};
+	template<class I>
+	requires requires { typename I::value_type; }
+	struct readable_traits<I> : __cond_value_type<typename I::value_type> {};
 
-	template<class T>
-	requires
-		detail::MemberValueType<T> && ext::Object<typename T::value_type> &&
-		detail::MemberElementType<T> && ext::Object<typename T::element_type> &&
-		Same<typename T::value_type, std::remove_cv_t<typename T::element_type>>
-	struct readable_traits<T> {
-		using type = typename T::value_type;
-	};
+	template<class I>
+	requires requires { typename I::element_type; }
+	struct readable_traits<I> : __cond_value_type<typename I::element_type> {};
 
 	///////////////////////////////////////////////////////////////////////////
 	// iter_value_t [readable.iterators]
 	//
-	template<class T>
-	using iter_value_t = meta::_t<readable_traits<T>>;
+	template<class I>
+	using iter_value_t = typename readable_traits<I>::value_type;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Readable [readable.iterators]

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -268,12 +268,12 @@ STL2_OPEN_NAMESPACE {
 
 	template<class I>
 	struct incrementable_traits<counted_iterator<I>> {
-		using type = iter_difference_t<I>;
+		using difference_type = iter_difference_t<I>;
 	};
 
 	template<Readable I>
 	struct readable_traits<counted_iterator<I>> {
-		using type = iter_value_t<I>;
+		using value_type = iter_value_t<I>;
 	};
 	template<InputIterator I>
 	struct iterator_category<counted_iterator<I>> {

--- a/include/stl2/detail/iterator/insert_iterators.hpp
+++ b/include/stl2/detail/iterator/insert_iterators.hpp
@@ -127,7 +127,7 @@ STL2_OPEN_NAMESPACE {
 	class insert_iterator {
 	public:
 		using container_type = Container;
-		using difference_type = ptrdiff_t;
+		using difference_type = std::ptrdiff_t;
 
 		insert_iterator() = default;
 		constexpr insert_iterator(Container& x, iterator_t<Container> i)

--- a/include/stl2/detail/iterator/ostream_iterator.hpp
+++ b/include/stl2/detail/iterator/ostream_iterator.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 		StreamInsertable<T, charT, traits>
 	class ostream_iterator {
 	public:
-		using difference_type = ptrdiff_t;
+		using difference_type = std::ptrdiff_t;
 		using char_type = charT;
 		using traits_type = traits;
 		using ostream_type = std::basic_ostream<charT, traits>;

--- a/include/stl2/detail/iterator/ostreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/ostreambuf_iterator.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 	template<class charT, class traits = std::char_traits<charT>>
 	class ostreambuf_iterator {
 	public:
-		using difference_type = ptrdiff_t;
+		using difference_type = std::ptrdiff_t;
 		using char_type = charT;
 		using traits_type = traits;
 		using ostream_type = std::basic_ostream<charT, traits>;

--- a/include/stl2/detail/memory/concepts.hpp
+++ b/include/stl2/detail/memory/concepts.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	STL2_CONCEPT __NoThrowInputIterator =
 		InputIterator<I> &&
-		_Is<iter_reference_t<I>, std::is_lvalue_reference> &&
+		std::is_lvalue_reference_v<iter_reference_t<I>> &&
 		Same<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
 		// Axiom: no exceptions are thrown from increment, copy, move, assignment,
 		//        indirection through valid iterators.

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -141,7 +141,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class R>
 	STL2_CONCEPT ContiguousRange =
-		_Is<iter_reference_t<iterator_t<R>>, std::is_reference> &&
+		std::is_reference_v<iter_reference_t<iterator_t<R>>> &&
 		Same<iter_value_t<iterator_t<R>>, __uncvref<iter_reference_t<iterator_t<R>>>> &&
 		requires(R& r) {
 			{ data(r) } -> Same<std::add_pointer_t<iter_reference_t<iterator_t<R>>>>;

--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 
 		inline constexpr auto dynamic_extent = static_cast<__span::index_t>(-1);
 
-		template<_Is<std::is_object> ElementType, __span::index_t Extent = dynamic_extent>
+		template<ext::Object ElementType, __span::index_t Extent = dynamic_extent>
 		requires Extent >= dynamic_extent
 		struct span;
 
@@ -124,7 +124,7 @@ STL2_OPEN_NAMESPACE {
 		} // namespace __span
 
 		// [span], class template span
-		template<_Is<std::is_object> ElementType, __span::index_t Extent>
+		template<ext::Object ElementType, __span::index_t Extent>
 		requires Extent >= dynamic_extent
 		struct span : private __span::extent<Extent> {
 			// constants and types

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -166,10 +166,10 @@ STL2_OPEN_NAMESPACE {
 	template<class T, class U>
 	struct __common_reference2 : __common_reference2_1_<T, U> {};
 
-	template<_Is<std::is_reference> T, _Is<std::is_reference> U>
-	requires
+	template<class T, class U>
+	requires std::is_reference_v<T> && std::is_reference_v<U> &&
 		_Valid<__builtin_common_t, T, U> &&
-		_Is<__builtin_common_t<T, U>, std::is_reference>
+		std::is_reference_v<__builtin_common_t<T, U>>
 	struct __common_reference2<T, U> : __builtin_common<T, U> {};
 
 	template<class T, class U>
@@ -201,14 +201,17 @@ STL2_OPEN_NAMESPACE {
 		requires {
 			typename common_type_t<T, U>;
 			typename common_type_t<U, T>;
+			requires Same<common_type_t<T, U>, common_type_t<U, T>>;
+			static_cast<common_type_t<T, U>>(std::declval<T>());
+			static_cast<common_type_t<T, U>>(std::declval<U>());
 		} &&
-		Same<common_type_t<T, U>, common_type_t<U, T>> &&
-		ConvertibleTo<T, common_type_t<T, U>> &&
-		ConvertibleTo<U, common_type_t<T, U>> &&
-		CommonReference<std::add_lvalue_reference_t<const T>,
+		CommonReference<
+			std::add_lvalue_reference_t<const T>,
 			std::add_lvalue_reference_t<const U>> &&
-		CommonReference<std::add_lvalue_reference_t<common_type_t<T, U>>,
-			common_reference_t<std::add_lvalue_reference_t<const T>,
+		CommonReference<
+			std::add_lvalue_reference_t<common_type_t<T, U>>,
+			common_reference_t<
+				std::add_lvalue_reference_t<const T>,
 				std::add_lvalue_reference_t<const U>>>;
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/counted.hpp
+++ b/include/stl2/view/counted.hpp
@@ -13,14 +13,14 @@
 #define STL2_VIEW_COUNTED_VIEW_HPP
 
 #include <stl2/detail/fwd.hpp>
-#include <stl2/detail/concepts/core.hpp>
-#include <stl2/view/subrange.hpp>
+#include <stl2/detail/concepts/object.hpp>
 #include <stl2/detail/iterator/counted_iterator.hpp>
+#include <stl2/view/subrange.hpp>
 
 STL2_OPEN_NAMESPACE {
 	namespace view {
 		struct __counted_fn {
-			template<_Is<std::is_object> T>
+			template<__stl2::ext::Object T>
 			constexpr auto operator()(T* p, std::ptrdiff_t d) const
 			{
 				STL2_EXPECT(d >= 0);

--- a/include/stl2/view/counted.hpp
+++ b/include/stl2/view/counted.hpp
@@ -20,16 +20,14 @@
 STL2_OPEN_NAMESPACE {
 	namespace view {
 		struct __counted_fn {
-			template<__stl2::ext::Object T>
-			constexpr auto operator()(T* p, std::ptrdiff_t d) const
-			{
-				STL2_EXPECT(d >= 0);
-				return subrange{p, p + d};
-			}
-
 			template<Iterator I>
-			constexpr auto operator()(I i, iter_difference_t<I> d) const
-			{ return subrange{counted_iterator{i, d}, default_sentinel{}}; }
+			constexpr auto operator()(I i, iter_difference_t<I> d) const {
+				if constexpr (RandomAccessIterator<I>) {
+					return subrange{i, i + d};
+				} else {
+					return subrange{counted_iterator{i, d}, default_sentinel{}};
+				}
+			}
 		};
 
 		inline constexpr __counted_fn counted {};

--- a/include/stl2/view/empty.hpp
+++ b/include/stl2/view/empty.hpp
@@ -17,14 +17,14 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<_Is<std::is_object> T>
+	template<ext::Object T>
 	class empty_view : public view_interface<empty_view<T>> {
 	public:
 		constexpr static T* begin() noexcept
 		{ return nullptr; }
 		constexpr static T* end() noexcept
 		{ return nullptr; }
-		constexpr static ptrdiff_t size() noexcept
+		constexpr static std::ptrdiff_t size() noexcept
 		{ return 0; }
 		constexpr static T* data() noexcept
 		{ return nullptr; }

--- a/include/stl2/view/empty.hpp
+++ b/include/stl2/view/empty.hpp
@@ -12,27 +12,20 @@
 #ifndef STL2_VIEW_EMPTY_HPP
 #define STL2_VIEW_EMPTY_HPP
 
-#include <stl2/detail/fwd.hpp>
-#include <stl2/detail/concepts/core.hpp>
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<ext::Object T>
-	class empty_view : public view_interface<empty_view<T>> {
-	public:
-		constexpr static T* begin() noexcept
-		{ return nullptr; }
-		constexpr static T* end() noexcept
-		{ return nullptr; }
-		constexpr static std::ptrdiff_t size() noexcept
-		{ return 0; }
-		constexpr static T* data() noexcept
-		{ return nullptr; }
+	template<class T>
+	requires std::is_object_v<T>
+	struct empty_view : view_interface<empty_view<T>> {
+		static constexpr T* begin() noexcept { return nullptr; }
+		static constexpr T* end() noexcept { return nullptr; }
+		static constexpr T* data() noexcept { return nullptr; }
+		static constexpr std::ptrdiff_t size() noexcept { return 0; }
+		static constexpr bool empty() noexcept { return true; }
 
-		friend T* begin(empty_view) noexcept
-		{ return nullptr; }
-		friend T* end(empty_view) noexcept
-		{ return nullptr; }
+		friend constexpr T* begin(empty_view) noexcept { return nullptr; }
+		friend constexpr T* end(empty_view) noexcept { return nullptr; }
 	};
 
 	namespace view {

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -29,8 +29,8 @@ STL2_OPEN_NAMESPACE {
 		// A conversion is a slicing conversion if the source and the destination
 		// are both pointers, and if the pointed-to types differ after removing
 		// cv qualifiers.
-		!(_Is<std::decay_t<From>, std::is_pointer> &&
-		  _Is<std::decay_t<To>, std::is_pointer> &&
+		!(std::is_pointer_v<std::decay_t<From>> &&
+		  std::is_pointer_v<std::decay_t<To>> &&
 		  _NotSameAs<std::remove_pointer_t<std::decay_t<From>>,
 		             std::remove_pointer_t<std::decay_t<To>>>);
 

--- a/test/concepts/iterator.cpp
+++ b/test/concepts/iterator.cpp
@@ -32,8 +32,6 @@ namespace ns {
 	template<class I>
 	using iter_value_t = ranges::iterator_value_t<I>;
 
-	using ranges::value_type;
-	using ranges::difference_type;
 	using ranges::iterator_category;
 
 	using ranges::input_iterator_tag;
@@ -68,6 +66,11 @@ namespace associated_type_test {
 	struct A { using value_type = int; int& operator*() const; };
 	struct B : A { using value_type = double; };
 
+	template<class, class = void>
+	constexpr bool has_member_value_type = false;
+	template<class T>
+	constexpr bool has_member_value_type<T, std::void_t<typename T::value_type>> = true;
+
 	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int*>>);
 	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[]>>);
 	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[4]>>);
@@ -88,12 +91,12 @@ namespace associated_type_test {
 	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<A>>);
 	CONCEPT_ASSERT(ranges::Same<double, ns::iter_value_t<B>>);
 	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int*>>);
-	CONCEPT_ASSERT(!meta::is_trait<ns::readable_traits<void>>());
-	CONCEPT_ASSERT(!meta::is_trait<ns::readable_traits<void*>>());
+	CONCEPT_ASSERT(!has_member_value_type<ns::readable_traits<void>>);
+	CONCEPT_ASSERT(!has_member_value_type<ns::readable_traits<void*>>);
 	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int* const>>);
 	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int[2]>>);
 	struct S { using value_type = int; using element_type = int const; };
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<S>>);
+	// ns::readable_traits<S> // ill-formed, hard error
 
 	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int*>>);
 	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int[]>>);


### PR DESCRIPTION
To avoid inadvertently taking advantage of subsumption that won't be
present in the working draft constraints.

Drive-by: std::-qualify uses of ptrdiff_t that were missed, and a update a few components I ran across eliminating uses of `ext::Object` in non-`ext` code.