### PR TITLE
Reduce meta/stl2 duplication:

### DIFF
--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -24,7 +24,7 @@
 STL2_OPEN_NAMESPACE {
 	namespace __sample {
 		template<class I, class S, class O, class Gen>
-		STL2_CONCEPT constraint =
+		META_CONCEPT constraint =
 			InputIterator<I> && Sentinel<S, I> && WeaklyIncrementable<O> &&
 			IndirectlyCopyable<I, O> &&
 			UniformRandomNumberGenerator<std::remove_reference_t<Gen>>;

--- a/include/stl2/detail/concepts/algorithm.hpp
+++ b/include/stl2/detail/concepts/algorithm.hpp
@@ -26,14 +26,14 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I1, class I2, class R = equal_to, class P1 = identity,
 		class P2 = identity>
-	STL2_CONCEPT IndirectlyComparable =
+	META_CONCEPT IndirectlyComparable =
 		IndirectRelation<R, projected<I1, P1>, projected<I2, P2>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Permutable [commmonalgoreq.permutable]
 	//
 	template<class I>
-	STL2_CONCEPT Permutable =
+	META_CONCEPT Permutable =
 		ForwardIterator<I> &&
 		IndirectlyMovableStorable<I, I> &&
 		IndirectlySwappable<I, I>;
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I1, class I2, class Out, class R = less,
 		class P1 = identity, class P2 = identity>
-	STL2_CONCEPT Mergeable =
+	META_CONCEPT Mergeable =
 		InputIterator<I1> &&
 		InputIterator<I2> &&
 		WeaklyIncrementable<Out> &&
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 	// Sortable [commmonalgoreq.sortable]
 	//
 	template<class I, class R = less, class P = identity>
-	STL2_CONCEPT Sortable =
+	META_CONCEPT Sortable =
 		Permutable<I> &&
 		IndirectStrictWeakOrder<R, projected<I, P>>;
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template<class F, class... Is>
-		STL2_CONCEPT IndirectInvocable =
+		META_CONCEPT IndirectInvocable =
 			(Readable<Is> && ... && true) &&
 			CopyConstructible<F> &&
 			// The following 3 are checked redundantly, but are called out
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class F, class I>
-	STL2_CONCEPT IndirectUnaryInvocable =
+	META_CONCEPT IndirectUnaryInvocable =
 		ext::IndirectInvocable<F, I>;
 
 	///////////////////////////////////////////////////////////////////////////
@@ -86,12 +86,12 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template<class F, class... Is>
-		STL2_CONCEPT IndirectRegularInvocable =
+		META_CONCEPT IndirectRegularInvocable =
 			IndirectInvocable<F, Is...>;
 	}
 
 	template<class F, class I>
-	STL2_CONCEPT IndirectRegularUnaryInvocable =
+	META_CONCEPT IndirectRegularUnaryInvocable =
 		ext::IndirectRegularInvocable<F, I>;
 
 	template<class, class...> struct __predicate : std::false_type {};
@@ -101,7 +101,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template<class F, class... Is>
-		STL2_CONCEPT IndirectPredicate =
+		META_CONCEPT IndirectPredicate =
 			(Readable<Is> && ... && true) &&
 			CopyConstructible<F> &&
 			// The following 3 are checked redundantly, but are called out
@@ -118,11 +118,11 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class F, class I>
-	STL2_CONCEPT IndirectUnaryPredicate =
+	META_CONCEPT IndirectUnaryPredicate =
 		ext::IndirectPredicate<F, I>;
 
 	template<class F, class I1, class I2 = I1>
-	STL2_CONCEPT IndirectRelation =
+	META_CONCEPT IndirectRelation =
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&
@@ -133,7 +133,7 @@ STL2_OPEN_NAMESPACE {
 		Relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template<class F, class I1, class I2 = I1>
-	STL2_CONCEPT IndirectStrictWeakOrder =
+	META_CONCEPT IndirectStrictWeakOrder =
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	// Boolean [concepts.lib.compare.boolean]
 	//
 	template<class B>
-	STL2_CONCEPT Boolean =
+	META_CONCEPT Boolean =
 		Movable<std::decay_t<B>> &&
 		requires(const std::remove_reference_t<B>& b1,
 			     const std::remove_reference_t<B>& b2, const bool a) {
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 	// requirements for Sentinel's operator ==.
 	//
 	template<class T, class U>
-	STL2_CONCEPT WeaklyEqualityComparable =
+	META_CONCEPT WeaklyEqualityComparable =
 		requires(const std::remove_reference_t<T>& t,
 				 const std::remove_reference_t<U>& u) {
 			{ t == u } -> Boolean&&;
@@ -76,11 +76,11 @@ STL2_OPEN_NAMESPACE {
 	// EqualityComparable [concepts.lib.compare.equalitycomparable]
 	//
 	template<class T>
-	STL2_CONCEPT EqualityComparable =
+	META_CONCEPT EqualityComparable =
 		WeaklyEqualityComparable<T, T>;
 
 	template<class T, class U>
-	STL2_CONCEPT EqualityComparableWith =
+	META_CONCEPT EqualityComparableWith =
 		EqualityComparable<T> &&
 		EqualityComparable<U> &&
 		WeaklyEqualityComparable<T, U> &&
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 	// StrictTotallyOrdered [concepts.lib.compare.stricttotallyordered]
 	//
 	template<class T, class U>
-	STL2_CONCEPT __totally_ordered =
+	META_CONCEPT __totally_ordered =
 		requires(const std::remove_reference_t<T>& t,
 		         const std::remove_reference_t<U>& u) {
 			{ t <  u } -> Boolean&&;
@@ -111,13 +111,13 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	template<class T>
-	STL2_CONCEPT StrictTotallyOrdered =
+	META_CONCEPT StrictTotallyOrdered =
 		EqualityComparable<T> && __totally_ordered<T, T>;
 		// Axiom: t1 == t2 and t1 < t2 have the same definition space.
 		// Axiom: bool(t <= t)
 
 	template<class T, class U>
-	STL2_CONCEPT StrictTotallyOrderedWith =
+	META_CONCEPT StrictTotallyOrderedWith =
 		StrictTotallyOrdered<T> &&
 		StrictTotallyOrdered<U> &&
 		EqualityComparableWith<T, U> &&

--- a/include/stl2/detail/concepts/function.hpp
+++ b/include/stl2/detail/concepts/function.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	// Invocable [concepts.lib.callables.callable]
 	//
 	template<class F, class... Args>
-	STL2_CONCEPT Invocable =
+	META_CONCEPT Invocable =
 		requires(F&& f, Args&&... args) {
 			__stl2::invoke((F&&)f, (Args&&)args...);
 		};
@@ -36,20 +36,20 @@ STL2_OPEN_NAMESPACE {
 	// RegularInvocable [concepts.lib.callables.regularcallable]
 	//
 	template<class F, class... Args>
-	STL2_CONCEPT RegularInvocable = Invocable<F, Args...>;
+	META_CONCEPT RegularInvocable = Invocable<F, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Predicate [concepts.lib.callables.predicate]
 	//
 	template<class F, class... Args>
-	STL2_CONCEPT Predicate =
+	META_CONCEPT Predicate =
 		RegularInvocable<F, Args...> && Boolean<invoke_result_t<F, Args...>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Relation [concepts.lib.callables.relation]
 	//
 	template<class R, class T, class U>
-	STL2_CONCEPT Relation =
+	META_CONCEPT Relation =
 		Predicate<R, T, T> &&
 		Predicate<R, U, U> &&
 		Predicate<R, T, U> &&
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 	// StrictWeakOrder [concepts.lib.callables.strictweakorder]
 	//
 	template<class R, class T, class U>
-	STL2_CONCEPT StrictWeakOrder = Relation<R, T, U>;
+	META_CONCEPT StrictWeakOrder = Relation<R, T, U>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/fundamental.hpp
+++ b/include/stl2/detail/concepts/fundamental.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT Scalar =
+		META_CONCEPT Scalar =
 			std::is_scalar_v<T> && Regular<T>;
 	}
 
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT Arithmetic =
+		META_CONCEPT Arithmetic =
 			std::is_arithmetic_v<T> && Scalar<T> && StrictTotallyOrdered<T>;
 	}
 
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT FloatingPoint =
+		META_CONCEPT FloatingPoint =
 			std::is_floating_point_v<T> && Arithmetic<T>;
 	}
 
@@ -51,21 +51,21 @@ STL2_OPEN_NAMESPACE {
 	// Integral [concepts.lib.corelang.integral]
 	//
 	template<class T>
-	STL2_CONCEPT Integral =
+	META_CONCEPT Integral =
 		std::is_integral_v<T> && ext::Arithmetic<T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// SignedIntegral [concepts.lib.corelang.signedintegral]
 	//
 	template<class T>
-	STL2_CONCEPT SignedIntegral =
+	META_CONCEPT SignedIntegral =
 		Integral<T> && (T(-1) < T(0));
 
 	///////////////////////////////////////////////////////////////////////////
 	// UnsignedIntegral [concepts.lib.corelang.unsignedintegral]
 	//
 	template<class T>
-	STL2_CONCEPT UnsignedIntegral =
+	META_CONCEPT UnsignedIntegral =
 		Integral<T> && !SignedIntegral<T>;
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -57,55 +57,55 @@ STL2_OPEN_NAMESPACE {
 		// 'structible object concepts
 		//
 		template<class T>
-		STL2_CONCEPT DestructibleObject = Object<T> && Destructible<T>;
+		META_CONCEPT DestructibleObject = Object<T> && Destructible<T>;
 
 		template<class T, class... Args>
-		STL2_CONCEPT ConstructibleObject = Object<T> && Constructible<T, Args...>;
+		META_CONCEPT ConstructibleObject = Object<T> && Constructible<T, Args...>;
 
 		template<class T>
-		STL2_CONCEPT DefaultConstructibleObject = Object<T> && DefaultConstructible<T>;
+		META_CONCEPT DefaultConstructibleObject = Object<T> && DefaultConstructible<T>;
 
 		template<class T>
-		STL2_CONCEPT MoveConstructibleObject = Object<T> && MoveConstructible<T>;
+		META_CONCEPT MoveConstructibleObject = Object<T> && MoveConstructible<T>;
 
 		template<class T>
-		STL2_CONCEPT CopyConstructibleObject = Object<T> && CopyConstructible<T>;
+		META_CONCEPT CopyConstructibleObject = Object<T> && CopyConstructible<T>;
 
 		///////////////////////////////////////////////////////////////////////////
 		// TriviallyFoo concepts
 		//
 		template<class T>
-		STL2_CONCEPT TriviallyDestructible =
+		META_CONCEPT TriviallyDestructible =
 			Destructible<T> && std::is_trivially_destructible_v<T>;
 
 		template<class T, class... Args>
-		STL2_CONCEPT TriviallyConstructible =
+		META_CONCEPT TriviallyConstructible =
 			Constructible<T, Args...> &&
 			std::is_trivially_constructible_v<T, Args...>;
 
 		template<class T>
-		STL2_CONCEPT TriviallyDefaultConstructible =
+		META_CONCEPT TriviallyDefaultConstructible =
 			DefaultConstructible<T> &&
 			std::is_trivially_default_constructible_v<T>;
 
 		template<class T>
-		STL2_CONCEPT TriviallyMoveConstructible =
+		META_CONCEPT TriviallyMoveConstructible =
 			MoveConstructible<T> && std::is_trivially_move_constructible_v<T>;
 
 		template<class T>
-		STL2_CONCEPT TriviallyCopyConstructible =
+		META_CONCEPT TriviallyCopyConstructible =
 			CopyConstructible<T> &&
 			TriviallyMoveConstructible<T> &&
 			std::is_trivially_copy_constructible_v<T>;
 
 		template<class T>
-		STL2_CONCEPT TriviallyMovable =
+		META_CONCEPT TriviallyMovable =
 			Movable<T> &&
 			TriviallyMoveConstructible<T> &&
 			std::is_trivially_move_assignable_v<T>;
 
 		template<class T>
-		STL2_CONCEPT TriviallyCopyable =
+		META_CONCEPT TriviallyCopyable =
 			Copyable<T> &&
 			TriviallyMovable<T> &&
 			TriviallyCopyConstructible<T> &&

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 	// Assignable [concepts.lib.corelang.assignable]
 	//
 	template<class LHS, class RHS>
-	STL2_CONCEPT Assignable =
+	META_CONCEPT Assignable =
 		std::is_lvalue_reference_v<LHS> &&
 #if 0 // TODO: investigate making this change
 		CommonReference<LHS, RHS> &&

--- a/include/stl2/detail/concepts/object/movable.hpp
+++ b/include/stl2/detail/concepts/object/movable.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 	// Movable [concepts.lib.object.movable]
 	//
 	template<class T>
-	STL2_CONCEPT Movable =
+	META_CONCEPT Movable =
 		std::is_object_v<T> && MoveConstructible<T> &&
 		Assignable<T&, T> && Swappable<T>;
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -24,33 +24,33 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT Object = std::is_object_v<T>;
+		META_CONCEPT Object = std::is_object_v<T>;
 	} // namespace ext
 
 	///////////////////////////////////////////////////////////////////////////
 	// Destructible [concept.destructible]
 	//
 	template<class T>
-	STL2_CONCEPT Destructible = std::is_nothrow_destructible_v<T>;
+	META_CONCEPT Destructible = std::is_nothrow_destructible_v<T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Constructible [concept.constructible]
 	//
 	template<class T, class... Args>
-	STL2_CONCEPT Constructible =
+	META_CONCEPT Constructible =
 		Destructible<T> && std::is_constructible_v<T, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// DefaultConstructible [concept.defaultconstructible]
 	//
 	template<class T>
-	STL2_CONCEPT DefaultConstructible = Constructible<T> && requires { T{}; };
+	META_CONCEPT DefaultConstructible = Constructible<T> && requires { T{}; };
 
 	///////////////////////////////////////////////////////////////////////////
 	// MoveConstructible [concept.moveconstructible]
 	//
 	template<class T>
-	STL2_CONCEPT MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
+	META_CONCEPT MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/regular.hpp
+++ b/include/stl2/detail/concepts/object/regular.hpp
@@ -22,7 +22,7 @@ STL2_OPEN_NAMESPACE {
 	// Regular [concepts.lib.object.regular]
 	//
 	template<class T>
-	STL2_CONCEPT Regular = Semiregular<T> && EqualityComparable<T>;
+	META_CONCEPT Regular = Semiregular<T> && EqualityComparable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/semiregular.hpp
+++ b/include/stl2/detail/concepts/object/semiregular.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	// CopyConstructible [concepts.lib.object.copyconstructible]
 	//
 	template<class T>
-	STL2_CONCEPT CopyConstructible =
+	META_CONCEPT CopyConstructible =
 		MoveConstructible<T> &&
 		Constructible<T, T&> && ConvertibleTo<T&, T> &&
 		Constructible<T, const T&> && ConvertibleTo<const T&, T> &&
@@ -35,14 +35,14 @@ STL2_OPEN_NAMESPACE {
 	// Copyable [concepts.lib.object.copyable]
 	//
 	template<class T>
-	STL2_CONCEPT Copyable =
+	META_CONCEPT Copyable =
 		CopyConstructible<T> && Movable<T> && Assignable<T&, const T&>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Semiregular [concepts.lib.object.semiregular]
 	//
 	template<class T>
-	STL2_CONCEPT Semiregular = Copyable<T> && DefaultConstructible<T>;
+	META_CONCEPT Semiregular = Copyable<T> && DefaultConstructible<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -19,7 +19,7 @@
 
 STL2_OPEN_NAMESPACE {
 	template<class G>
-	STL2_CONCEPT UniformRandomNumberGenerator =
+	META_CONCEPT UniformRandomNumberGenerator =
 		requires(G&& g) {
 			g();
 			requires UnsignedIntegral<decltype(g())>;

--- a/include/stl2/detail/functional/invoke.hpp
+++ b/include/stl2/detail/functional/invoke.hpp
@@ -39,8 +39,8 @@ STL2_OPEN_NAMESPACE {
 
 		template<class T>
 		inline constexpr bool is_reference_wrapper =
-			meta::is<T, reference_wrapper>::value ||
-			meta::is<T, std::reference_wrapper>::value;
+			meta::is_v<T, reference_wrapper> ||
+			meta::is_v<T, std::reference_wrapper>;
 
 		template<class, class T1>
 		requires is_reference_wrapper<std::decay_t<T1>>

--- a/include/stl2/detail/functional/not_fn.hpp
+++ b/include/stl2/detail/functional/not_fn.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	// not_fn from C++17
 	//
 	template<class F, class... Args>
-	STL2_CONCEPT _NegateInvocable = Invocable<F, Args...> &&
+	META_CONCEPT _NegateInvocable = Invocable<F, Args...> &&
 		requires(F&& f, Args&&... args) {
 			!__stl2::invoke(static_cast<F&&>(f),
 				static_cast<Args&&>(args)...);

--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -27,14 +27,6 @@
  #endif // __GNUC__
 #endif // __clang__
 
-#if !defined(__cpp_concepts) || __cpp_concepts == 0
-#error Nothing here will work without support for C++ concepts.
-#elif __cpp_concepts <= 201507L
-#define STL2_CONCEPT concept bool
-#else
-#define STL2_CONCEPT concept
-#endif
-
 #ifndef STL2_WORKAROUND_GCC_69096
  #if defined(__GNUC__) && __GNUC__ >= 6
   // Return type deduction performed *before* checking constraints.

--- a/include/stl2/detail/hash.hpp
+++ b/include/stl2/detail/hash.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class T>
-		STL2_CONCEPT Hashable = requires(const T& e) {
+		META_CONCEPT Hashable = requires(const T& e) {
 			typename std::hash<T>;
 			{ std::hash<T>{}(e) } -> std::size_t;
 		};

--- a/include/stl2/detail/iostream/concepts.hpp
+++ b/include/stl2/detail/iostream/concepts.hpp
@@ -20,7 +20,7 @@ STL2_OPEN_NAMESPACE {
 	// StreamExtractable [Extension]
 	//
 	template<class T, class charT = char, class traits = std::char_traits<charT>>
-	STL2_CONCEPT StreamExtractable =
+	META_CONCEPT StreamExtractable =
 		requires(std::basic_istream<charT, traits>& is, T& t) {
 			{ is >> t } -> Same<std::basic_istream<charT, traits>>&;
 			// Axiom: &is == &(is << t)
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	// StreamInsertable [Extension]
 	//
 	template<class T, class charT = char, class traits = std::char_traits<charT>>
-	STL2_CONCEPT StreamInsertable =
+	META_CONCEPT StreamInsertable =
 		requires(std::basic_ostream<charT, traits>& os, const T& t) {
 			{ os << t } -> Same<std::basic_ostream<charT, traits>>&;
 			// Axiom: &os == &(os << t)

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -159,14 +159,14 @@ STL2_OPEN_NAMESPACE {
 		using value_type_t = meta::_t<value_type<C>>;
 
 		template<class C, class M>
-		STL2_CONCEPT _Cursor =
+		META_CONCEPT _Cursor =
 			Semiregular<C> &&
 			Semiregular<M> &&
 			Constructible<M, C> &&
 			Constructible<M, const C&>;
 
 		template<class C>
-		STL2_CONCEPT Cursor =
+		META_CONCEPT Cursor =
 			requires {
 				typename difference_type_t<C>;
 				typename mixin_t<std::remove_cv_t<C>>;
@@ -174,7 +174,7 @@ STL2_OPEN_NAMESPACE {
 			_Cursor<std::remove_cv_t<C>, mixin_t<std::remove_cv_t<C>>>;
 
 		template<class C>
-		STL2_CONCEPT Readable =
+		META_CONCEPT Readable =
 			Cursor<C> &&
 			requires(const C& c) {
 				c.read(); requires __can_reference<decltype(c.read())>;
@@ -182,52 +182,52 @@ STL2_OPEN_NAMESPACE {
 				typename value_type_t<C>;
 			};
 		template<class C>
-		STL2_CONCEPT Arrow =
+		META_CONCEPT Arrow =
 			Readable<C> &&
 			requires(const C& c) {
 				c.arrow(); requires __can_reference<decltype(c.arrow())>;
 			};
 		template<class C, class T>
-		STL2_CONCEPT Writable =
+		META_CONCEPT Writable =
 			Cursor<C> &&
 			requires(C& c, T&& t) {
 				c.write(std::forward<T>(t)); // Not required to be equality-preserving
 			};
 
 		template<class S, class C>
-		STL2_CONCEPT Sentinel =
+		META_CONCEPT Sentinel =
 			Cursor<C> &&
 			Semiregular<S> &&
 			requires(const C& c, const S& s) {
 				{ c.equal(s) } -> bool;
 			};
 		template<class S, class C>
-		STL2_CONCEPT SizedSentinel =
+		META_CONCEPT SizedSentinel =
 			Sentinel<S, C> &&
 			requires(const C& c, const S& s) {
 				{ c.distance_to(s) } -> Same<difference_type_t<C>>&&;
 			};
 
 		template<class C>
-		STL2_CONCEPT Next =
+		META_CONCEPT Next =
 			Cursor<C> && requires(C& c) { c.next(); };
 		template<class C>
-		STL2_CONCEPT PostIncrement =
+		META_CONCEPT PostIncrement =
 			Cursor<C> &&
 			requires(C& c) {
 				c.post_increment();
 			};
 		template<class C>
-		STL2_CONCEPT Prev =
+		META_CONCEPT Prev =
 			Cursor<C> && requires(C& c) { c.prev(); };
 		template<class C>
-		STL2_CONCEPT Advance =
+		META_CONCEPT Advance =
 			Cursor<C> && requires(C& c, difference_type_t<C> n) {
 				c.advance(n);
 			};
 
 		template<class C>
-		STL2_CONCEPT IndirectMove =
+		META_CONCEPT IndirectMove =
 			Readable<C> && requires(const C& c) {
 				c.indirect_move(); requires __can_reference<decltype(c.indirect_move())>;
 			};
@@ -252,7 +252,7 @@ STL2_OPEN_NAMESPACE {
 		using rvalue_reference_t = meta::_t<rvalue_reference<C>>;
 
 		template<class C1, class C2>
-		STL2_CONCEPT IndirectSwap =
+		META_CONCEPT IndirectSwap =
 			Readable<C1> &&
 			Readable<C2> &&
 			requires(const C1& c1, const C2& c2) {
@@ -264,25 +264,25 @@ STL2_OPEN_NAMESPACE {
 			};
 
 		template<class C>
-		STL2_CONCEPT Input =
+		META_CONCEPT Input =
 			Readable<C> && Next<C>;
 		template<class C>
-		STL2_CONCEPT Forward =
+		META_CONCEPT Forward =
 			Input<C> && !single_pass<C> && Sentinel<C, C>;
 		template<class C>
-		STL2_CONCEPT Bidirectional =
+		META_CONCEPT Bidirectional =
 			Forward<C> && Prev<C>;
 		template<class C>
-		STL2_CONCEPT RandomAccess =
+		META_CONCEPT RandomAccess =
 			Bidirectional<C> && Advance<C> && SizedSentinel<C, C>;
 		template<class C>
-		STL2_CONCEPT Contiguous =
+		META_CONCEPT Contiguous =
 			RandomAccess<C> &&
 			contiguous<C> &&
 			std::is_lvalue_reference<reference_t<C>>::value;
 
 		template<class From, class To>
-		STL2_CONCEPT ConvertibleTo =
+		META_CONCEPT ConvertibleTo =
 			Cursor<From> &&
 			Cursor<To> &&
 			__stl2::ConvertibleTo<From, To> &&
@@ -542,7 +542,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class C>
-		STL2_CONCEPT PostIncrementCursor =
+		META_CONCEPT PostIncrementCursor =
 			requires(C& c) {
 				{ c.post_increment() } -> Same<C>&&;
 			};

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -156,7 +156,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class I>
-	STL2_CONCEPT _HasArrow = requires(I& i) { i.operator->(); };
+	META_CONCEPT _HasArrow = requires(I& i) { i.operator->(); };
 
 	// common_iterator [common.iterator]
 	template<Iterator I, Sentinel<I> S>

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -31,7 +31,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	template<class T>
-	STL2_CONCEPT __dereferenceable = requires(T& t) {
+	META_CONCEPT __dereferenceable = requires(T& t) {
 		// { *t } -> __can_reference;
 		*t; typename __with_reference<decltype(*t)>;
 	};
@@ -97,7 +97,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace detail {
 		template<class T>
-		STL2_CONCEPT MemberValueType =
+		META_CONCEPT MemberValueType =
 			requires { typename T::value_type; };
 	}
 
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 	// Readable [readable.iterators]
 	//
 	template<class I>
-	STL2_CONCEPT Readable =
+	META_CONCEPT Readable =
 		requires {
 			// Associated types
 			typename iter_value_t<I>;
@@ -161,7 +161,7 @@ STL2_OPEN_NAMESPACE {
 	// Writable [iterators.writable]
 	//
 	template<class Out, class R>
-	STL2_CONCEPT Writable =
+	META_CONCEPT Writable =
 		__dereferenceable<Out> &&
 		requires(Out&& o, R&& r) {
 			*o = static_cast<R&&>(r);
@@ -174,7 +174,7 @@ STL2_OPEN_NAMESPACE {
 	// IndirectlyMovable [commonalgoreq.indirectlymovable]
 	//
 	template<class In, class Out>
-	STL2_CONCEPT IndirectlyMovable =
+	META_CONCEPT IndirectlyMovable =
 		Readable<In> &&
 		Writable<Out, iter_rvalue_reference_t<In>>;
 
@@ -190,7 +190,7 @@ STL2_OPEN_NAMESPACE {
 	// IndirectlyMovableStorable [commonalgoreq.indirectlymovable]
 	//
 	template<class In, class Out>
-	STL2_CONCEPT IndirectlyMovableStorable =
+	META_CONCEPT IndirectlyMovableStorable =
 		IndirectlyMovable<In, Out> &&
 		Writable<Out, iter_value_t<In>&&> &&
 		Movable<iter_value_t<In>> &&
@@ -211,14 +211,14 @@ STL2_OPEN_NAMESPACE {
 	// IndirectlyCopyable [commonalgoreq.indirectlycopyable]
 	//
 	template<class In, class Out>
-	STL2_CONCEPT IndirectlyCopyable =
+	META_CONCEPT IndirectlyCopyable =
 		Readable<In> && Writable<Out, iter_reference_t<In>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// IndirectlyCopyableStorable [commonalgoreq.indirectlycopyable]
 	//
 	template<class In, class Out>
-	STL2_CONCEPT IndirectlyCopyableStorable =
+	META_CONCEPT IndirectlyCopyableStorable =
 		IndirectlyCopyable<In, Out> &&
 		Writable<Out, const iter_value_t<In>&> &&
 		Copyable<iter_value_t<In>> &&
@@ -297,7 +297,7 @@ STL2_OPEN_NAMESPACE {
 	//
 
 	template<class I1, class I2 = I1>
-	STL2_CONCEPT IndirectlySwappable =
+	META_CONCEPT IndirectlySwappable =
 		requires(I1&& i1, I2&& i2) {
 			iter_swap((I1&&)i1, (I2&&)i2);
 			iter_swap((I2&&)i2, (I1&&)i1);
@@ -341,7 +341,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace detail {
 		template<class T>
-		STL2_CONCEPT MemberIteratorCategory =
+		META_CONCEPT MemberIteratorCategory =
 			requires { typename T::iterator_category; };
 
 		namespace std_to_stl2_iterator_category_ {
@@ -392,7 +392,7 @@ STL2_OPEN_NAMESPACE {
 	// Denotes an element of a range, i.e., is a position.
 	//
 	template<class I>
-	STL2_CONCEPT Iterator =
+	META_CONCEPT Iterator =
 		__dereferenceable<I&> && WeaklyIncrementable<I>;
 		// Axiom?: i is non-singular iff it denotes an element
 		// Axiom?: if i equals j then i and j denote equal elements
@@ -407,7 +407,7 @@ STL2_OPEN_NAMESPACE {
 	// that denote a range.
 	//
 	template<class S, class I>
-	STL2_CONCEPT Sentinel =
+	META_CONCEPT Sentinel =
 		Iterator<I> &&
 		Semiregular<S> &&
 		WeaklyEqualityComparable<S, I>;
@@ -430,7 +430,7 @@ STL2_OPEN_NAMESPACE {
 	constexpr bool disable_sized_sentinel = false;
 
 	template<class S, class I>
-	STL2_CONCEPT SizedSentinel =
+	META_CONCEPT SizedSentinel =
 		Sentinel<S, I> &&
 		!disable_sized_sentinel<std::remove_cv_t<S>, std::remove_cv_t<I>> &&
 		requires(const I i, const S s) {
@@ -449,7 +449,7 @@ STL2_OPEN_NAMESPACE {
 	// OutputIterator [iterators.output]
 	//
 	template<class I, class T>
-	STL2_CONCEPT OutputIterator =
+	META_CONCEPT OutputIterator =
 		Iterator<I> &&
 		Writable<I, T> &&
 		requires(I& i, T&& t) {
@@ -460,7 +460,7 @@ STL2_OPEN_NAMESPACE {
 	// InputIterator [iterators.input]
 	//
 	template<class I>
-	STL2_CONCEPT InputIterator =
+	META_CONCEPT InputIterator =
 		Iterator<I> &&
 		Readable<I> &&
 		requires(I& i, const I& ci) {
@@ -473,7 +473,7 @@ STL2_OPEN_NAMESPACE {
 	// ForwardIterator [iterators.forward]
 	//
 	template<class I>
-	STL2_CONCEPT ForwardIterator =
+	META_CONCEPT ForwardIterator =
 		InputIterator<I> &&
 		DerivedFrom<iterator_category_t<I>, forward_iterator_tag> &&
 		Incrementable<I> &&
@@ -490,7 +490,7 @@ STL2_OPEN_NAMESPACE {
 	// BidirectionalIterator [iterators.bidirectional]
 	//
 	template<class I>
-	STL2_CONCEPT BidirectionalIterator =
+	META_CONCEPT BidirectionalIterator =
 		ForwardIterator<I> &&
 		DerivedFrom<iterator_category_t<I>, bidirectional_iterator_tag> &&
 		ext::Decrementable<I>;
@@ -499,7 +499,7 @@ STL2_OPEN_NAMESPACE {
 	// RandomAccessIterator [iterators.random.access]
 	//
 	template<class I>
-	STL2_CONCEPT RandomAccessIterator =
+	META_CONCEPT RandomAccessIterator =
 		BidirectionalIterator<I> &&
 		DerivedFrom<iterator_category_t<I>, random_access_iterator_tag> &&
 		SizedSentinel<I, I> &&
@@ -520,7 +520,7 @@ STL2_OPEN_NAMESPACE {
 	// ContiguousIterator
 	//
 	template<class I>
-	STL2_CONCEPT ContiguousIterator =
+	META_CONCEPT ContiguousIterator =
 		RandomAccessIterator<I> &&
 		DerivedFrom<iterator_category_t<I>, contiguous_iterator_tag> &&
 		std::is_lvalue_reference<iter_reference_t<I>>::value &&
@@ -605,14 +605,14 @@ STL2_OPEN_NAMESPACE {
 		struct pointer_with_a_default<T, U> : meta::id<typename T::pointer> {};
 
 		template<class I>
-		STL2_CONCEPT LooksLikeSTL1Iterator =
+		META_CONCEPT LooksLikeSTL1Iterator =
 			requires {
 				typename I::iterator_category;
 				requires DerivedFrom<typename I::iterator_category, std::input_iterator_tag> ||
 						 DerivedFrom<typename I::iterator_category, std::output_iterator_tag>;
 			};
 		template<class I>
-		STL2_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;
+		META_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;
 	} // namespace detail
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 	// WeaklyIncrementable [weaklyincrementable.iterators]
 	//
 	template<class I>
-	STL2_CONCEPT WeaklyIncrementable =
+	META_CONCEPT WeaklyIncrementable =
 		Semiregular<I> &&
 		requires(I i) {
 			typename iter_difference_t<I>;
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 	// Incrementable [incrementable.iterators]
 	//
 	template<class I>
-	STL2_CONCEPT Incrementable =
+	META_CONCEPT Incrementable =
 		Regular<I> &&
 		WeaklyIncrementable<I> &&
 		requires(I i) {
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class I>
-		STL2_CONCEPT Decrementable =
+		META_CONCEPT Decrementable =
 			Incrementable<I> &&
 			requires(I i) {
 				{ --i } -> Same<I>&;
@@ -108,7 +108,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	namespace ext {
 		template<class I>
-		STL2_CONCEPT RandomAccessIncrementable =
+		META_CONCEPT RandomAccessIncrementable =
 			Decrementable<I> &&
 			requires(I& i, const I& ci, const iter_difference_t<I> n) {
 				{ i += n } -> Same<I&>&&;

--- a/include/stl2/detail/iterator/insert_iterators.hpp
+++ b/include/stl2/detail/iterator/insert_iterators.hpp
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class T, class C>
-		STL2_CONCEPT BackInsertableInto =
+		META_CONCEPT BackInsertableInto =
 			requires(T&& t, C& c) {
 				c.push_back((T&&)t);
 			};
@@ -79,7 +79,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace detail {
 		template<class T, class C>
-		STL2_CONCEPT FrontInsertableInto =
+		META_CONCEPT FrontInsertableInto =
 			requires(T&& t, C& c) {
 				c.push_front((T&&)t);
 			};
@@ -113,7 +113,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace detail {
 		template<class T, class C>
-		STL2_CONCEPT InsertableInto =
+		META_CONCEPT InsertableInto =
 			requires(T&& t, C& c, iterator_t<C> i) {
 				{  c.insert(i, (T&&)t) } -> iterator_t<C>;
 			};

--- a/include/stl2/detail/memory/concepts.hpp
+++ b/include/stl2/detail/memory/concepts.hpp
@@ -22,7 +22,7 @@ STL2_OPEN_NAMESPACE {
 	// __NoThrowInputIterator [Exposition]
 	//
 	template<class I>
-	STL2_CONCEPT __NoThrowInputIterator =
+	META_CONCEPT __NoThrowInputIterator =
 		InputIterator<I> &&
 		std::is_lvalue_reference_v<iter_reference_t<I>> &&
 		Same<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
@@ -33,7 +33,7 @@ STL2_OPEN_NAMESPACE {
 	// __NoThrowSentinel [Exposition]
 	//
 	template<class S, class I>
-	STL2_CONCEPT __NoThrowSentinel =
+	META_CONCEPT __NoThrowSentinel =
 		Sentinel<S, I>;
 		// Axiom: no exceptions are thrown from comparisons between objects of types
 		//        I and S.
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 	// __NoThrowInputRange [Exposition]
 	//
 	template<class Rng>
-	STL2_CONCEPT __NoThrowInputRange =
+	META_CONCEPT __NoThrowInputRange =
 		Range<Rng> &&
 		__NoThrowInputIterator<iterator_t<Rng>> &&
 		__NoThrowSentinel<sentinel_t<Rng>, iterator_t<Rng>>;
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 	// __NoThrowForwardIterator [Exposition]
 	//
 	template<class I>
-	STL2_CONCEPT __NoThrowForwardIterator =
+	META_CONCEPT __NoThrowForwardIterator =
 		__NoThrowInputIterator<I> &&
 		__NoThrowSentinel<I, I> &&
 		ForwardIterator<I>;
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 	// __NoThrowForwardRange [Exposition]
 	//
 	template<class Rng>
-	STL2_CONCEPT __NoThrowForwardRange =
+	META_CONCEPT __NoThrowForwardRange =
 		__NoThrowForwardIterator<iterator_t<Rng>> &&
 		__NoThrowInputRange<Rng> &&
 		ForwardRange<Rng>;

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -47,14 +47,14 @@ STL2_OPEN_NAMESPACE {
 		void begin(std::initializer_list<T>) = delete; // TODO: file LWG issue
 
 		template<class R>
-		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
+		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				r.begin();
 				{ __decay_copy(r.begin()) } -> Iterator;
 			};
 
 		template<class R>
-		STL2_CONCEPT has_non_member = requires(R&& r) {
+		META_CONCEPT has_non_member = requires(R&& r) {
 			begin(static_cast<R&&>(r));
 			{ __decay_copy(begin(static_cast<R&&>(r))) } -> Iterator;
 		};
@@ -112,7 +112,7 @@ STL2_OPEN_NAMESPACE {
 		void end(std::initializer_list<T>) = delete; // TODO: file LWG issue
 
 		template<class R>
-		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
+		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				r.end();
 				begin(r);
@@ -120,7 +120,7 @@ STL2_OPEN_NAMESPACE {
 			};
 
 		template<class R>
-		STL2_CONCEPT has_non_member = requires(R&& r) {
+		META_CONCEPT has_non_member = requires(R&& r) {
 			end(static_cast<R&&>(r));
 			begin(static_cast<R&&>(r));
 			{ __decay_copy(end(static_cast<R&&>(r))) } -> Sentinel<__begin_t<R>>;
@@ -199,14 +199,14 @@ STL2_OPEN_NAMESPACE {
 
 		// Prefer member if it returns Iterator
 		template<class R>
-		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
+		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				r.rbegin();
 				{ __decay_copy(r.rbegin()) } -> Iterator;
 			};
 
 		template<class R>
-		STL2_CONCEPT has_non_member = requires(R&& r) {
+		META_CONCEPT has_non_member = requires(R&& r) {
 			rbegin(static_cast<R&&>(r));
 			{ __decay_copy(rbegin(static_cast<R&&>(r))) } -> Iterator;
 		};
@@ -214,7 +214,7 @@ STL2_OPEN_NAMESPACE {
 		// Default to make_reverse_iterator(end(r)) for Common ranges of
 		// Bidirectional iterators.
 		template<class R>
-		STL2_CONCEPT can_make_reverse = requires(R&& r) {
+		META_CONCEPT can_make_reverse = requires(R&& r) {
 			{ begin(static_cast<R&&>(r)) } -> BidirectionalIterator;
 			{ end(static_cast<R&&>(r)) } -> Same<__begin_t<R>>;
 		};
@@ -262,7 +262,7 @@ STL2_OPEN_NAMESPACE {
 		template<class R> void rend(R&&) = delete;
 
 		template<class R>
-		STL2_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
+		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				rbegin(r);
 				r.rend();
@@ -270,7 +270,7 @@ STL2_OPEN_NAMESPACE {
 			};
 
 		template<class R>
-		STL2_CONCEPT has_non_member = requires(R&& r) {
+		META_CONCEPT has_non_member = requires(R&& r) {
 			rbegin(static_cast<R&&>(r));
 			rend(static_cast<R&&>(r));
 			{ __decay_copy(rend(static_cast<R&&>(r))) } ->
@@ -348,19 +348,19 @@ STL2_OPEN_NAMESPACE {
 		template<class T> void size(T&&) = delete;
 
 		template<class R>
-		STL2_CONCEPT has_member = requires(R& r) {
+		META_CONCEPT has_member = requires(R& r) {
 			r.size();
 			{ __decay_copy(r.size()) } -> Integral;
 		};
 
 		template<class R>
-		STL2_CONCEPT has_non_member = requires(R& r) {
+		META_CONCEPT has_non_member = requires(R& r) {
 			size(r);
 			{ __decay_copy(size(r)) } -> Integral;
 		};
 
 		template<class R>
-		STL2_CONCEPT has_difference = requires(R& r) {
+		META_CONCEPT has_difference = requires(R& r) {
 			{ begin(r) } -> ForwardIterator;
 			{ end(r) } -> SizedSentinel<__begin_t<R&>>;
 		};
@@ -408,18 +408,18 @@ STL2_OPEN_NAMESPACE {
 	// TODO: LWG issue
 	namespace __empty {
 		template<class R>
-		STL2_CONCEPT has_member = requires(R& r) {
+		META_CONCEPT has_member = requires(R& r) {
 			r.empty();
 			bool(r.empty());
 		};
 
 		template<class R>
-		STL2_CONCEPT has_size = requires(R& r) {
+		META_CONCEPT has_size = requires(R& r) {
 			size(r);
 		};
 
 		template<class R>
-		STL2_CONCEPT has_begin_end = requires(R& r) {
+		META_CONCEPT has_begin_end = requires(R& r) {
 			{ begin(r) } -> ForwardIterator;
 			end(r);
 		};
@@ -468,12 +468,12 @@ STL2_OPEN_NAMESPACE {
 		inline constexpr bool is_object_ptr<T*> = true;
 
 		template<class R>
-		STL2_CONCEPT forwarding_range_hack = requires(R&& r) {
+		META_CONCEPT forwarding_range_hack = requires(R&& r) {
 			end(static_cast<R&&>(r));
 		};
 
 		template<class R>
-		STL2_CONCEPT has_member =
+		META_CONCEPT has_member =
 			requires(R& r) {
 				r.data();
 				__decay_copy(r.data());
@@ -482,7 +482,7 @@ STL2_OPEN_NAMESPACE {
 			(std::is_lvalue_reference_v<R> || forwarding_range_hack<R>);
 
 		template<class R>
-		STL2_CONCEPT has_contiguous_iterator = requires(R&& r) {
+		META_CONCEPT has_contiguous_iterator = requires(R&& r) {
 			{ begin(static_cast<R&&>(r)) } -> ContiguousIterator;
 			end(static_cast<R&&>(r));
 		};

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -44,20 +44,20 @@ STL2_OPEN_NAMESPACE {
 	using sentinel_t = __end_t<T&>;
 
 	template<class T>
-	STL2_CONCEPT _RangeImpl =
+	META_CONCEPT _RangeImpl =
 		requires(T&& t) {
 			begin(static_cast<T&&>(t)); // not necessarily equality-preserving
 			end(static_cast<T&&>(t));
 		};
 
 	template<class T>
-	STL2_CONCEPT Range = _RangeImpl<T&>;
+	META_CONCEPT Range = _RangeImpl<T&>;
 
 	template<class T>
-	STL2_CONCEPT _ForwardingRange = Range<T> && _RangeImpl<T>;
+	META_CONCEPT _ForwardingRange = Range<T> && _RangeImpl<T>;
 
 	template<class R>
-	STL2_CONCEPT SizedRange =
+	META_CONCEPT SizedRange =
 		Range<R> && !disable_sized_range<__uncvref<R>> &&
 		requires(R& r) { size(r); };
 
@@ -67,12 +67,12 @@ STL2_OPEN_NAMESPACE {
 	struct view_base {};
 
 	template<class T>
-	STL2_CONCEPT _ContainerLike =
+	META_CONCEPT _ContainerLike =
 		Range<T> && Range<const T> &&
 		!Same<iter_reference_t<iterator_t<T>>, iter_reference_t<iterator_t<const T>>>;
 
 	template<class T>
-	STL2_CONCEPT __enable_view_default = DerivedFrom<T, view_base> || !_ContainerLike<T>;
+	META_CONCEPT __enable_view_default = DerivedFrom<T, view_base> || !_ContainerLike<T>;
 
 	template<class T>
 	inline constexpr bool enable_view = __enable_view_default<T>;
@@ -89,7 +89,7 @@ STL2_OPEN_NAMESPACE {
 	inline constexpr bool enable_view<std::unordered_multiset<Key, Hash, Pred, Alloc>> = false;
 
 	template<class T>
-	STL2_CONCEPT View =
+	META_CONCEPT View =
 		Range<T> &&
 		Semiregular<T> &&
 		enable_view<__uncvref<T>>;
@@ -98,49 +98,49 @@ STL2_OPEN_NAMESPACE {
 	// CommonRange
 	//
 	template<class T>
-	STL2_CONCEPT CommonRange =
+	META_CONCEPT CommonRange =
 		Range<T> && Same<iterator_t<T>, sentinel_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// OutputRange [ranges.output]
 	//
 	template<class R, class T>
-	STL2_CONCEPT OutputRange =
+	META_CONCEPT OutputRange =
 		Range<R> && OutputIterator<iterator_t<R>, T>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// InputRange [ranges.input]
 	//
 	template<class T>
-	STL2_CONCEPT InputRange =
+	META_CONCEPT InputRange =
 		Range<T> && InputIterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// ForwardRange [ranges.forward]
 	//
 	template<class T>
-	STL2_CONCEPT ForwardRange =
+	META_CONCEPT ForwardRange =
 		Range<T> && ForwardIterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// BidirectionalRange [ranges.bidirectional]
 	//
 	template<class T>
-	STL2_CONCEPT BidirectionalRange =
+	META_CONCEPT BidirectionalRange =
 		Range<T> && BidirectionalIterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// RandomAccessRange [ranges.random.access]
 	//
 	template<class T>
-	STL2_CONCEPT RandomAccessRange =
+	META_CONCEPT RandomAccessRange =
 		Range<T> && RandomAccessIterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// ContiguousRange [ranges.contiguous]
 	//
 	template<class R>
-	STL2_CONCEPT ContiguousRange =
+	META_CONCEPT ContiguousRange =
 		std::is_reference_v<iter_reference_t<iterator_t<R>>> &&
 		Same<iter_value_t<iterator_t<R>>, __uncvref<iter_reference_t<iterator_t<R>>>> &&
 		requires(R& r) {
@@ -149,14 +149,14 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		template<class R>
-		STL2_CONCEPT SimpleView =
+		META_CONCEPT SimpleView =
 			View<R> && Range<const R> &&
 			Same<iterator_t<R>, iterator_t<const R>> &&
 			Same<sentinel_t<R>, sentinel_t<const R>>;
 	}
 
 	template<class Rng>
-	STL2_CONCEPT ViewableRange =
+	META_CONCEPT ViewableRange =
 		Range<Rng> &&
 		(_RangeImpl<Rng> || View<Rng>);
 

--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 		using data_pointer_t = decltype(data(std::declval<T&>()));
 
 		template<class Range>
-		STL2_CONCEPT SizedContiguousRange =
+		META_CONCEPT SizedContiguousRange =
 			ContiguousRange<Range> && SizedRange<Range>;
 
 		namespace __span {
@@ -94,11 +94,11 @@ STL2_OPEN_NAMESPACE {
 			constexpr bool has_static_extent<T> = true;
 
 			template<class Range>
-			STL2_CONCEPT StaticSizedContiguousRange =
+			META_CONCEPT StaticSizedContiguousRange =
 				SizedContiguousRange<Range> && has_static_extent<Range>;
 
 			template<class Range, class ElementType>
-			STL2_CONCEPT compatible = SizedContiguousRange<Range> &&
+			META_CONCEPT compatible = SizedContiguousRange<Range> &&
 				ConvertibleTo<
 					std::remove_pointer_t<data_pointer_t<Range>>(*)[],
 					ElementType(*)[]>;

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T, std::size_t N> void swap(T(&)[N], T(&)[N]) = delete;
 
 		template<class T, class U>
-		STL2_CONCEPT has_customization =
+		META_CONCEPT has_customization =
 			(std::is_class_v<__uncvref<T>> || std::is_class_v<__uncvref<U>>
 			 || std::is_enum_v<__uncvref<T>> || std::is_enum_v<__uncvref<U>>) &&
 			requires(T&& t, U&& u) {
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 			};
 
 		template<class F, class T, class U>
-		STL2_CONCEPT has_operator = requires(const F& f, T& t, U& u) {
+		META_CONCEPT has_operator = requires(const F& f, T& t, U& u) {
 			f(t, u);
 		};
 
@@ -98,13 +98,13 @@ STL2_OPEN_NAMESPACE {
 	// Swappable [concepts.lib.corelang.swappable]
 	//
 	template<class T>
-	STL2_CONCEPT Swappable =
+	META_CONCEPT Swappable =
 		requires(T& a, T& b) {
 			__stl2::swap(a, b);
 		};
 
 	template<class T, class U>
-	STL2_CONCEPT SwappableWith =
+	META_CONCEPT SwappableWith =
 #if 1 // P/R of unfiled LWG issue
 		CommonReference<T, U> &&
 #else

--- a/include/stl2/detail/tagged.hpp
+++ b/include/stl2/detail/tagged.hpp
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 	} // namespace __tagged
 
 	template<class T>
-	STL2_CONCEPT TagSpecifier =
+	META_CONCEPT TagSpecifier =
 		requires {
 			typename T::template tagged_getter<std::tuple<int>, 0, __tagged::base<std::tuple<int>>>;
 			requires DerivedFrom<
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	template<class T>
-	STL2_CONCEPT TaggedType =
+	META_CONCEPT TaggedType =
 		requires {
 			typename __tagged::specifier<T>;
 			typename __tagged::element<T>;

--- a/include/stl2/detail/view/view_closure.hpp
+++ b/include/stl2/detail/view/view_closure.hpp
@@ -22,7 +22,7 @@ STL2_OPEN_NAMESPACE {
 		struct __pipeable_base;
 
 		template<class T>
-		STL2_CONCEPT Pipeable =
+		META_CONCEPT Pipeable =
 			DerivedFrom<T, __pipeable_base> && ext::CopyConstructibleObject<T>;
 
 		template<Pipeable, Pipeable>

--- a/include/stl2/meta/meta.hpp
+++ b/include/stl2/meta/meta.hpp
@@ -554,26 +554,11 @@ namespace meta
         }
 
         /// is
-        /// \cond
-        namespace detail
-        {
-            template<typename, template<typename...> class>
-            struct is_ : std::false_type
-            {
-            };
-
-            template<typename... Ts, template<typename...> class C>
-            struct is_<C<Ts...>, C> : std::true_type
-            {
-            };
-        }
-        /// \endcond
-
         /// Test whether a type \p T is an instantiation of class
         /// template \p C.
         /// \ingroup trait
         template<typename T, template<typename...> class C>
-        using is = _t<detail::is_<T, C>>;
+        using is = bool_<is_v<T, C>>;
 
         /// Compose the Invocables \p Fns in the parameter pack \p Ts.
         /// \ingroup composition

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 	template<class T, class U>
 	using __builtin_common_t = meta::_t<__builtin_common<T, U>>;
 	template<class T, class U>
-	requires _Valid<__cond, __cref<T>, __cref<U>>
+	requires meta::Valid<__cond, __cref<T>, __cref<U>>
 	struct __builtin_common<T, U> : std::decay<__cond<__cref<T>, __cref<U>>> {};
 
 	template<class T, class U, class R = __builtin_common_t<T &, U &>>
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class T, class U>
 	requires
-		_Valid<__builtin_common_t, T &, U &> &&
+		meta::Valid<__builtin_common_t, T &, U &> &&
 		ConvertibleTo<T &&, __rref_res<T, U>> &&
 		ConvertibleTo<U &&, __rref_res<T, U>>
 	struct __builtin_common<T &&, U &&> : meta::id<__rref_res<T, U>> {};
@@ -76,7 +76,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class T, class U>
 	requires
-		_Valid<__builtin_common_t, T &, U const &> &&
+		meta::Valid<__builtin_common_t, T &, U const &> &&
 		ConvertibleTo<U &&, __builtin_common_t<T &, U const &>>
 	struct __builtin_common<T &, U &&> : __builtin_common<T &, U const &> {};
 	template<class T, class U>
@@ -106,7 +106,7 @@ STL2_OPEN_NAMESPACE {
 	struct common_type<T, U> : __common_type2<T, U> {};
 
 	template<class T, class U, class V, class...  W>
-	requires _Valid<common_type_t, T, U>
+	requires meta::Valid<common_type_t, T, U>
 	struct common_type<T, U, V, W...>
 	: common_type<common_type_t<T, U>, V, W...> {};
 
@@ -160,7 +160,7 @@ STL2_OPEN_NAMESPACE {
 	struct __common_reference2_1_ : __common_reference2_2_<T, U> {};
 
 	template<class T, class U>
-	requires _Valid<meta::_t, __basic_common_reference<T, U>>
+	requires meta::Valid<meta::_t, __basic_common_reference<T, U>>
 	struct __common_reference2_1_<T, U> : __basic_common_reference<T, U> {};
 
 	template<class T, class U>
@@ -168,7 +168,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class T, class U>
 	requires std::is_reference_v<T> && std::is_reference_v<U> &&
-		_Valid<__builtin_common_t, T, U> &&
+		meta::Valid<__builtin_common_t, T, U> &&
 		std::is_reference_v<__builtin_common_t<T, U>>
 	struct __common_reference2<T, U> : __builtin_common<T, U> {};
 
@@ -176,7 +176,7 @@ STL2_OPEN_NAMESPACE {
 	struct common_reference<T, U> : __common_reference2<T, U> {};
 
 	template<class T, class U, class V, class... W>
-	requires _Valid<common_reference_t, T, U>
+	requires meta::Valid<common_reference_t, T, U>
 	struct common_reference<T, U, V, W...>
 	: common_reference<common_reference_t<T, U>, V, W...> {};
 
@@ -184,7 +184,7 @@ STL2_OPEN_NAMESPACE {
 	// CommonReference [concept.commonref]
 	//
 	template<class T, class U>
-	STL2_CONCEPT CommonReference =
+	META_CONCEPT CommonReference =
 		requires {
 			typename common_reference_t<T, U>;
 			typename common_reference_t<U, T>;
@@ -197,7 +197,7 @@ STL2_OPEN_NAMESPACE {
 	// Common [concept.common]
 	//
 	template<class T, class U>
-	STL2_CONCEPT Common =
+	META_CONCEPT Common =
 		requires {
 			typename common_type_t<T, U>;
 			typename common_type_t<U, T>;

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -25,13 +25,11 @@
 #include <type_traits>
 
 STL2_OPEN_NAMESPACE {
-	template<auto> struct __require_constant;
-
 	template<class R>
-	STL2_CONCEPT _TinyRange =
+	META_CONCEPT _TinyRange =
 		SizedRange<R> &&
 		requires {
-			typename __require_constant<std::remove_reference_t<R>::size()>;
+			typename meta::detail::require_constant<std::remove_reference_t<R>::size()>;
 		} &&
 		std::remove_reference_t<R>::size() <= 1;
 

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -24,7 +24,7 @@
 
 STL2_OPEN_NAMESPACE {
 	template<class From, class To>
-	STL2_CONCEPT _ConvertibleToNotSlicing =
+	META_CONCEPT _ConvertibleToNotSlicing =
 		ConvertibleTo<From, To> &&
 		// A conversion is a slicing conversion if the source and the destination
 		// are both pointers, and if the pointed-to types differ after removing
@@ -35,13 +35,13 @@ STL2_OPEN_NAMESPACE {
 		             std::remove_pointer_t<std::decay_t<To>>>);
 
 	template<class T>
-	STL2_CONCEPT _PairLikeGCCBugs = requires(T t) {
+	META_CONCEPT _PairLikeGCCBugs = requires(T t) {
 		{ std::get<0>(t) } -> const std::tuple_element_t<0, T>&;
 		{ std::get<1>(t) } -> const std::tuple_element_t<1, T>&;
 	};
 
 	template<class T>
-	STL2_CONCEPT _PairLike =
+	META_CONCEPT _PairLike =
 		!std::is_reference_v<T> && requires {
 			typename std::tuple_size<T>::type;
 			requires DerivedFrom<std::tuple_size<T>, std::integral_constant<std::size_t, 2>>;
@@ -52,14 +52,14 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	template<class T, class U, class V>
-	STL2_CONCEPT _PairLikeConvertibleFromGCCBugs =
+	META_CONCEPT _PairLikeConvertibleFromGCCBugs =
 		!std::is_reference_v<std::tuple_element_t<0, T>> &&
 		!std::is_reference_v<std::tuple_element_t<1, T>> &&
 		_ConvertibleToNotSlicing<U, std::tuple_element_t<0, T>> &&
 		ConvertibleTo<V, std::tuple_element_t<1, T>>;
 
 	template<class T, class U, class V>
-	STL2_CONCEPT _PairLikeConvertibleFrom =
+	META_CONCEPT _PairLikeConvertibleFrom =
 		!Range<T> && _PairLike<T> && Constructible<T, U, V> &&
 		_PairLikeConvertibleFromGCCBugs<T, U, V>; // Separate named concept to avoid
 		                                          // premature substitution.

--- a/include/stl2/view/view_interface.hpp
+++ b/include/stl2/view/view_interface.hpp
@@ -34,15 +34,15 @@ STL2_OPEN_NAMESPACE {
 			typename __range_common_iterator_impl<Rng>::type;
 
 		template<class R>
-		STL2_CONCEPT CanEmpty = Range<R> && requires(R& r) { empty(r); };
+		META_CONCEPT CanEmpty = Range<R> && requires(R& r) { empty(r); };
 		template<class R>
-		STL2_CONCEPT SizedSentinelForwardRange = ForwardRange<R> && SizedSentinel<sentinel_t<R>, iterator_t<R>>;
+		META_CONCEPT SizedSentinelForwardRange = ForwardRange<R> && SizedSentinel<sentinel_t<R>, iterator_t<R>>;
 		template<class C, class R> // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
-		STL2_CONCEPT ContainerConvertibleGCCBugs = InputRange<R> &&
+		META_CONCEPT ContainerConvertibleGCCBugs = InputRange<R> &&
 			ConvertibleTo<iter_reference_t<iterator_t<R>>, iter_value_t<iterator_t<C>>> &&
 			Constructible<C, __range_common_iterator<R>, __range_common_iterator<R>>;
 		template<class C, class R>
-		STL2_CONCEPT ContainerConvertible = ForwardRange<C> && !View<C> &&
+		META_CONCEPT ContainerConvertible = ForwardRange<C> && !View<C> &&
 			ContainerConvertibleGCCBugs<C, R>;
 
 		template<Range R>

--- a/test/algorithm/find.cpp
+++ b/test/algorithm/find.cpp
@@ -23,16 +23,14 @@
 #include "../simple_test.hpp"
 #include "../test_iterators.hpp"
 
-struct S
-{
+namespace ranges = __stl2;
+
+struct S {
 	int i_;
 };
 
-template<class> class show_type;
-
-int main()
-{
-	using namespace __stl2;
+int main() {
+	using namespace ranges;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	auto first = [&ia]{ return input_iterator<const int*>{ia}; };

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -51,7 +51,7 @@ static_assert(!meta::is_trait<common_reference<int, short, int, char*>>(), "");
 
 STL2_OPEN_NAMESPACE {
 template<class... T, class... U, template<class> class TQual, template<class> class UQual>
-	requires(_Valid<common_reference_t, TQual<T>, UQual<U>> && ...)
+	requires (meta::Valid<common_reference_t, TQual<T>, UQual<U>> && ...)
 struct basic_common_reference<tuple<T...>, tuple<U...>, TQual, UQual> {
 	using type = tuple<common_reference_t<TQual<T>, UQual<U>>...>;
 };

--- a/test/concepts/swap.cpp
+++ b/test/concepts/swap.cpp
@@ -66,7 +66,7 @@ namespace swappable_test {
 			constrained_swappable(constrained_swappable&&) = default;
 		};
 		template<class T>
-		STL2_CONCEPT ConstrainedSwappable = Same<T, constrained_swappable>;
+		META_CONCEPT ConstrainedSwappable = Same<T, constrained_swappable>;
 		template<ConstrainedSwappable T, ConstrainedSwappable U>
 		void swap(T&, U&) {}
 		template<ConstrainedSwappable T>

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -412,5 +412,25 @@ int main()
 	}
 
 	test_tuple_cat();
+
+	{
+		static_assert(meta::Integral<std::true_type>);
+		static_assert(meta::Integral<std::integral_constant<std::size_t, 42>>);
+		static_assert(meta::Integral<std::integral_constant<int, -42>>);
+
+		struct S1 : std::integral_constant<int, 42>
+		{
+		};
+		static_assert(meta::Integral<S1>);
+
+#if !defined(__GNUC__) || defined(__clang__) // Avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88515
+		struct S2 : S1
+		{
+			const int value;
+		};
+		static_assert(!meta::Integral<S2>);
+#endif
+	}
+
 	return ::test_result();
 }

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -76,13 +76,13 @@ void test_array(std::integer_sequence<T, Is...>) {
 
 namespace begin_testing {
 	template<class R>
-	STL2_CONCEPT CanBegin =
+	META_CONCEPT CanBegin =
 		requires(R&& r) {
 			ranges::begin((R&&)r);
 		};
 
 	template<class R>
-	STL2_CONCEPT CanCBegin =
+	META_CONCEPT CanCBegin =
 		requires(R&& r) {
 			ranges::cbegin((R&&)r);
 		};


### PR DESCRIPTION
meta:
* Define macro `META_CONCEPT_BARRIER` to wrap atomic expressions in a `constexpr bool` to avoid inadvertent subsumption when using TS concepts.

* Replace implementation of `meta::Same` with that of `__stl2::_SameImpl`.

* Add `meta::is_v` variable template form of `meta::is`. Use it to implement `meta::List` and `meta::is`.

* Update definition of `meta::Integral`, now that https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68434 is fixed. Guard against substitutions producing non-constant expressions.

stl2:
* Replace `_Valid` with `meta::_Valid`

* Replace `STL2_CONCEPT` with `META_CONCEPT`

* Removed unused `_Is` and `_IsNot` concepts

* Use `meta::Same` to implement `Same`, `_Decayed`, `_OneOf`, and `_NotSameAs`.

* Remove unused `__as_integer_sequence` alias.

* Factor out intrinsic selection for `is_convertible` into a variable template, use it in `ConvertibleTo`, `DerivedFrom`, `is_nothrow_convertible_v`, and `__decay_copy`.