### PR TITLE
semiregular_box: partial specialization must be at-least-as-constrained

### DIFF
--- a/include/stl2/detail/semiregular_box.hpp
+++ b/include/stl2/detail/semiregular_box.hpp
@@ -120,6 +120,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<Semiregular T>
+		requires ext::Object<T>
 		struct semiregular_box<T> : ebo_box<T, semiregular_box<T>> {
 			using semiregular_box::ebo_box::ebo_box;
 


### PR DESCRIPTION
.... and `Semiregular` doesn't subsume `ext::Object` =(

