### PR TITLE
CI updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ task:
     - cmake .. -GNinja -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
   build_script:
     - cd build
-    - ninja
+    - ninja -v
   test_script:
     - cd build
     - ctest -j8 --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
-dist: trusty
-sudo: false
+dist: xenial
 language: cpp
 
 cache:
@@ -13,37 +12,40 @@ cache:
 
 matrix:
   include:
-    - env: GCC_VERSION=7 BUILD_TYPE=Debug ASAN=Off
+    - env: GCC_VERSION=7 BUILD_TYPE=Debug
       os: linux
       addons: &gcc7
         apt:
           packages:
             - g++-7
+            - ninja-build
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=7 BUILD_TYPE=Release ASAN=Off
+    - env: GCC_VERSION=7 BUILD_TYPE=Release
       os: linux
       addons: *gcc7
 
-    - env: GCC_VERSION=8 BUILD_TYPE=Debug ASAN=Off
+    - env: GCC_VERSION=8 BUILD_TYPE=Debug
       os: linux
       addons: &gcc8
         apt:
           packages:
             - g++-8
+            - ninja-build
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=8 BUILD_TYPE=Release ASAN=Off
+    - env: GCC_VERSION=8 BUILD_TYPE=Release
       os: linux
       addons: *gcc8
 
 before_install:
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
-  - which $CXX
   - which $CC
+  - which $CXX
   - $CXX --version
+  - ninja --version
   - JOBS=2
 
 install:
@@ -65,9 +67,8 @@ before_script:
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir -p build
   - cd build
-  - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then CXX_FLAGS="${CXX_FLAGS}"; fi
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
-  - make VERBOSE=1 -j${JOBS}
+  - cmake .. -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+  - ninja -v
 
 script:
   - ctest -j${JOBS} --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
 # cmcstl2
-An implementation of [ISO/IEC Technical Specification 21425:2017 "Programming languages -- C++ Extensions for ranges"](https://www.iso.org/standard/70910.html) (the "Ranges TS").
+An implementation of [P0896R4 "The One Ranges Proposal"](https://wg21.link/p0896r4).
 Compilation requires a compiler with support for C++17 and the Concepts TS, which as of this writing means [GCC 7+](https://gcc.gnu.org/) with the `-std=c++1z` and `-fconcepts` command line options.
-
-**Build status**
-- on Travis-CI: [![Travis Build Status](https://travis-ci.org/CaseyCarter/cmcstl2.svg?branch=master)](https://travis-ci.org/CaseyCarter/cmcstl2)


### PR DESCRIPTION
`ninja -v` on Cirrus; use `ninja` on Travis.

Strip Travis info from the README, preparatory to disabling Travis integration.