### PR TITLE
meta: implement make_integer_sequence with __integer_pack on GCC8+

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -463,6 +463,14 @@ namespace meta
 
     template <std::size_t N>
     using make_index_sequence = make_integer_sequence<std::size_t, N>;
+#elif META_HAS_INTEGER_PACK && !defined(META_DOXYGEN_INVOKED)
+    // Implement make_integer_sequence and make_index_sequence with the
+    // __integer_pack builtin on compilers that provide it.
+    template <typename T, T N>
+    using make_integer_sequence = integer_sequence<T, __integer_pack(N)...>;
+
+    template <std::size_t N>
+    using make_index_sequence = make_integer_sequence<std::size_t, N>;
 #else
     /// Generate \c index_sequence containing integer constants [0,1,2,...,N-1].
     /// \par Complexity

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -45,7 +45,9 @@
 
 #elif defined(__GNUC__)
 #define META_WORKAROUND_GCC_86356 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86356
-#if __GNUC__ < 8
+#if __GNUC__ >= 8
+#define META_HAS_INTEGER_PACK 1
+#else
 #define META_WORKAROUND_GCC_UNKNOWN1 // Older GCCs don't like fold + debug + -march=native
 #endif
 #if __GNUC__ == 5 && __GNUC_MINOR__ == 1
@@ -97,6 +99,10 @@
 #endif
 #ifndef META_HAS_MAKE_INTEGER_SEQ
 #define META_HAS_MAKE_INTEGER_SEQ 0
+#endif
+
+#ifndef META_HAS_INTEGER_PACK
+#define META_HAS_INTEGER_PACK 0
 #endif
 
 #ifndef META_HAS_TYPE_PACK_ELEMENT


### PR DESCRIPTION
Awaiting merge of https://github.com/ericniebler/meta/pull/61 to avoid `meta` divergence.