### PR TITLE
Remove non-standard extension from span

### DIFF
--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -142,7 +142,6 @@ STL2_OPEN_NAMESPACE {
 			// [span.cons], span constructors
 			constexpr span() noexcept = default;
 			constexpr span(pointer ptr, index_type count) noexcept
-			requires true // HACK: disambiguates span{ptr, 0}
 			: __span::extent<Extent>{count}, data_{ptr}
 			{
 				STL2_EXPECT(count == 0 || ptr != nullptr);

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -157,15 +157,6 @@ void test_case_from_pointer_size_constructor()
 		auto s = make_span(p, static_cast<span<int>::index_type>(0));
 		CHECK((s.size() == 0 && s.data() == nullptr));
 	}
-
-	{
-		int i = 42;
-		span<int> s{&i, 0};
-		CHECK((s.size() == 0 && s.data() == &i));
-
-		span<const int> cs{&i, 0};
-		CHECK((s.size() == 0 && s.data() == &i));
-	}
 }
 
 void test_case_from_pointer_pointer_constructor()
@@ -1091,7 +1082,7 @@ int main() {
 	static_assert(ranges::Same<decltype(ranges::end(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
 	{
 		int some_ints[]{42};
-		CHECK(ranges::data(span{some_ints, 0}) == +some_ints);
+		CHECK(ranges::data(span{some_ints, 42}) == +some_ints);
 	}
 
 	{


### PR DESCRIPTION
... which uses a GCC bug to disambiguate construction from `(pointer, 0)`.