### PR TITLE
iterator.move_iterator: Brutally hack proxy_iterator

### DIFF
--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -166,9 +166,11 @@ public:
 		return *this;
 	}
 	readable_proxy operator++(int) & {
-		readable_proxy tmp{ranges::iter_move(*ptr_)};
-		++*this;
-		return tmp;
+		struct guard { // Just a weeee hack.
+			proxy_iterator& self_;
+			~guard() { ++self_; }
+		} _{*this};
+		return readable_proxy{ranges::iter_move(*ptr_)};
 	}
 
 	friend T&& iter_move(const proxy_iterator& p) {


### PR DESCRIPTION
...to use C++17 guaranteed copy elision instead of non-guaranteed NRVO.