### PR TITLE
MSVC bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,13 @@ add_library(stl2 INTERFACE)
 target_include_directories(stl2 INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
-target_compile_features(stl2 INTERFACE cxx_std_17)
+if(NOT MSVC)
+    target_compile_features(stl2 INTERFACE cxx_std_17)
+endif()
 target_compile_options(stl2 INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-fconcepts>
-    $<$<CXX_COMPILER_ID:Clang>:-Xclang -fconcepts-ts>)
+    $<$<CXX_COMPILER_ID:Clang>:-Xclang -fconcepts-ts>
+    $<$<CXX_COMPILER_ID:MSVC>:/std:c++latest /permissive- /experimental:concepts /D__cpp_concepts=201811L>)
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS stl2 EXPORT cmcstl2-targets)

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -653,6 +653,56 @@ STL2_OPEN_NAMESPACE {
 		using type = __stl2::contiguous_iterator_tag;
 	};
 } STL2_CLOSE_NAMESPACE
+#elif defined(_MSVC_STL_VERSION)
+namespace std {
+	template<class, size_t> class _Array_iterator;
+	template<class, size_t> class _Array_const_iterator;
+	template<class, size_t> class _Span_iterator;       // My crystal ball tells me we'll pick
+	template<class, size_t> class _Span_const_iterator; // these names when we implement span.
+	template<class> class _String_iterator;
+	template<class> class _String_const_iterator;
+	template<class> class _String_view_iterator;
+	template<class> class _Vector_iterator;
+	template<class> class _Vector_const_iterator;
+}
+STL2_OPEN_NAMESPACE {
+	template<class T, size_t N>
+	struct iterator_category<::std::_Array_iterator<T, N>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T, size_t N>
+	struct iterator_category<::std::_Array_const_iterator<T, N>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T, size_t N>
+	struct iterator_category<::std::_Span_iterator<T, N>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T, size_t N>
+	struct iterator_category<::std::_Span_const_iterator<T, N>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T>
+	struct iterator_category<::std::_String_iterator<T>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T>
+	struct iterator_category<::std::_String_const_iterator<T>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T>
+	struct iterator_category<::std::_String_view_iterator<T>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T>
+	struct iterator_category<::std::_Vector_iterator<T>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+	template<class T>
+	struct iterator_category<::std::_Vector_const_iterator<T>> {
+		using type = __stl2::contiguous_iterator_tag;
+	};
+} STL2_CLOSE_NAMESPACE
 #endif
 
 #endif

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -24,8 +24,9 @@
 #include <stl2/detail/range/access.hpp>
 
 namespace std {
-#ifndef __GLIBCXX__
-#pragma message "These forward declarations will likely only work with libstdc++."
+#if !defined(__GLIBCXX__) && !defined(_MSVC_STL_VERSION)
+#pragma message "These forward declarations will only work with standard " \
+	"libraries that don't use inline namespaces for versioning."
 #endif
 	template<class, class, class> class set;
 	template<class, class, class> class multiset;

--- a/test/simple_test.hpp
+++ b/test/simple_test.hpp
@@ -173,6 +173,9 @@ inline int test_result()
 	return ::test_impl::test_failures() ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
 #define CHECK(...)                                                                                 \
 	(void)(::test_impl::S{__FILE__, __LINE__, #__VA_ARGS__, __PRETTY_FUNCTION__} ->* __VA_ARGS__)  \
 	/**/


### PR DESCRIPTION
* Teach `CMakeLists.txt` the flags to enable concepts. Define `__cpp_concepts` directly for now since the compiler does not.
* The forward declarations in `range/concepts.hpp` work with MSVC's standard library as well.
* Teach `iterator_category` about MSVC's contiguous iterators
* `__PRETTY_FUNCTION__` is a GCC-ish thing; use `__FUNCSIG__` on MSVC.