### PR TITLE
Speculatively implement the PR of ericniebler/stl2#623

### DIFF
--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -157,8 +157,12 @@ STL2_OPEN_NAMESPACE {
 
 	template<class Rng>
 	META_CONCEPT ViewableRange =
+#if 1 // This is the PR of https://github.com/ericniebler/stl2/issues/623
+		View<__uncvref<Rng>> || _ForwardingRange<Rng>;
+#else
 		Range<Rng> &&
-		(_RangeImpl<Rng> || View<Rng>);
+		(_RangeImpl<Rng> || View<std::decay_t<Rng>>);
+#endif
 
 	namespace ext {
 		template<Range R>

--- a/test/view/filter_view.cpp
+++ b/test/view/filter_view.cpp
@@ -135,8 +135,14 @@ int main() {
 	}
 
 	{
-		auto yes = [](int){ return true; };
+		auto yes = [](int) { return true; };
 		(void) (view::iota(0) | view::filter(yes));
+	}
+
+	{
+		auto yes = [](int) { return true; };
+		auto const rng = view::iota(0) | view::filter(yes);
+		view::all(rng);
 	}
 
 	return test_result();


### PR DESCRIPTION
This fails to compile view.move and view.split. The former is due to a GCC bug - the compiler is instantiating `std::vector<std::unique_ptr<some_type>>::operator=(const vector&)` when it sees `if constexpr(View<std::vector<std::unique_ptr<some_type>>&>)` - and I suspect the latter is similar although I haven't investigated.

I'm opening this PR to remind me to devise a workaround and fix this so I can merge.