### PR TITLE
Implemented changes from P1716

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class Pred = equal_to<>,
 		class Proj = identity>
 	requires
-		IndirectRelation<Pred, projected<I, Proj>>
+		IndirectBinaryPredicate<Pred, projected<I, Proj>, projected<I, Proj>>
 	I adjacent_find(I first, S last, Pred pred = Pred{}, Proj proj = Proj{})
 	{
 		if (first == last) {
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <ForwardRange Rng, class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<Pred, projected<iterator_t<Rng>, Proj>>
+		IndirectBinaryPredicate<Pred, projected<iterator_t<Rng>, Proj>, projected<iterator_t<Rng>, Proj>>
 	safe_iterator_t<Rng>
 	adjacent_find(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T*>
 	iter_difference_t<I>
 	count(I first, S last, const T& value, Proj proj = Proj{})
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class T, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
 	iter_difference_t<iterator_t<Rng>>
 	count(Rng&& rng, const T& value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	template <InputIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T*>
 	I find(I first, S last, const T& value, Proj proj = Proj{})
 	{
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 
 	template <InputRange Rng, class T, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
 	safe_iterator_t<Rng> find(Rng&& rng, const T& value, Proj proj = Proj{}) {
 		return __stl2::find(__stl2::begin(rng), __stl2::end(rng), value, std::ref(proj));

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		ForwardIterator I2, Sentinel<I2> S2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			Pred, I2, projected<I1, Proj>>
 	I1 find_end(I1 first1, const S1 last1,
 		const I2 first2, const S2 last2,
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 	template <BidirectionalIterator I1, BidirectionalIterator I2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			Pred, I2, projected<I1, Proj>>
 	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
 		Pred pred = Pred{}, Proj proj = Proj{})
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 	template <RandomAccessIterator I1, RandomAccessIterator I2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			Pred, I2, projected<I1, Proj>>
 	I1 find_end(I1 first1, I1 last1, I2 first2, I2 last2,
 		Pred pred = Pred{}, Proj proj = Proj{})
@@ -123,7 +123,7 @@ STL2_OPEN_NAMESPACE {
 		BidirectionalIterator I2, Sentinel<I2> S2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			Pred, I2, projected<I1, Proj>>
 	I1 find_end(I1 first1, S1 s1, I2 first2, S2 s2, Pred pred = Pred{}, Proj proj = Proj{})
 	{
@@ -138,7 +138,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng1, ForwardRange Rng2,
 		class Pred = equal_to<>, class Proj = identity>
 	requires
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			Pred, iterator_t<Rng2>, projected<iterator_t<Rng1>, Proj>>
 	safe_iterator_t<Rng1>
 	find_end(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{}, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -15,7 +15,7 @@
 #include <stl2/functional.hpp>
 #include <stl2/iterator.hpp>
 #include <stl2/detail/fwd.hpp>
-#include <stl2/detail/concepts/callable.hpp>
+#include <stl2/detail/concepts/algorithm.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
 // find_first_of [alg.find.first.of]
@@ -26,9 +26,7 @@ STL2_OPEN_NAMESPACE {
 		class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		IndirectRelation<Pred,
-			projected<I1, Proj1>,
-			projected<I2, Proj2>>
+		IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
 	I1 find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
 		Pred pred = Pred{}, Proj1 proj1 = Proj1{},
 		Proj2 proj2 = Proj2{})
@@ -46,9 +44,8 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, ForwardRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+        IndirectlyComparable<
+            iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>
 	safe_iterator_t<Rng1>
 	find_first_of(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -16,7 +16,7 @@
 #include <stl2/iterator.hpp>
 #include <stl2/utility.hpp>
 #include <stl2/detail/algorithm/tagspec.hpp>
-#include <stl2/detail/concepts/callable.hpp>
+#include <stl2/detail/concepts/algorithm.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
 // mismatch [mismatch]
@@ -28,9 +28,7 @@ STL2_OPEN_NAMESPACE {
 	mismatch(I1 first1, S1 last1, I2&& first2_, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
 	requires
-		IndirectRelation<Pred,
-			projected<I1, Proj1>,
-			projected<std::decay_t<I2>, Proj2>>
+        IndirectlyComparable<I1, std::decay_t<I2>, Pred, Proj1, Proj2>
 	{
 		auto first2 = std::forward<I2>(first2_);
 		for (; first1 != last1; ++first1, ++first2) {
@@ -45,8 +43,7 @@ STL2_OPEN_NAMESPACE {
 		InputIterator I2, Sentinel<I2> S2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		IndirectRelation<
-			Pred, projected<I1, Proj1>, projected<I2, Proj2>>
+        IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
 	tagged_pair<tag::in1(I1), tag::in2(I2)>
 	mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})
@@ -68,9 +65,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		InputIterator<std::decay_t<I2>> &&
 		!Range<I2> &&
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<std::decay_t<I2>, Proj2>>
+        IndirectlyComparable<iterator_t<Rng1>, std::decay_t<I2>, Pred, Proj1, Proj2>
 	{
 		auto first2 = std::forward<I2>(first2_);
 		return __stl2::mismatch(
@@ -82,9 +77,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng1, InputRange Rng2, class Pred = equal_to<>,
 		class Proj1 = identity, class Proj2 = identity>
 	requires
-		IndirectRelation<Pred,
-			projected<iterator_t<Rng1>, Proj1>,
-			projected<iterator_t<Rng2>, Proj2>>
+        IndirectlyComparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>
 	tagged_pair<tag::in1(safe_iterator_t<Rng1>), tag::in2(safe_iterator_t<Rng2>)>
 	mismatch(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
 		Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{})

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardIterator I, Sentinel<I> S, class T, class Proj = identity>
 	requires
 		Permutable<I> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T*>
 	I remove(I first, S last, const T& value, Proj proj = Proj{})
 	{
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng, class T, class Proj = identity>
 	requires
 		Permutable<iterator_t<Rng>> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
 	safe_iterator_t<Rng>
 	remove(Rng&& rng, const T& value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 		class T, class Proj = identity>
 	requires
 		IndirectlyCopyable<I, O> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T*>
 	tagged_pair<tag::in(I), tag::out(O)>
 	remove_copy(I first, S last, O result, const T& value, Proj proj = Proj{})
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		WeaklyIncrementable<__f<O>> &&
 		IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T*>
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	remove_copy(Rng&& rng, O&& result, const T& value, Proj proj = Proj{})

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 		class Proj = identity>
 	requires
 		Writable<I, const T2&> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T1*>
 	I replace(I first, S last, const T1& old_value, const T2& new_value,
 		Proj proj = Proj{})
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 	template <InputRange Rng, class T1, class T2, class Proj = identity>
 	requires
 		Writable<iterator_t<Rng>, const T2&> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>
 	safe_iterator_t<Rng>
 	replace(Rng&& rng, const T1& old_value, const T2& new_value,

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 		OutputIterator<const T2&> O, class Proj = identity>
 	requires
 		IndirectlyCopyable<I, O> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<I, Proj>, const T1*>
 	tagged_pair<tag::in(I), tag::out(O)>
 	replace_copy(I first, S last, O result, const T1& old_value,
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 	requires
 		OutputIterator<__f<O>, const T2&> &&
 		IndirectlyCopyable<iterator_t<Rng>, __f<O>> &&
-		IndirectRelation<
+		IndirectBinaryPredicate<
 			equal_to<>, projected<iterator_t<Rng>, Proj>, const T1*>
 	tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(__f<O>)>
 	replace_copy(Rng&& rng, O&& result, const T1& old_value,

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 		class R = equal_to<>, class Proj = identity>
 	requires
 		Permutable<I> &&
-		IndirectRelation<__f<R>, projected<I, Proj>>
+		IndirectBinaryPredicate<__f<R>, projected<I, Proj>, projected<I, Proj>>
 	I unique(I first, S last, R comp = R{}, Proj proj = Proj{})
 	{
 		first = __stl2::adjacent_find(
@@ -46,8 +46,8 @@ STL2_OPEN_NAMESPACE {
 	template <ForwardRange Rng, class R = equal_to<>, class Proj = identity>
 	requires
 		Permutable<iterator_t<Rng>> &&
-		IndirectRelation<
-			__f<R>, projected<iterator_t<Rng>, Proj>>
+		IndirectBinaryPredicate<
+			__f<R>, projected<iterator_t<Rng>, Proj>, projected<iterator_t<Rng>, Proj>>
 	safe_iterator_t<Rng>
 	unique(Rng&& rng, R comp = R{}, Proj proj = Proj{})
 	{

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 		class R = equal_to<>, class Proj = identity>
 	requires
 		IndirectlyCopyable<I, O> &&
-		IndirectRelation<R, projected<I, Proj>> &&
+		IndirectBinaryPredicate<R, projected<I, Proj>, projected<I, Proj>> &&
 		(ForwardIterator<I> ||
 		 InputIterator<O> && Same<iter_value_t<I>, iter_value_t<O>> ||
 		 IndirectlyCopyableStorable<I, O>)
@@ -112,7 +112,7 @@ STL2_OPEN_NAMESPACE {
 		class Proj = identity>
 	requires
 		IndirectlyCopyable<iterator_t<Rng>, O> &&
-		IndirectRelation<R, projected<iterator_t<Rng>, Proj>> &&
+		IndirectBinaryPredicate<R, projected<iterator_t<Rng>, Proj>, projected<iterator_t<Rng>, Proj>> &&
 		(ForwardIterator<iterator_t<Rng>> ||
 		 InputIterator<O> && Same<iter_value_t<iterator_t<Rng>>, iter_value_t<O>> ||
 		 IndirectlyCopyableStorable<iterator_t<Rng>, O>)

--- a/include/stl2/detail/concepts/algorithm.hpp
+++ b/include/stl2/detail/concepts/algorithm.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	template <class I1, class I2, class R = equal_to<>, class P1 = identity,
 		class P2 = identity>
 	concept bool IndirectlyComparable =
-		IndirectRelation<R, projected<I1, P1>, projected<I2, P2>>;
+		IndirectBinaryPredicate<R, projected<I1, P1>, projected<I2, P2>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// Permutable [commmonalgoreq.permutable]

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -118,16 +118,16 @@ STL2_OPEN_NAMESPACE {
 	concept bool IndirectUnaryPredicate =
 		ext::IndirectPredicate<F, I>;
 
-	template <class F, class I1, class I2 = I1>
-	concept bool IndirectRelation =
+	template <class F, class I1, class I2>
+	concept bool IndirectBinaryPredicate =
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&
-		Relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-		Relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-		Relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-		Relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-		Relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+		Predicate<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		Predicate<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		Predicate<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		Predicate<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+		Predicate<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template <class F, class I1, class I2 = I1>
 	concept bool IndirectStrictWeakOrder =


### PR DESCRIPTION
The changes in this papers weakness the constrains of compare
algorithm to be derived from the predicate (required invocation
only in the specific direction).
The IndirectRelation concept is now replaced with IndirectBinaryPredicate,
that requires only single order of argument.
The IndirectlyComparable concept is now derived from IndirectBinaryPredicate.

Updated the following algorithms, to use IndirectRelation:
* find,
* adjacent_find,
* count,
* replace and replace_copy,
* remove and remove_copy,
* unique and unique_copy.

In addition the following two algorithms were changed to use
IndirectlyComparable as they compare elements of two different sequences:
* find_first_of,
* mismatch.