### PR TITLE
Implemented changes from P1716

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __adjacent_find_fn : private __niebloid {
 		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectRelation<projected<I, Proj>> Pred = equal_to>
+			IndirectBinaryPredicate<projected<I, Proj>, projected<I, Proj>> Pred = equal_to>
 		constexpr I
 		operator()(I first, S last, Pred pred = {}, Proj proj = {}) const {
 			if (first == last) {
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<ForwardRange R, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> Pred = equal_to>
+			IndirectBinaryPredicate<projected<iterator_t<R>, Proj>, projected<iterator_t<R>, Proj>> Pred = equal_to>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -21,7 +21,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __count_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		requires IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T*>
 		constexpr iter_difference_t<I>
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			iter_difference_t<I> n = 0;
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+		requires IndirectBinaryPredicate<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr iter_difference_t<iterator_t<R>>
 		operator()(R&& r, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -21,7 +21,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __find_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		requires IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T*>
 		constexpr I
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -33,7 +33,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+		requires IndirectBinaryPredicate<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -22,8 +22,10 @@
 STL2_OPEN_NAMESPACE {
 	struct __find_first_of_fn : private __niebloid {
 		template<InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
-			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<I1, Proj1>,	projected<I2, Proj2>> Pred = equal_to>
+			class Pred = equal_to,
+            class Proj1 = identity, class Proj2 = identity>
+        requires
+            IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
 		constexpr I1 operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
@@ -40,10 +42,10 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R1, ForwardRange R2,
-			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<
-				projected<iterator_t<R1>, Proj1>,
-				projected<iterator_t<R2>, Proj2>> Pred = equal_to>
+            class Pred = equal_to,
+			class Proj1 = identity, class Proj2 = identity>
+        requires
+            IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
 		constexpr safe_iterator_t<R1>
 		operator()(R1&& r1, R2&& r2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -25,9 +25,9 @@ STL2_OPEN_NAMESPACE {
 
 	struct __mismatch_fn : private __niebloid {
 		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<I1, Proj1>,
-				projected<I2, Proj2>> Pred = equal_to>
+			Sentinel<I2> S2, class Pred = equal_to, class Proj1 = identity, class Proj2 = identity>
+	    requires
+            IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
 		constexpr mismatch_result<I1, I2>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -47,9 +47,10 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R1, InputRange R2,
-			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<iterator_t<R1>, Proj1>,
-				projected<iterator_t<R2>, Proj2>> Pred = equal_to>
+            class Pred = equal_to,
+			class Proj1 = identity, class Proj2 = identity>
+        requires
+            IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
 		constexpr mismatch_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
 		operator()(R1&& r1, R2&& r2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -22,7 +22,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __remove_fn : private __niebloid {
 		template<Permutable I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		requires IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T*>
 		constexpr I
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			first = find(std::move(first), last, value, __stl2::ref(proj));
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<ForwardRange Rng, class T, class Proj = identity>
 		requires Permutable<iterator_t<Rng>> &&
-			IndirectRelation<equal_to, projected<iterator_t<Rng>, Proj>, const T*>
+			IndirectBinaryPredicate<equal_to, projected<iterator_t<Rng>, Proj>, const T*>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, const T& value, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
 			class Proj = identity>
 		requires IndirectlyCopyable<I, O> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T*>
+			IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T*>
 		constexpr remove_copy_result<I, O>
 		operator()(I first, S last, O result, const T& value, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<InputRange R, WeaklyIncrementable O, class T, class Proj = identity>
 		requires IndirectlyCopyable<iterator_t<R>, O> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+			IndirectBinaryPredicate<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr remove_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 		template<InputIterator I, Sentinel<I> S, class T1, class T2,
 			class Proj = identity>
 		requires Writable<I, const T2&> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T1*>
+			IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T1*>
 		constexpr I operator()(I first, S last, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
 		{
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<InputRange R, class T1, class T2, class Proj = identity>
 		requires Writable<iterator_t<R>, const T2&> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
+			IndirectBinaryPredicate<equal_to, projected<iterator_t<R>, Proj>, const T1*>
 		constexpr safe_iterator_t<R> operator()(R&& r, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
 		{

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 		template<InputIterator I, Sentinel<I> S, class T1, class T2,
 			OutputIterator<const T2&> O, class Proj = identity>
 		requires IndirectlyCopyable<I, O> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T1*>
+			IndirectBinaryPredicate<equal_to, projected<I, Proj>, const T1*>
 		constexpr replace_copy_result<I, O>
 		operator()(I first, S last, O result, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		template<InputRange R, class T1, class T2, OutputIterator<const T2&> O,
 			class Proj = identity>
 		requires IndirectlyCopyable<iterator_t<R>, O> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
+			IndirectBinaryPredicate<equal_to, projected<iterator_t<R>, Proj>, const T1*>
 		constexpr replace_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, const T1& old_value, const T2& new_value,
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -22,7 +22,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __unique_fn : private __niebloid {
 		template<Permutable I, Sentinel<I> S, class Proj = identity,
-			IndirectRelation<projected<I, Proj>> Comp = equal_to>
+			IndirectBinaryPredicate<projected<I, Proj>, projected<I, Proj>> Comp = equal_to>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			first = adjacent_find(std::move(first), last, __stl2::ref(comp),
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<ForwardRange R, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> Comp = equal_to>
+			IndirectBinaryPredicate<projected<iterator_t<R>, Proj>, projected<iterator_t<R>, Proj>> Comp = equal_to>
 		requires Permutable<iterator_t<R>>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	struct __unique_copy_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
 			class Proj = identity,
-			IndirectRelation<projected<I, Proj>> C = equal_to>
+			IndirectBinaryPredicate<projected<I, Proj>, projected<I, Proj>> C = equal_to>
 		requires IndirectlyCopyable<I, O> &&
 			(ForwardIterator<I> || __unique_copy_helper<I, O> ||
 			 IndirectlyCopyableStorable<I, O>)
@@ -82,7 +82,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R, WeaklyIncrementable O, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> C = equal_to>
+			IndirectBinaryPredicate<projected<iterator_t<R>, Proj>, projected<iterator_t<R>, Proj>> C = equal_to>
 		requires IndirectlyCopyable<iterator_t<R>, O> &&
 			(ForwardRange<R> || __unique_copy_helper<iterator_t<R>, O> ||
 			 IndirectlyCopyableStorable<iterator_t<R>, O>)

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -119,15 +119,15 @@ STL2_OPEN_NAMESPACE {
 		ext::IndirectPredicate<F, I>;
 
 	template<class F, class I1, class I2 = I1>
-	META_CONCEPT IndirectRelation =
+	META_CONCEPT IndirectBinaryPredicate =
 		Readable<I1> &&
 		Readable<I2> &&
 		CopyConstructible<F> &&
-		Relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-		Relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-		Relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-		Relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-		Relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+		Predicate<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		Predicate<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		Predicate<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		Predicate<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+		Predicate<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template<class F, class I1, class I2 = I1>
 	META_CONCEPT IndirectStrictWeakOrder =
@@ -160,7 +160,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I1, class I2, class R = equal_to, class P1 = identity,
 		class P2 = identity>
 	META_CONCEPT IndirectlyComparable =
-		IndirectRelation<R, projected<I1, P1>, projected<I2, P2>>;
+		IndirectBinaryPredicate<R, projected<I1, P1>, projected<I2, P2>>;
 
 	////////////////////////////////////////////////////////////////////////////
 	// Permutable [alg.req.permutable]


### PR DESCRIPTION
The changes in this papers weakness the constrains of compare
algorithm to be derived from the predicate (required invocation
only in the specific direction).
The IndirectRelation concept is now replaced with IndirectBinaryPredicate,
that requires only single order of argument.
The IndirectlyComparable concept is now derived from IndirectBinaryPredicate.

Updated the following algorithms, to use IndirectRelation:
* find,
* adjacent_find,
* count,
* replace and replace_copy,
* remove and remove_copy,
* unique and unique_copy.

In addition the following two algorithms were changed to use
IndirectlyComparable as they compare elements of two different sequences:
* find_first_of,
* mismatch.