### PR TITLE
Add missing #include <ostream>

### DIFF
--- a/test/move_only_string.hpp
+++ b/test/move_only_string.hpp
@@ -14,6 +14,7 @@
 #define STL2_MOVE_ONLY_STRING_HPP
 
 #include <cstring>
+#include <ostream>
 #include <stl2/detail/swap.hpp>
 
 namespace cmcstl2_test {


### PR DESCRIPTION
Changes in libstdc++ to reduce implicit dependencies on other headers mean
that this test now needs to explicitly include <ostream>.