### PR TITLE
renames all the concepts in P1754 up to readable

### DIFF
--- a/include/stl2/detail/algorithm/forward_sort.hpp
+++ b/include/stl2/detail/algorithm/forward_sort.hpp
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 			{
 				STL2_EXPECT(0 <= n);
 				auto ufirst = ext::uncounted(first);
-				static_assert(Same<iter_value_t<I>, iter_value_t<decltype(ufirst)>>);
+				static_assert(same_as<iter_value_t<I>, iter_value_t<decltype(ufirst)>>);
 				using buf_t = temporary_buffer<iter_value_t<I>>;
 				// TODO: tune this threshold.
 				auto buf = n / 2 >= 16 ? buf_t{n / 2} : buf_t{};

--- a/include/stl2/detail/algorithm/generate.hpp
+++ b/include/stl2/detail/algorithm/generate.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __generate_fn : private __niebloid {
-		template<Iterator O, Sentinel<O> S, CopyConstructible F>
-		requires Invocable<F&> && Writable<O, invoke_result_t<F&>>
+		template<Iterator O, Sentinel<O> S, copy_constructible F>
+		requires invocable<F&> && Writable<O, invoke_result_t<F&>>
 		constexpr O operator()(O first, S last, F gen) const {
 			for (; first != last; ++first) {
 				*first = gen();
@@ -29,8 +29,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<class R, CopyConstructible F>
-		requires Invocable<F&> && OutputRange<R, invoke_result_t<F&>>
+		template<class R, copy_constructible F>
+		requires invocable<F&> && OutputRange<R, invoke_result_t<F&>>
 		constexpr safe_iterator_t<R> operator()(R&& r, F gen) const {
 			return (*this)(begin(r), end(r), __stl2::ref(gen));
 		}

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __generate_n_fn : private __niebloid {
-		template<Iterator O, CopyConstructible F>
-		requires Invocable<F&> && Writable<O, invoke_result_t<F&>>
+		template<Iterator O, copy_constructible F>
+		requires invocable<F&> && Writable<O, invoke_result_t<F&>>
 		constexpr O operator()(O first, iter_difference_t<O> n, F gen) const {
 			for (; n > 0; (void) ++first, --n) {
 				*first = gen();

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -87,14 +87,14 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 	private:
-		template<Integral To, Integral From>
+		template<integral To, integral From>
 		static constexpr bool __can_represent(const From value) noexcept {
 			using C = decltype(true ? value : To{});
-			if constexpr (Same<To, C> && (SignedIntegral<To> || UnsignedIntegral<From>)) {
+			if constexpr (same_as<To, C> && (signed_integral<To> || unsigned_integral<From>)) {
 				return true;
 			} else {
-				if constexpr (SignedIntegral<From>) {
-					if constexpr (UnsignedIntegral<To>) {
+				if constexpr (signed_integral<From>) {
+					if constexpr (unsigned_integral<To>) {
 						if (value < 0) return false;
 					} else {
 						if (C(value) < C(std::numeric_limits<To>::min())) return false;
@@ -105,7 +105,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Does distance(first, last) == n?
-		template<Iterator I, Sentinel<I> S, SignedIntegral D>
+		template<Iterator I, Sentinel<I> S, signed_integral D>
 		static constexpr bool __has_length(const I first, const S last, const D n) {
 			STL2_EXPECT(n >= 0);
 			if constexpr (SizedSentinel<S, I>) {
@@ -119,7 +119,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 		// Does distance(rng) == n?
-		template<Range Rng, SignedIntegral D>
+		template<Range Rng, signed_integral D>
 		static constexpr bool __has_length(Rng&& rng, const D n) {
 			STL2_EXPECT(n >= 0);
 			if constexpr (SizedRange<Rng>) {

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 			return !test ? a : b;
 		}
 
-		template<Copyable T, class Proj = identity,
+		template<copyable T, class Proj = identity,
 			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
 		constexpr T operator()(std::initializer_list<T> r, Comp comp = {},
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 			return test ? b : a;
 		}
 
-		template<Copyable T, class Proj = identity,
+		template<copyable T, class Proj = identity,
 			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
 		constexpr T
 		operator()(std::initializer_list<T> r, Comp comp = {}, Proj proj = {}) const {

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 				return {a, b};
 		}
 
-		template<Copyable T, class Proj = identity,
+		template<copyable T, class Proj = identity,
 			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
 		constexpr minmax_result<T>
 		operator()(std::initializer_list<T>&& r, Comp comp = {}, Proj proj = {}) const {
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<InputRange R, class Proj = identity,
 			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
-		requires Copyable<iter_value_t<iterator_t<R>>>
+		requires copyable<iter_value_t<iterator_t<R>>>
 		constexpr minmax_result<iter_value_t<iterator_t<R>>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/results.hpp
+++ b/include/stl2/detail/algorithm/results.hpp
@@ -23,12 +23,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class I2, class O2>
-		requires ConvertibleTo<const I&, I2> && ConvertibleTo<const O&, O2>
+		requires convertible_to<const I&, I2> && convertible_to<const O&, O2>
 		operator __in_out_result<I2, O2>() const& {
 			return {in, out};
 		}
 		template<class I2, class O2>
-		requires ConvertibleTo<I, I2> && ConvertibleTo<O, O2>
+		requires convertible_to<I, I2> && convertible_to<O, O2>
 		operator __in_out_result<I2, O2>() && {
 			return {std::move(in), std::move(out)};
 		}
@@ -41,12 +41,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class II1, class II2>
-		requires ConvertibleTo<const I1&, II1> && ConvertibleTo<const I2&, II2>
+		requires convertible_to<const I1&, II1> && convertible_to<const I2&, II2>
 		operator __in_in_result<II1, II2>() const& {
 			return {in1, in2};
 		}
 		template<class II1, class II2>
-		requires ConvertibleTo<I1, II1> && ConvertibleTo<I2, II2>
+		requires convertible_to<I1, II1> && convertible_to<I2, II2>
 		operator __in_in_result<II1, II2>() && {
 			return {std::move(in1), std::move(in2)};
 		}
@@ -60,14 +60,14 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class II1, class II2, class OO>
-		requires ConvertibleTo<const I1&, II1> &&
-			ConvertibleTo<const I2&, II2> && ConvertibleTo<const O&, OO>
+		requires convertible_to<const I1&, II1> &&
+			convertible_to<const I2&, II2> && convertible_to<const O&, OO>
 		operator __in_in_out_result<II1, II2, OO>() const& {
 			return {in1, in2, out};
 		}
 		template<class II1, class II2, class OO>
-		requires ConvertibleTo<I1, II1> &&
-			ConvertibleTo<I2, II2> && ConvertibleTo<O, OO>
+		requires convertible_to<I1, II1> &&
+			convertible_to<I2, II2> && convertible_to<O, OO>
 		operator __in_in_out_result<II1, II2, OO>() && {
 			return {std::move(in1), std::move(in2), std::move(out)};
 		}
@@ -81,14 +81,14 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class II, class OO1, class OO2>
-		requires ConvertibleTo<const I&, II> &&
-			ConvertibleTo<const O1&, OO1> && ConvertibleTo<const O2&, OO2>
+		requires convertible_to<const I&, II> &&
+			convertible_to<const O1&, OO1> && convertible_to<const O2&, OO2>
 		operator __in_out_out_result<II, OO1, OO2>() const& {
 			return {in, out1, out2};
 		}
 		template<class II, class OO1, class OO2>
-		requires ConvertibleTo<I, II> &&
-			ConvertibleTo<O1, OO1> && ConvertibleTo<O2, OO2>
+		requires convertible_to<I, II> &&
+			convertible_to<O1, OO1> && convertible_to<O2, OO2>
 		operator __in_out_out_result<II, OO1, OO2>() && {
 			return {std::move(in), std::move(out1), std::move(out2)};
 		}
@@ -101,12 +101,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class I2, class F2>
-		requires ConvertibleTo<const I&, I2> && ConvertibleTo<const F&, F2>
+		requires convertible_to<const I&, I2> && convertible_to<const F&, F2>
 		operator __in_fun_result<I2, F2>() const& {
 			return {in, fun};
 		}
 		template<class I2, class F2>
-		requires ConvertibleTo<I, I2> && ConvertibleTo<F, F2>
+		requires convertible_to<I, I2> && convertible_to<F, F2>
 		operator __in_fun_result<I2, F2>() && {
 			return {std::move(in), std::move(fun)};
 		}
@@ -119,12 +119,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Extension: the dangling story actually works.
 		template<class T2>
-		requires ConvertibleTo<const T&, T2>
+		requires convertible_to<const T&, T2>
 		operator minmax_result<T2>() const& {
 			return {min, max};
 		}
 		template<class T2>
-		requires ConvertibleTo<T, T2>
+		requires convertible_to<T, T2>
 		operator minmax_result<T2>() && {
 			return {std::move(min), std::move(max)};
 		}

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 				if (next(first) == middle) {
 					return __rotate_left(std::move(first), std::move(last));
 				}
-				if constexpr (Same<I, S>) {
+				if constexpr (same_as<I, S>) {
 					if constexpr (BidirectionalIterator<I>) {
 						if (next(middle) == last) {
 							return __rotate_right(std::move(first), std
@@ -124,7 +124,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(r), std::move(i)};
 		}
 
-		template<Integral I>
+		template<integral I>
 		static constexpr I __gcd(I x, I y) {
 			do {
 				auto t = x % y;

--- a/include/stl2/detail/algorithm/sort.hpp
+++ b/include/stl2/detail/algorithm/sort.hpp
@@ -131,7 +131,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<Integral I>
+		template<integral I>
 		static constexpr auto log2(I n) {
 			STL2_EXPECT(n > 0);
 			I k = 0;

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 
 	struct __transform_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-			CopyConstructible F, class Proj = identity>
+			copy_constructible F, class Proj = identity>
 		requires Writable<O, indirect_result_t<F&, projected<I, Proj>>>
 		constexpr unary_transform_result<I, O>
 		operator()(I first, S last, O result, F op, Proj proj = {}) const {
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, CopyConstructible F,
+		template<InputRange R, WeaklyIncrementable O, copy_constructible F,
 			class Proj = identity>
 		requires Writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
 		constexpr unary_transform_result<safe_iterator_t<R>, O>
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<InputIterator I1, Sentinel<I1> S1,
 			InputIterator I2, Sentinel<I2> S2,
-			WeaklyIncrementable O, CopyConstructible F,
+			WeaklyIncrementable O, copy_constructible F,
 			class Proj1 = identity, class Proj2 = identity>
 		requires Writable<O, indirect_result_t<F&,
 			projected<I1, Proj1>, projected<I2, Proj2>>>
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
-			CopyConstructible F, class Proj1 = identity, class Proj2 = identity>
+			copy_constructible F, class Proj1 = identity, class Proj2 = identity>
 		requires Writable<O, indirect_result_t<F&,
 			projected<iterator_t<R1>, Proj1>, projected<iterator_t<R2>, Proj2>>>
 		constexpr binary_transform_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class I, class O>
 	META_CONCEPT __unique_copy_helper = InputIterator<I> &&  InputIterator<O> &&
-		Same<iter_value_t<I>, iter_value_t<O>>;
+		same_as<iter_value_t<I>, iter_value_t<O>>;
 
 	struct __unique_copy_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,

--- a/include/stl2/detail/cheap_storage.hpp
+++ b/include/stl2/detail/cheap_storage.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr bool cheaply_copyable = false;
 		template<class T>
 		requires
-			CopyConstructible<T> &&
+			copy_constructible<T> &&
 			std::is_trivially_copyable<T>::value &&
 			((std::is_empty_v<T> && !std::is_final_v<T>) ||
 				sizeof(T) <= cheap_copy_size)
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 			raw_ptr<T> ptr_;
 		};
 
-		// Note: promotes to CopyConstructible
+		// Note: promotes to copy_constructible
 		template<ext::Object T, class Tag = void>
 		using cheap_reference_box_t = meta::if_c<
 			cheaply_copyable<remove_cv_t<T>>,

--- a/include/stl2/detail/compressed_pair.hpp
+++ b/include/stl2/detail/compressed_pair.hpp
@@ -19,7 +19,7 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<Destructible T, Destructible U>
+		template<destructible T, destructible U>
 		class STL2_EMPTY_BASES compressed_pair :
 			detail::ebo_box<T, meta::size_t<0>>,
 			detail::ebo_box<U, meta::size_t<1>> {
@@ -27,12 +27,12 @@ STL2_OPEN_NAMESPACE {
 			using second_t = detail::ebo_box<U, meta::size_t<1>>;
 		public:
 			compressed_pair()
-			requires DefaultConstructible<T> &&
-				DefaultConstructible<U> = default;
+			requires default_initializable<T> &&
+				default_initializable<U> = default;
 
 			template<typename TT = T, typename UU = U>
 			requires
-				Constructible<T, TT> && Constructible<U, UU>
+				constructible_from<T, TT> && constructible_from<U, UU>
 			constexpr compressed_pair(TT&& t, UU&& u)
 			noexcept(is_nothrow_constructible<first_t, TT&&>::value &&
 				is_nothrow_constructible<second_t, UU&&>::value)

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 	: meta::bool_<sizeof...(T) == 1> {};
 
 	template<class T, class U, class... Rest>
-	requires CommonReference<T, U>
+	requires common_reference_with<T, U>
 	struct __common_reference<T, U, Rest...>
 	: __common_reference<common_reference_t<T, U>, Rest...> {};
 
@@ -49,19 +49,19 @@ STL2_OPEN_NAMESPACE {
 			meta::quote<__iter_args_lists>>;
 
 	template<class F, class... Args>
-	requires Invocable<F, Args...>
+	requires invocable<F, Args...>
 	using __callable_result_t = invoke_result_t<F, Args...>;
 
 	namespace ext {
 		template<class F, class... Is>
 		META_CONCEPT IndirectInvocable =
 			(Readable<Is> && ... && true) &&
-			CopyConstructible<F> &&
+			copy_constructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
-			Invocable<F&, iter_value_t<Is>&...> &&
-			Invocable<F&, iter_reference_t<Is>...> &&
-			Invocable<F&, iter_common_reference_t<Is>...> &&
+			invocable<F&, iter_value_t<Is>&...> &&
+			invocable<F&, iter_reference_t<Is>...> &&
+			invocable<F&, iter_common_reference_t<Is>...> &&
 			// redundantly checks the above 3 requirements
 			meta::_v<meta::invoke<
 				__iter_map_reduce_fn<
@@ -78,7 +78,7 @@ STL2_OPEN_NAMESPACE {
 	// indirect_result_t
 	//
 	template<class F, class... Is>
-	requires (Readable<Is> && ...) && Invocable<F, iter_reference_t<Is>...>
+	requires (Readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
 	using indirect_result_t = invoke_result_t<F, iter_reference_t<Is>&&...>;
 
 	namespace ext {
@@ -93,19 +93,19 @@ STL2_OPEN_NAMESPACE {
 
 	template<class, class...> struct __predicate : std::false_type {};
 	template<class F, class... Args>
-	requires Predicate<F, Args...>
+	requires predicate<F, Args...>
 	struct __predicate<F, Args...> : std::true_type {};
 
 	namespace ext {
 		template<class F, class... Is>
 		META_CONCEPT IndirectPredicate =
 			(Readable<Is> && ... && true) &&
-			CopyConstructible<F> &&
+			copy_constructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
-			Predicate<F&, iter_value_t<Is>&...> &&
-			Predicate<F&, iter_reference_t<Is>...> &&
-			Predicate<F&, iter_common_reference_t<Is>...> &&
+			predicate<F&, iter_value_t<Is>&...> &&
+			predicate<F&, iter_reference_t<Is>...> &&
+			predicate<F&, iter_common_reference_t<Is>...> &&
 			// redundantly checks the above 3 requirements
 			meta::_v<meta::invoke<
 				__iter_map_reduce_fn<
@@ -122,23 +122,23 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT IndirectRelation =
 		Readable<I1> &&
 		Readable<I2> &&
-		CopyConstructible<F> &&
-		Relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-		Relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-		Relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-		Relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-		Relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+		copy_constructible<F> &&
+		relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+		relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template<class F, class I1, class I2 = I1>
 	META_CONCEPT IndirectStrictWeakOrder =
 		Readable<I1> &&
 		Readable<I2> &&
-		CopyConstructible<F> &&
-		StrictWeakOrder<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-		StrictWeakOrder<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-		StrictWeakOrder<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-		StrictWeakOrder<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-		StrictWeakOrder<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+		copy_constructible<F> &&
+		strict_weak_order<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+		strict_weak_order<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+		strict_weak_order<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+		strict_weak_order<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+		strict_weak_order<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	////////////////////////////////////////////////////////////////////////////
 	// projected [projected.indirectcallables]

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -24,85 +24,85 @@
 //
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Boolean [concepts.lib.compare.boolean]
+	// boolean [concepts.lib.compare.boolean]
 	//
 	template<class B>
-	META_CONCEPT Boolean =
-		Movable<std::decay_t<B>> &&
+	META_CONCEPT boolean =
+		movable<std::decay_t<B>> &&
 		requires(const std::remove_reference_t<B>& b1,
 			     const std::remove_reference_t<B>& b2, const bool a) {
-			// Requirements common to both Boolean and BooleanTestable.
-			{  b1      } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{ !b1      } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{  b1 && a } -> STL2_RVALUE_REQ(Same<bool>);
-			{  b1 || a } -> STL2_RVALUE_REQ(Same<bool>);
+			// Requirements common to both boolean and BooleanTestable.
+			{  b1      } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{ !b1      } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{  b1 && a } -> STL2_RVALUE_REQ(same_as<bool>);
+			{  b1 || a } -> STL2_RVALUE_REQ(same_as<bool>);
 
-			// Requirements of Boolean that are also be valid for
+			// Requirements of boolean that are also be valid for
 			// BooleanTestable, but for which BooleanTestable does not
 			// require validation.
-			{ b1 && b2 } -> STL2_RVALUE_REQ(Same<bool>);
-			{  a && b2 } -> STL2_RVALUE_REQ(Same<bool>);
-			{ b1 || b2 } -> STL2_RVALUE_REQ(Same<bool>);
-			{  a || b2 } -> STL2_RVALUE_REQ(Same<bool>);
+			{ b1 && b2 } -> STL2_RVALUE_REQ(same_as<bool>);
+			{  a && b2 } -> STL2_RVALUE_REQ(same_as<bool>);
+			{ b1 || b2 } -> STL2_RVALUE_REQ(same_as<bool>);
+			{  a || b2 } -> STL2_RVALUE_REQ(same_as<bool>);
 
-			// Requirements of Boolean that are not required by
+			// Requirements of boolean that are not required by
 			// BooleanTestable.
-			{ b1 == b2 } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{ b1 == a  } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{  a == b2 } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{ b1 != b2 } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{ b1 != a  } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
-			{  a != b2 } -> STL2_RVALUE_REQ(ConvertibleTo<bool>);
+			{ b1 == b2 } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{ b1 == a  } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{  a == b2 } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{ b1 != b2 } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{ b1 != a  } -> STL2_RVALUE_REQ(convertible_to<bool>);
+			{  a != b2 } -> STL2_RVALUE_REQ(convertible_to<bool>);
 		};
 
 	///////////////////////////////////////////////////////////////////////////
 	// WeaklyEqualityComparable [concepts.lib.compare.equalitycomparable]
-	// Relaxation of EqualityComparable<T, U> that doesn't require
-	// EqualityComparable<T>, EqualityComparable<U>, Common<T, U>, or
-	// EqualityComparable<common_type_t<T, U>>. I.e., provides exactly the
+	// Relaxation of equality_comparable<T, U> that doesn't require
+	// equality_comparable<T>, equality_comparable<U>, common_with<T, U>, or
+	// equality_comparable<common_type_t<T, U>>. I.e., provides exactly the
 	// requirements for Sentinel's operator ==.
 	//
 	template<class T, class U>
 	META_CONCEPT WeaklyEqualityComparable =
 		requires(const std::remove_reference_t<T>& t,
 				 const std::remove_reference_t<U>& u) {
-			{ t == u } -> STL2_RVALUE_REQ(Boolean);
-			{ t != u } -> STL2_RVALUE_REQ(Boolean);
-			{ u == t } -> STL2_RVALUE_REQ(Boolean);
-			{ u != t } -> STL2_RVALUE_REQ(Boolean);
+			{ t == u } -> STL2_RVALUE_REQ(boolean);
+			{ t != u } -> STL2_RVALUE_REQ(boolean);
+			{ u == t } -> STL2_RVALUE_REQ(boolean);
+			{ u != t } -> STL2_RVALUE_REQ(boolean);
 		};
 
 	///////////////////////////////////////////////////////////////////////////
-	// EqualityComparable [concepts.lib.compare.equalitycomparable]
+	// equality_comparable [concepts.lib.compare.equalitycomparable]
 	//
 	template<class T>
-	META_CONCEPT EqualityComparable =
+	META_CONCEPT equality_comparable =
 		WeaklyEqualityComparable<T, T>;
 
 	template<class T, class U>
-	META_CONCEPT EqualityComparableWith =
-		EqualityComparable<T> &&
-		EqualityComparable<U> &&
+	META_CONCEPT equality_comparable_with =
+		equality_comparable<T> &&
+		equality_comparable<U> &&
 		WeaklyEqualityComparable<T, U> &&
-		CommonReference<
+		common_reference_with<
 			const std::remove_reference_t<T>&,
 			const std::remove_reference_t<U>&> &&
-		EqualityComparable<
+		equality_comparable<
 			common_reference_t<
 				const std::remove_reference_t<T>&,
 				const std::remove_reference_t<U>&>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// StrictTotallyOrdered [concepts.lib.compare.stricttotallyordered]
+	// totally_ordered [concepts.lib.compare.stricttotallyordered]
 	//
 	template<class T, class U>
 	META_CONCEPT __totally_ordered =
 		requires(const std::remove_reference_t<T>& t,
 		         const std::remove_reference_t<U>& u) {
-			{ t <  u } -> STL2_RVALUE_REQ(Boolean);
-			{ t >  u } -> STL2_RVALUE_REQ(Boolean);
-			{ t <= u } -> STL2_RVALUE_REQ(Boolean);
-			{ t >= u } -> STL2_RVALUE_REQ(Boolean);
+			{ t <  u } -> STL2_RVALUE_REQ(boolean);
+			{ t >  u } -> STL2_RVALUE_REQ(boolean);
+			{ t <= u } -> STL2_RVALUE_REQ(boolean);
+			{ t >= u } -> STL2_RVALUE_REQ(boolean);
 			// Axiom: t < u, t > u, t <= u, t >= u have the same definition space.
 			// Axiom: If bool(t < u) then bool(t <= u)
 			// Axiom: If bool(t > u) then bool(t >= u)
@@ -111,22 +111,22 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	template<class T>
-	META_CONCEPT StrictTotallyOrdered =
-		EqualityComparable<T> && __totally_ordered<T, T>;
+	META_CONCEPT totally_ordered =
+		equality_comparable<T> && __totally_ordered<T, T>;
 		// Axiom: t1 == t2 and t1 < t2 have the same definition space.
 		// Axiom: bool(t <= t)
 
 	template<class T, class U>
-	META_CONCEPT StrictTotallyOrderedWith =
-		StrictTotallyOrdered<T> &&
-		StrictTotallyOrdered<U> &&
-		EqualityComparableWith<T, U> &&
+	META_CONCEPT totally_ordered_with =
+		totally_ordered<T> &&
+		totally_ordered<U> &&
+		equality_comparable_with<T, U> &&
 		__totally_ordered<T, U> &&
 		__totally_ordered<U, T> &&
-		CommonReference<
+		common_reference_with<
 			const std::remove_reference_t<T>&,
 			const std::remove_reference_t<U>&> &&
-		StrictTotallyOrdered<
+		totally_ordered<
 			common_reference_t<
 				const std::remove_reference_t<T>&,
 				const std::remove_reference_t<U>&>>;

--- a/include/stl2/detail/concepts/core.hpp
+++ b/include/stl2/detail/concepts/core.hpp
@@ -31,10 +31,10 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT __can_reference = requires { typename __with_reference<T>; };
 
 	///////////////////////////////////////////////////////////////////////////
-	// Same
+	// same_as
 	//
 	template<class T, class U>
-	META_CONCEPT Same = meta::Same<T, U> && meta::Same<U, T>;
+	META_CONCEPT same_as = meta::Same<T, U> && meta::Same<U, T>;
 
 	template<class T>
 	META_CONCEPT _Decayed = meta::Same<T, std::decay_t<T>>;
@@ -46,10 +46,10 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT _NotSameAs = !meta::Same<__uncvref<T>, __uncvref<U>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// DerivedFrom
+	// derived_from
 	//
 	template<class Derived, class Base>
-	META_CONCEPT DerivedFrom =
+	META_CONCEPT derived_from =
 #if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
 		META_CONCEPT_BARRIER(__is_base_of(Base, Derived)) &&
 #else
@@ -58,10 +58,10 @@ STL2_OPEN_NAMESPACE {
 		_IsConvertibleImpl<const volatile Derived*, const volatile Base*>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// ConvertibleTo
+	// convertible_to
 	//
 	template<class From, class To>
-	META_CONCEPT ConvertibleTo =
+	META_CONCEPT convertible_to =
 		_IsConvertibleImpl<From, To> &&
 #if 1 // This is the PR for https://wg21.link/lwg3151
 		requires {

--- a/include/stl2/detail/concepts/function.hpp
+++ b/include/stl2/detail/concepts/function.hpp
@@ -20,44 +20,44 @@
 #include <stl2/detail/functional/invoke.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
-// Invocable Concepts [concepts.lib.callables]
+// invocable Concepts [concepts.lib.callables]
 //
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Invocable [concepts.lib.callables.callable]
+	// invocable [concepts.lib.callables.callable]
 	//
 	template<class F, class... Args>
-	META_CONCEPT Invocable =
+	META_CONCEPT invocable =
 		requires(F&& f, Args&&... args) {
 			__stl2::invoke((F&&)f, (Args&&)args...);
 		};
 
 	///////////////////////////////////////////////////////////////////////////
-	// RegularInvocable [concepts.lib.callables.regularcallable]
+	// regular_invocable [concepts.lib.callables.regularcallable]
 	//
 	template<class F, class... Args>
-	META_CONCEPT RegularInvocable = Invocable<F, Args...>;
+	META_CONCEPT regular_invocable = invocable<F, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Predicate [concepts.lib.callables.predicate]
+	// predicate [concepts.lib.callables.predicate]
 	//
 	template<class F, class... Args>
-	META_CONCEPT Predicate =
-		RegularInvocable<F, Args...> && Boolean<invoke_result_t<F, Args...>>;
+	META_CONCEPT predicate =
+		regular_invocable<F, Args...> && boolean<invoke_result_t<F, Args...>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Relation [concepts.lib.callables.relation]
+	// relation [concepts.lib.callables.relation]
 	//
 	template<class R, class T, class U>
-	META_CONCEPT Relation =
-		Predicate<R, T, T> &&
-		Predicate<R, U, U> &&
-		Predicate<R, T, U> &&
-		Predicate<R, U, T> &&
-		CommonReference<
+	META_CONCEPT relation =
+		predicate<R, T, T> &&
+		predicate<R, U, U> &&
+		predicate<R, T, U> &&
+		predicate<R, U, T> &&
+		common_reference_with<
 			const std::remove_reference_t<T>&,
 			const std::remove_reference_t<U>&> &&
-		Predicate<
+		predicate<
 			R,
 			common_reference_t<
 				const std::remove_reference_t<T>&,
@@ -67,10 +67,10 @@ STL2_OPEN_NAMESPACE {
 				const std::remove_reference_t<U>&>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// StrictWeakOrder [concepts.lib.callables.strictweakorder]
+	// strict_weak_order [concepts.lib.callables.strictweakorder]
 	//
 	template<class R, class T, class U>
-	META_CONCEPT StrictWeakOrder = Relation<R, T, U>;
+	META_CONCEPT strict_weak_order = relation<R, T, U>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/fundamental.hpp
+++ b/include/stl2/detail/concepts/fundamental.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		META_CONCEPT Scalar =
-			std::is_scalar_v<T> && Regular<T>;
+			std::is_scalar_v<T> && regular<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
@@ -35,38 +35,36 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class T>
 		META_CONCEPT Arithmetic =
-			std::is_arithmetic_v<T> && Scalar<T> && StrictTotallyOrdered<T>;
+			std::is_arithmetic_v<T> && Scalar<T> && totally_ordered<T>;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
-	// FloatingPoint [Extension]
-	//
-	namespace ext {
-		template<class T>
-		META_CONCEPT FloatingPoint =
-			std::is_floating_point_v<T> && Arithmetic<T>;
-	}
-
-	///////////////////////////////////////////////////////////////////////////
-	// Integral [concepts.lib.corelang.integral]
+	// floating_point
 	//
 	template<class T>
-	META_CONCEPT Integral =
+	META_CONCEPT floating_point =
+		std::is_floating_point_v<T> && ext::Arithmetic<T>;
+
+	///////////////////////////////////////////////////////////////////////////
+	// integral [concepts.lib.corelang.integral]
+	//
+	template<class T>
+	META_CONCEPT integral =
 		std::is_integral_v<T> && ext::Arithmetic<T>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// SignedIntegral [concepts.lib.corelang.signedintegral]
+	// signed_integral [concepts.lib.corelang.signedintegral]
 	//
 	template<class T>
-	META_CONCEPT SignedIntegral =
-		Integral<T> && (T(-1) < T(0));
+	META_CONCEPT signed_integral =
+		integral<T> && (T(-1) < T(0));
 
 	///////////////////////////////////////////////////////////////////////////
-	// UnsignedIntegral [concepts.lib.corelang.unsignedintegral]
+	// unsigned_integral [concepts.lib.corelang.unsignedintegral]
 	//
 	template<class T>
-	META_CONCEPT UnsignedIntegral =
-		Integral<T> && !SignedIntegral<T>;
+	META_CONCEPT unsigned_integral =
+		integral<T> && !signed_integral<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	// the decayed type can in fact be constructed from the actual type.
 	//
 	template<class T>
-		requires Constructible<std::decay_t<T>, T>
+		requires constructible_from<std::decay_t<T>, T>
 	using __f = std::decay_t<T>;
 
 	namespace ext {
@@ -57,56 +57,56 @@ STL2_OPEN_NAMESPACE {
 		// 'structible object concepts
 		//
 		template<class T>
-		META_CONCEPT DestructibleObject = Object<T> && Destructible<T>;
+		META_CONCEPT DestructibleObject = Object<T> && destructible<T>;
 
 		template<class T, class... Args>
-		META_CONCEPT ConstructibleObject = Object<T> && Constructible<T, Args...>;
+		META_CONCEPT ConstructibleObject = Object<T> && constructible_from<T, Args...>;
 
 		template<class T>
-		META_CONCEPT DefaultConstructibleObject = Object<T> && DefaultConstructible<T>;
+		META_CONCEPT DefaultConstructibleObject = Object<T> && default_initializable<T>;
 
 		template<class T>
-		META_CONCEPT MoveConstructibleObject = Object<T> && MoveConstructible<T>;
+		META_CONCEPT MoveConstructibleObject = Object<T> && move_constructible<T>;
 
 		template<class T>
-		META_CONCEPT CopyConstructibleObject = Object<T> && CopyConstructible<T>;
+		META_CONCEPT CopyConstructibleObject = Object<T> && copy_constructible<T>;
 
 		///////////////////////////////////////////////////////////////////////////
 		// TriviallyFoo concepts
 		//
 		template<class T>
 		META_CONCEPT TriviallyDestructible =
-			Destructible<T> && std::is_trivially_destructible_v<T>;
+			destructible<T> && std::is_trivially_destructible_v<T>;
 
 		template<class T, class... Args>
 		META_CONCEPT TriviallyConstructible =
-			Constructible<T, Args...> &&
+			constructible_from<T, Args...> &&
 			std::is_trivially_constructible_v<T, Args...>;
 
 		template<class T>
 		META_CONCEPT TriviallyDefaultConstructible =
-			DefaultConstructible<T> &&
+			default_initializable<T> &&
 			std::is_trivially_default_constructible_v<T>;
 
 		template<class T>
 		META_CONCEPT TriviallyMoveConstructible =
-			MoveConstructible<T> && std::is_trivially_move_constructible_v<T>;
+			move_constructible<T> && std::is_trivially_move_constructible_v<T>;
 
 		template<class T>
 		META_CONCEPT TriviallyCopyConstructible =
-			CopyConstructible<T> &&
+			copy_constructible<T> &&
 			TriviallyMoveConstructible<T> &&
 			std::is_trivially_copy_constructible_v<T>;
 
 		template<class T>
 		META_CONCEPT TriviallyMovable =
-			Movable<T> &&
+			movable<T> &&
 			TriviallyMoveConstructible<T> &&
 			std::is_trivially_move_assignable_v<T>;
 
 		template<class T>
 		META_CONCEPT TriviallyCopyable =
-			Copyable<T> &&
+			copyable<T> &&
 			TriviallyMovable<T> &&
 			TriviallyCopyConstructible<T> &&
 			std::is_trivially_copy_assignable_v<T>;

--- a/include/stl2/detail/concepts/object/assignable.hpp
+++ b/include/stl2/detail/concepts/object/assignable.hpp
@@ -20,20 +20,20 @@
 
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Assignable [concepts.lib.corelang.assignable]
+	// assignable_from [concepts.lib.corelang.assignable]
 	//
 	template<class LHS, class RHS>
-	META_CONCEPT Assignable =
+	META_CONCEPT assignable_from =
 		std::is_lvalue_reference_v<LHS> &&
 #if 0 // TODO: investigate making this change
-		CommonReference<LHS, RHS> &&
+		common_reference_with<LHS, RHS> &&
 #else
-		CommonReference<
+		common_reference_with<
 			const std::remove_reference_t<LHS>&,
 			const std::remove_reference_t<RHS>&> &&
 #endif
 		requires(LHS lhs, RHS&& rhs) {
-			{ lhs = static_cast<RHS&&>(rhs) } -> STL2_RVALUE_REQ(Same<LHS>);
+			{ lhs = static_cast<RHS&&>(rhs) } -> STL2_RVALUE_REQ(same_as<LHS>);
 		};
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/concepts/object/movable.hpp
+++ b/include/stl2/detail/concepts/object/movable.hpp
@@ -20,12 +20,12 @@
 
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Movable [concepts.lib.object.movable]
+	// movable [concepts.lib.object.movable]
 	//
 	template<class T>
-	META_CONCEPT Movable =
-		std::is_object_v<T> && MoveConstructible<T> &&
-		Assignable<T&, T> && Swappable<T>;
+	META_CONCEPT movable =
+		std::is_object_v<T> && move_constructible<T> &&
+		assignable_from<T&, T> && swappable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 	template<class T>
 	META_CONCEPT default_initializable = constructible_from<T>
 #if !STL2_WORKAROUND_GCC_UNKNOWN0 // Implement P/R for LWG 3149
-		&& requires { T{}; } // && is_default_constructible<T>
+		&& requires { T{}; } // && is-default-initializable<T>
 #endif // LWG 3149
 		;
 

--- a/include/stl2/detail/concepts/object/move_constructible.hpp
+++ b/include/stl2/detail/concepts/object/move_constructible.hpp
@@ -28,33 +28,33 @@ STL2_OPEN_NAMESPACE {
 	} // namespace ext
 
 	///////////////////////////////////////////////////////////////////////////
-	// Destructible [concept.destructible]
+	// destructible [concept.destructible]
 	//
 	template<class T>
-	META_CONCEPT Destructible = std::is_nothrow_destructible_v<T>;
+	META_CONCEPT destructible = std::is_nothrow_destructible_v<T>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Constructible [concept.constructible]
+	// constructible_from [concept.constructible]
 	//
 	template<class T, class... Args>
-	META_CONCEPT Constructible =
-		Destructible<T> && std::is_constructible_v<T, Args...>;
+	META_CONCEPT constructible_from =
+		destructible<T> && std::is_constructible_v<T, Args...>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// DefaultConstructible [concept.defaultconstructible]
+	// default_initializable [concept.defaultconstructible]
 	//
 	template<class T>
-	META_CONCEPT DefaultConstructible = Constructible<T>
+	META_CONCEPT default_initializable = constructible_from<T>
 #if !STL2_WORKAROUND_GCC_UNKNOWN0 // Implement P/R for LWG 3149
-		&& requires { T{}; } // && is_default_initializable<T>
+		&& requires { T{}; } // && is_default_constructible<T>
 #endif // LWG 3149
 		;
 
 	///////////////////////////////////////////////////////////////////////////
-	// MoveConstructible [concept.moveconstructible]
+	// move_constructible [concept.moveconstructible]
 	//
 	template<class T>
-	META_CONCEPT MoveConstructible = Constructible<T, T> && ConvertibleTo<T, T>;
+	META_CONCEPT move_constructible = constructible_from<T, T> && convertible_to<T, T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/regular.hpp
+++ b/include/stl2/detail/concepts/object/regular.hpp
@@ -19,10 +19,10 @@
 
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Regular [concepts.lib.object.regular]
+	// regular [concepts.lib.object.regular]
 	//
 	template<class T>
-	META_CONCEPT Regular = Semiregular<T> && EqualityComparable<T>;
+	META_CONCEPT regular = semiregular<T> && equality_comparable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/object/semiregular.hpp
+++ b/include/stl2/detail/concepts/object/semiregular.hpp
@@ -22,27 +22,27 @@
 
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// CopyConstructible [concepts.lib.object.copyconstructible]
+	// copy_constructible [concepts.lib.object.copyconstructible]
 	//
 	template<class T>
-	META_CONCEPT CopyConstructible =
-		MoveConstructible<T> &&
-		Constructible<T, T&> && ConvertibleTo<T&, T> &&
-		Constructible<T, const T&> && ConvertibleTo<const T&, T> &&
-		Constructible<T, const T> && ConvertibleTo<const T, T>;
+	META_CONCEPT copy_constructible =
+		move_constructible<T> &&
+		constructible_from<T, T&> && convertible_to<T&, T> &&
+		constructible_from<T, const T&> && convertible_to<const T&, T> &&
+		constructible_from<T, const T> && convertible_to<const T, T>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Copyable [concepts.lib.object.copyable]
+	// copyable [concepts.lib.object.copyable]
 	//
 	template<class T>
-	META_CONCEPT Copyable =
-		CopyConstructible<T> && Movable<T> && Assignable<T&, const T&>;
+	META_CONCEPT copyable =
+		copy_constructible<T> && movable<T> && assignable_from<T&, const T&>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Semiregular [concepts.lib.object.semiregular]
+	// semiregular [concepts.lib.object.semiregular]
 	//
 	template<class T>
-	META_CONCEPT Semiregular = Copyable<T> && DefaultConstructible<T>;
+	META_CONCEPT semiregular = copyable<T> && default_initializable<T>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -20,14 +20,14 @@ STL2_OPEN_NAMESPACE {
 
 	template<class G>
 	META_CONCEPT UniformRandomBitGenerator =
-		Invocable<G&> && UnsignedIntegral<invoke_result_t<G&>> &&
+		invocable<G&> && unsigned_integral<invoke_result_t<G&>> &&
 		requires {
 #ifdef META_HAS_P1084
-			{ G::min() } -> Same<invoke_result_t<G&>>;
-			{ G::max() } -> Same<invoke_result_t<G&>>;
+			{ G::min() } -> same_as<invoke_result_t<G&>>;
+			{ G::max() } -> same_as<invoke_result_t<G&>>;
 #else
-			G::min(); requires Same<decltype(G::min()), invoke_result_t<G&>>;
-			G::max(); requires Same<decltype(G::max()), invoke_result_t<G&>>;
+			G::min(); requires same_as<decltype(G::min()), invoke_result_t<G&>>;
+			G::max(); requires same_as<decltype(G::max()), invoke_result_t<G&>>;
 #endif
 #if 1 // This is the PR for https://wg21.link/lwg3150
 			typename __require_constant<G::min()>;

--- a/include/stl2/detail/construct_destruct.hpp
+++ b/include/stl2/detail/construct_destruct.hpp
@@ -20,12 +20,12 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct destruct_fn {
-			template<Destructible T>
+			template<destructible T>
 			void operator()(T& t) const noexcept {
 				t.~T();
 			}
 
-			template<Destructible T, std::size_t N>
+			template<destructible T, std::size_t N>
 			void operator()(T (&a)[N]) const noexcept {
 				std::size_t i = N;
 				while (i > 0) {
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 
 		struct construct_fn {
 			template<class T, class... Args>
-			requires Constructible<T, Args...>
+			requires constructible_from<T, Args...>
 			void operator()(T& t, Args&&... args) const
 			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			{

--- a/include/stl2/detail/ebo_box.hpp
+++ b/include/stl2/detail/ebo_box.hpp
@@ -24,25 +24,25 @@ STL2_OPEN_NAMESPACE {
 			ebo_box() = default;
 			constexpr ebo_box(const T& t)
 			noexcept(std::is_nothrow_copy_constructible<T>::value)
-			requires CopyConstructible<T>
+			requires copy_constructible<T>
 			: item_(t)
 			{}
 			constexpr ebo_box(T&& t)
 			noexcept(std::is_nothrow_move_constructible<T>::value)
-			requires MoveConstructible<T>
+			requires move_constructible<T>
 			: item_(std::move(t))
 			{}
 
 			template<class First>
 			requires (!_OneOf<std::decay_t<First>, ebo_box, T> &&
-				Constructible<T, First> && ConvertibleTo<First, T>)
+				constructible_from<T, First> && convertible_to<First, T>)
 			constexpr ebo_box(First&& f)
 			noexcept(std::is_nothrow_constructible<T, First>::value)
 			: item_(std::forward<First>(f))
 			{}
 			template<class First, class... Rest>
 			requires (sizeof...(Rest) > 0 || !_OneOf<std::decay_t<First>, ebo_box, T>) &&
-				Constructible<T, First, Rest...>
+				constructible_from<T, First, Rest...>
 			constexpr explicit ebo_box(First&& f, Rest&&... r)
 			noexcept(std::is_nothrow_constructible<T, First, Rest...>::value)
 			: item_(std::forward<First>(f), std::forward<Rest>(r)...)
@@ -63,12 +63,12 @@ STL2_OPEN_NAMESPACE {
 			ebo_box() = default;
 			constexpr ebo_box(const T& t)
 			noexcept(std::is_nothrow_copy_constructible<T>::value)
-			requires CopyConstructible<T>
+			requires copy_constructible<T>
 			: T(t)
 			{}
 			constexpr ebo_box(T&& t)
 			noexcept(std::is_nothrow_move_constructible<T>::value)
-			requires MoveConstructible<T>
+			requires move_constructible<T>
 			: T(std::move(t))
 			{}
 			using T::T;

--- a/include/stl2/detail/functional/comparisons.hpp
+++ b/include/stl2/detail/functional/comparisons.hpp
@@ -24,7 +24,7 @@ STL2_OPEN_NAMESPACE {
 	// equal_to [comparisons]
 	//
 	struct equal_to {
-		template<class T, EqualityComparableWith<T> U>
+		template<class T, equality_comparable_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) == std::forward<U>(u);
 		}
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 	// not_equal_to
 	//
 	struct not_equal_to {
-		template<class T, EqualityComparableWith<T> U>
+		template<class T, equality_comparable_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) != std::forward<U>(u);
 		}
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 	// greater
 	//
 	struct greater {
-		template<class T, StrictTotallyOrderedWith<T> U>
+		template<class T, totally_ordered_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) > std::forward<U>(u);
 		}
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 	// less
 	//
 	struct less {
-		template<class T, StrictTotallyOrderedWith<T> U>
+		template<class T, totally_ordered_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) < std::forward<U>(u);
 		}
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 	// greater_equal
 	//
 	struct greater_equal {
-		template<class T, StrictTotallyOrderedWith<T> U>
+		template<class T, totally_ordered_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) >= std::forward<U>(u);
 		}
@@ -84,7 +84,7 @@ STL2_OPEN_NAMESPACE {
 	// less_equal
 	//
 	struct less_equal {
-		template<class T, StrictTotallyOrderedWith<T> U>
+		template<class T, totally_ordered_with<T> U>
 		constexpr decltype(auto) operator()(T&& t, U&& u) const {
 			return std::forward<T>(t) <= std::forward<U>(u);
 		}

--- a/include/stl2/detail/functional/invoke.hpp
+++ b/include/stl2/detail/functional/invoke.hpp
@@ -32,7 +32,7 @@ STL2_OPEN_NAMESPACE {
 		)
 
 		template<class T, class T1>
-		requires DerivedFrom<std::decay_t<T1>, T>
+		requires derived_from<std::decay_t<T1>, T>
 		constexpr decltype(auto) coerce(T1&& t1)
 		STL2_NOEXCEPT_RETURN(
 			static_cast<T1&&>(t1)

--- a/include/stl2/detail/functional/not_fn.hpp
+++ b/include/stl2/detail/functional/not_fn.hpp
@@ -25,14 +25,14 @@ STL2_OPEN_NAMESPACE {
 	// not_fn from C++17
 	//
 	template<class F, class... Args>
-	META_CONCEPT _NegateInvocable = Invocable<F, Args...> &&
+	META_CONCEPT _NegateInvocable = invocable<F, Args...> &&
 		requires(F&& f, Args&&... args) {
 #ifdef META_HAS_P1084
-			{ !__stl2::invoke(static_cast<F&&>(f), static_cast<Args&&>(args)...) } -> Boolean;
+			{ !__stl2::invoke(static_cast<F&&>(f), static_cast<Args&&>(args)...) } -> boolean;
 #else
 			!__stl2::invoke(static_cast<F&&>(f),
 				static_cast<Args&&>(args)...);
-			requires Boolean<decltype(!__stl2::invoke(static_cast<F&&>(f),
+			requires boolean<decltype(!__stl2::invoke(static_cast<F&&>(f),
 				static_cast<Args&&>(args)...))>;
 #endif
 		};
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 		using box_t = detail::ebo_box<F, __not_fn<F>>;
 	public:
 		template<class FF>
-		requires Constructible<F, FF>
+		requires constructible_from<F, FF>
 		explicit constexpr __not_fn(FF&& arg)
 		noexcept(std::is_nothrow_constructible_v<F, FF>)
 		: box_t(static_cast<FF&&>(arg))
@@ -79,7 +79,7 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template<class F>
-	requires MoveConstructible<__f<F>>
+	requires move_constructible<__f<F>>
 	constexpr __not_fn<__f<F>> not_fn(F&& f)
 	STL2_NOEXCEPT_RETURN(
 		__not_fn<__f<F>>{static_cast<F&&>(f)}

--- a/include/stl2/detail/iostream/concepts.hpp
+++ b/include/stl2/detail/iostream/concepts.hpp
@@ -23,9 +23,9 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT StreamExtractable =
 		requires(std::basic_istream<charT, traits>& is, T& t) {
 #ifdef META_HAS_P1084
-			{ is >> t } -> Same<std::basic_istream<charT, traits>&>;
+			{ is >> t } -> same_as<std::basic_istream<charT, traits>&>;
 #else
-			{ is >> t } -> Same<std::basic_istream<charT, traits>>&;
+			{ is >> t } -> same_as<std::basic_istream<charT, traits>>&;
 #endif
 			// Axiom: &is == &(is << t)
 		};
@@ -37,9 +37,9 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT StreamInsertable =
 		requires(std::basic_ostream<charT, traits>& os, const T& t) {
 #ifdef META_HAS_P1084
-			{ os << t } -> Same<std::basic_ostream<charT, traits>&>;
+			{ os << t } -> same_as<std::basic_ostream<charT, traits>&>;
 #else
-			{ os << t } -> Same<std::basic_ostream<charT, traits>>&;
+			{ os << t } -> same_as<std::basic_ostream<charT, traits>>&;
 #endif
 			// Axiom: &os == &(os << t)
 		};

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -25,7 +25,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	template<Iterator I, Sentinel<I> S>
-	requires (!Same<I, S>)
+	requires (!same_as<I, S>)
 	class common_iterator;
 
 	namespace __common_iterator {
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 			template<class U>
 			constexpr explicit operator_arrow_proxy(U&& u)
 			noexcept(std::is_nothrow_constructible_v<T, U>)
-			requires Constructible<T, U>
+			requires constructible_from<T, U>
 			: value_(std::forward<U>(u)) {}
 
 			constexpr const T* operator->() const noexcept {
@@ -97,7 +97,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
-		requires ConvertibleTo<const I2&, I1> && ConvertibleTo<const S2&, S1>
+		requires convertible_to<const I2&, I1> && convertible_to<const S2&, S1>
 		struct convert_visitor {
 			constexpr auto operator()(const I2& i) const
 			STL2_NOEXCEPT_RETURN(
@@ -110,8 +110,8 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
-		requires ConvertibleTo<const I2&, I1> && ConvertibleTo<const S2&, S1> &&
-			Assignable<I1&, const I2&> && Assignable<S1&, const S2&>
+		requires convertible_to<const I2&, I1> && convertible_to<const S2&, S1> &&
+			assignable_from<I1&, const I2&> && assignable_from<S1&, const S2&>
 		struct assign_visitor {
 			std::variant<I1, S1>& v_;
 
@@ -141,7 +141,7 @@ STL2_OPEN_NAMESPACE {
 			}
 			constexpr bool operator()(const I1& i1, const I2& i2) const
 			noexcept(noexcept(bool(i1 == i2)))
-			requires EqualityComparableWith<I1, I2> {
+			requires equality_comparable_with<I1, I2> {
 				return i1 == i2;
 			}
 			constexpr bool operator()(const S1&, const S2&) const noexcept {
@@ -160,7 +160,7 @@ STL2_OPEN_NAMESPACE {
 
 	// common_iterator [common.iterator]
 	template<Iterator I, Sentinel<I> S>
-	requires (!Same<I, S>)
+	requires (!same_as<I, S>)
 	class common_iterator
 	: __common_iterator::access
 	{
@@ -180,7 +180,7 @@ STL2_OPEN_NAMESPACE {
 		: v_{std::in_place_type<S>, std::move(s)} {}
 
 		template<class I2, class S2>
-		requires ConvertibleTo<const I2&, I> && ConvertibleTo<const S2&, S>
+		requires convertible_to<const I2&, I> && convertible_to<const S2&, S>
 		constexpr common_iterator(const common_iterator<I2, S2>& i)
 		noexcept(
 			std::is_nothrow_constructible_v<I, const I2&> &&
@@ -191,8 +191,8 @@ STL2_OPEN_NAMESPACE {
 		{}
 
 		template<class I2, class S2>
-		requires ConvertibleTo<const I2&, I> && ConvertibleTo<const S2&, S> &&
-			Assignable<I&, const I2&> && Assignable<S&, const S2&>
+		requires convertible_to<const I2&, I> && convertible_to<const S2&, S> &&
+			assignable_from<I&, const I2&> && assignable_from<S&, const S2&>
 		common_iterator& operator=(const common_iterator<I2, S2>& i)
 		noexcept(
 			std::is_nothrow_assignable_v<I&, const I2&> &&
@@ -217,7 +217,7 @@ STL2_OPEN_NAMESPACE {
 		requires Readable<const I> &&
 			(_HasArrow<const I> ||
 			 std::is_reference_v<iter_reference_t<I>> ||
-			 Constructible<iter_value_t<I>, iter_reference_t<I>>)
+			 constructible_from<iter_value_t<I>, iter_reference_t<I>>)
 		{
 			if constexpr (std::is_pointer_v<I> || _HasArrow<const I>)
 				return __stl2::__unchecked_get<I>(v_);

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -154,9 +154,9 @@ STL2_OPEN_NAMESPACE {
 			typename iter_rvalue_reference_t<I>;
 		} &&
 		// Relationships between associated types
-		CommonReference<iter_reference_t<I>&&, iter_value_t<I>&> &&
-		CommonReference<iter_reference_t<I>&&, iter_rvalue_reference_t<I>&&> &&
-		CommonReference<iter_rvalue_reference_t<I>&&, const iter_value_t<I>&>;
+		common_reference_with<iter_reference_t<I>&&, iter_value_t<I>&> &&
+		common_reference_with<iter_reference_t<I>&&, iter_rvalue_reference_t<I>&&> &&
+		common_reference_with<iter_rvalue_reference_t<I>&&, const iter_value_t<I>&>;
 
 	// A generally useful dependent type
 	template<Readable I>
@@ -198,9 +198,9 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT IndirectlyMovableStorable =
 		IndirectlyMovable<In, Out> &&
 		Writable<Out, iter_value_t<In>&&> &&
-		Movable<iter_value_t<In>> &&
-		Constructible<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
-		Assignable<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
+		movable<iter_value_t<In>> &&
+		constructible_from<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
+		assignable_from<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
 
 	template<class In, class Out>
 	constexpr bool is_nothrow_indirectly_movable_storable_v = false;
@@ -226,9 +226,9 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT IndirectlyCopyableStorable =
 		IndirectlyCopyable<In, Out> &&
 		Writable<Out, const iter_value_t<In>&> &&
-		Copyable<iter_value_t<In>> &&
-		Constructible<iter_value_t<In>, iter_reference_t<In>> &&
-		Assignable<iter_value_t<In>&, iter_reference_t<In>>;
+		copyable<iter_value_t<In>> &&
+		constructible_from<iter_value_t<In>, iter_reference_t<In>> &&
+		assignable_from<iter_value_t<In>&, iter_reference_t<In>>;
 
 	////////////////////////////////////////////////////////////////////////////
 	// iter_swap
@@ -245,14 +245,14 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class R1, class R2>
-		requires SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>>
+		requires swappable_with<iter_reference_t<R1>, iter_reference_t<R2>>
 		constexpr void impl(R1&& r1, R2&& r2)
 		STL2_NOEXCEPT_RETURN(
 			__stl2::swap(*r1, *r2)
 		)
 
 		template<class R1, class R2>
-		requires (!SwappableWith<iter_reference_t<R1>, iter_reference_t<R2>> &&
+		requires (!swappable_with<iter_reference_t<R1>, iter_reference_t<R2>> &&
 			IndirectlyMovableStorable<R1, R2> &&
 			IndirectlyMovableStorable<R2, R1>)
 		constexpr void impl(R1& r1, R2& r2)
@@ -352,15 +352,15 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template<detail::MemberIteratorCategory T>
-	requires DerivedFrom<typename T::iterator_category, std::input_iterator_tag>
+	requires derived_from<typename T::iterator_category, std::input_iterator_tag>
 	struct iterator_category<T> {
 		using type = detail::std_to_stl2_iterator_category<typename T::iterator_category>;
 	};
 
 	template<detail::MemberIteratorCategory T>
 	requires
-		DerivedFrom<typename T::iterator_category, std::output_iterator_tag> &&
-		(!DerivedFrom<typename T::iterator_category, std::input_iterator_tag>)
+		derived_from<typename T::iterator_category, std::output_iterator_tag> &&
+		(!derived_from<typename T::iterator_category, std::input_iterator_tag>)
 	struct iterator_category<T> {};
 
 	template<class T>
@@ -378,18 +378,18 @@ STL2_OPEN_NAMESPACE {
 		// Axiom?: if i equals j then i and j denote equal elements
 		// Axiom?: I{} is in the domain of copy/move construction/assignment
 		//        (This should probably be a requirement of the object concepts,
-		//         or at least Semiregular.)
+		//         or at least semiregular.)
 
 	////////////////////////////////////////////////////////////////////////////
 	// Sentinel [sentinel.iterators]
 	//
-	// A relationship between an Iterator and a Semiregular ("sentinel")
+	// A relationship between an Iterator and a semiregular ("sentinel")
 	// that denote a range.
 	//
 	template<class S, class I>
 	META_CONCEPT Sentinel =
 		Iterator<I> &&
-		Semiregular<S> &&
+		semiregular<S> &&
 		WeaklyEqualityComparable<S, I>;
 		// Axiom: if [i,s) denotes a range then:
 		//        * i == s is well-defined
@@ -414,8 +414,8 @@ STL2_OPEN_NAMESPACE {
 		Sentinel<S, I> &&
 		!disable_sized_sentinel<std::remove_cv_t<S>, std::remove_cv_t<I>> &&
 		requires(const I i, const S s) {
-			{ s - i } -> STL2_RVALUE_REQ(Same<iter_difference_t<I>>);
-			{ i - s } -> STL2_RVALUE_REQ(Same<iter_difference_t<I>>);
+			{ s - i } -> STL2_RVALUE_REQ(same_as<iter_difference_t<I>>);
+			{ i - s } -> STL2_RVALUE_REQ(same_as<iter_difference_t<I>>);
 			// Axiom: If [i,s) denotes a range and N is the smallest
 			//        non-negative integer such that N applications of
 			//        ++i make bool(i == s) == true
@@ -445,7 +445,7 @@ STL2_OPEN_NAMESPACE {
 		Readable<I> &&
 		requires(I& i, const I& ci) {
 			typename iterator_category_t<I>;
-			DerivedFrom<iterator_category_t<I>, input_iterator_tag>;
+			derived_from<iterator_category_t<I>, input_iterator_tag>;
 			i++;
 		};
 
@@ -461,7 +461,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	META_CONCEPT ForwardIterator =
 		InputIterator<I> &&
-		DerivedFrom<iterator_category_t<I>, forward_iterator_tag> &&
+		derived_from<iterator_category_t<I>, forward_iterator_tag> &&
 		Incrementable<I> &&
 		Sentinel<I, I>;
 		// Axiom: I{} is equality-preserving and non-singular
@@ -478,7 +478,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	META_CONCEPT BidirectionalIterator =
 		ForwardIterator<I> &&
-		DerivedFrom<iterator_category_t<I>, bidirectional_iterator_tag> &&
+		derived_from<iterator_category_t<I>, bidirectional_iterator_tag> &&
 		ext::Decrementable<I>;
 
 	////////////////////////////////////////////////////////////////////////////
@@ -487,17 +487,17 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	META_CONCEPT RandomAccessIterator =
 		BidirectionalIterator<I> &&
-		DerivedFrom<iterator_category_t<I>, random_access_iterator_tag> &&
+		derived_from<iterator_category_t<I>, random_access_iterator_tag> &&
 		SizedSentinel<I, I> &&
 		// Should ordering be in SizedSentinel and/or RandomAccessIncrementable?
-		StrictTotallyOrdered<I> &&
+		totally_ordered<I> &&
 		ext::RandomAccessIncrementable<I> &&
 		requires(const I& ci, const iter_difference_t<I> n) {
 #ifdef META_HAS_P1084
-			{ ci[n] } -> Same<iter_reference_t<I>>;
+			{ ci[n] } -> same_as<iter_reference_t<I>>;
 #else
 			ci[n];
-			requires Same<decltype(ci[n]), iter_reference_t<I>>;
+			requires same_as<decltype(ci[n]), iter_reference_t<I>>;
 #endif
 		};
 		// FIXME: Axioms for definition space of ordering operations. Don't
@@ -512,9 +512,9 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	META_CONCEPT ContiguousIterator =
 		RandomAccessIterator<I> &&
-		DerivedFrom<iterator_category_t<I>, contiguous_iterator_tag> &&
+		derived_from<iterator_category_t<I>, contiguous_iterator_tag> &&
 		std::is_lvalue_reference<iter_reference_t<I>>::value &&
-		Same<iter_value_t<I>, __uncvref<iter_reference_t<I>>>;
+		same_as<iter_value_t<I>, __uncvref<iter_reference_t<I>>>;
 
 	////////////////////////////////////////////////////////////////////////////
 	// iterator_traits [iterator.assoc]
@@ -601,8 +601,8 @@ STL2_OPEN_NAMESPACE {
 		META_CONCEPT LooksLikeSTL1Iterator =
 			requires {
 				typename I::iterator_category;
-				requires DerivedFrom<typename I::iterator_category, std::input_iterator_tag> ||
-						 DerivedFrom<typename I::iterator_category, std::output_iterator_tag>;
+				requires derived_from<typename I::iterator_category, std::input_iterator_tag> ||
+						 derived_from<typename I::iterator_category, std::output_iterator_tag>;
 			};
 		template<class I>
 		META_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -77,13 +77,13 @@ STL2_OPEN_NAMESPACE {
 			STL2_EXPECT(n >= 0);
 		}
 		template<class I2>
-		requires ConvertibleTo<const I2&, I>
+		requires convertible_to<const I2&, I>
 		constexpr counted_iterator(const counted_iterator<I2>& i)
 		noexcept(std::is_nothrow_copy_constructible_v<I>) // strengthened
 		: current_(__counted_iterator::access::current(i))
 		, length_{__counted_iterator::access::count(i)} {}
 		template<class I2>
-		requires Assignable<I&, const I2&>
+		requires assignable_from<I&, const I2&>
 		constexpr counted_iterator& operator=(const counted_iterator<I2>& i)
 		noexcept(std::is_nothrow_assignable_v<I&, const I2&>) { // strengthened
 			current_ = __counted_iterator::access::current(i);
@@ -161,7 +161,7 @@ STL2_OPEN_NAMESPACE {
 			STL2_EXPECT(-n <= length_);
 			return counted_iterator(current_ - n, length_ + n);
 		}
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr iter_difference_t<I2>
 		operator-(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened
@@ -191,7 +191,7 @@ STL2_OPEN_NAMESPACE {
 			return current_[n];
 		}
 
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator==(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened
@@ -207,7 +207,7 @@ STL2_OPEN_NAMESPACE {
 		noexcept { // strengthened
 			return y.length_ == 0;
 		}
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator!=(const counted_iterator& x, const counted_iterator<I2>& y)
 		 noexcept { // strengthened
@@ -224,25 +224,25 @@ STL2_OPEN_NAMESPACE {
 			return !(x == y);
 		}
 
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator<(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened
 			return y.count() < x.length_;
 		}
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator>(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened
 			return y < x;
 		}
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator<=(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened
 			return !(y < x);
 		}
-		template<Common<I> I2>
+		template<common_with<I> I2>
 		friend constexpr bool
 		operator>=(const counted_iterator& x, const counted_iterator<I2>& y)
 		noexcept { // strengthened

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -50,9 +50,9 @@ STL2_OPEN_NAMESPACE {
 		!std::is_pointer_v<T> && // Avoid GCC PR 78173 (See above)
 		requires(const T& a, const T& b) {
 #ifdef META_HAS_P1084
-			{ a - b } -> Integral;
+			{ a - b } -> integral;
 #else
-			a - b; requires Integral<decltype(a - b)>;
+			a - b; requires integral<decltype(a - b)>;
 #endif
 		})
 	struct incrementable_traits<T> {
@@ -68,14 +68,14 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I>
 	META_CONCEPT WeaklyIncrementable =
-		Semiregular<I> &&
+		semiregular<I> &&
 		requires(I i) {
 			typename iter_difference_t<I>;
-			requires SignedIntegral<iter_difference_t<I>>;
+			requires signed_integral<iter_difference_t<I>>;
 #ifdef META_HAS_P1084
-			{ ++i } -> Same<I&>; // not required to be equality-preserving
+			{ ++i } -> same_as<I&>; // not required to be equality-preserving
 #else
-			{ ++i } -> Same<I>&; // not required to be equality-preserving
+			{ ++i } -> same_as<I>&; // not required to be equality-preserving
 #endif
 			i++; // not required to be equality-preserving
 		};
@@ -85,13 +85,13 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I>
 	META_CONCEPT Incrementable =
-		Regular<I> &&
+		regular<I> &&
 		WeaklyIncrementable<I> &&
 		requires(I i) {
 #ifdef META_HAS_P1084
-			{ i++ } -> Same<I>;
+			{ i++ } -> same_as<I>;
 #else
-			i++; requires Same<decltype(i++), I>;
+			i++; requires same_as<decltype(i++), I>;
 #endif
 		};
 
@@ -104,11 +104,11 @@ STL2_OPEN_NAMESPACE {
 			Incrementable<I> &&
 			requires(I i) {
 #ifdef META_HAS_P1084
-				{ --i } -> Same<I&>;
-				{ i-- } -> Same<I>;
+				{ --i } -> same_as<I&>;
+				{ i-- } -> same_as<I>;
 #else
-				{ --i } -> Same<I>&;
-				i--; requires Same<I, decltype(i--)>;
+				{ --i } -> same_as<I>&;
+				i--; requires same_as<I, decltype(i--)>;
 #endif
 			};
 			// Let a and b be objects of type I.
@@ -127,11 +127,11 @@ STL2_OPEN_NAMESPACE {
 		META_CONCEPT RandomAccessIncrementable =
 			Decrementable<I> &&
 			requires(I& i, const I& ci, const iter_difference_t<I> n) {
-				{ i += n } -> STL2_RVALUE_REQ(Same<I&>);
-				{ i -= n } -> STL2_RVALUE_REQ(Same<I&>);
-				{ ci + n } -> STL2_RVALUE_REQ(Same<I>);
-				{ n + ci } -> STL2_RVALUE_REQ(Same<I>);
-				{ ci - n } -> STL2_RVALUE_REQ(Same<I>);
+				{ i += n } -> STL2_RVALUE_REQ(same_as<I&>);
+				{ i -= n } -> STL2_RVALUE_REQ(same_as<I&>);
+				{ ci + n } -> STL2_RVALUE_REQ(same_as<I>);
+				{ n + ci } -> STL2_RVALUE_REQ(same_as<I>);
+				{ ci - n } -> STL2_RVALUE_REQ(same_as<I>);
 				{ ci - ci } -> iter_difference_t<I>;
 			};
 			// FIXME: Axioms

--- a/include/stl2/detail/iterator/istream_iterator.hpp
+++ b/include/stl2/detail/iterator/istream_iterator.hpp
@@ -30,9 +30,9 @@ STL2_OPEN_NAMESPACE {
 		///////////////////////////////////////////////////////////////////////////
 		// istream_cursor [Implementation detail]
 		//
-		template<Semiregular T, class charT = char,
+		template<semiregular T, class charT = char,
 			class traits = std::char_traits<charT>,
-			SignedIntegral Distance = std::ptrdiff_t>
+			signed_integral Distance = std::ptrdiff_t>
 		requires
 			StreamExtractable<T, charT, traits>
 		class istream_cursor : semiregular_box<T> {
@@ -109,8 +109,8 @@ STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
 	// istream_iterator [iterator.istream]
 	//
-	template<Semiregular T, class charT = char, class traits = std::char_traits<charT>,
-		SignedIntegral Distance = std::ptrdiff_t>
+	template<semiregular T, class charT = char, class traits = std::char_traits<charT>,
+		signed_integral Distance = std::ptrdiff_t>
 	requires
 		StreamExtractable<T, charT, traits>
 	using istream_iterator =

--- a/include/stl2/detail/iterator/istreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/istreambuf_iterator.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	namespace __istreambuf_iterator {
 		template<class charT, class traits = std::char_traits<charT>>
 		requires
-			SignedIntegral<typename traits::off_type>
+			signed_integral<typename traits::off_type>
 		class cursor;
 	}
 
@@ -36,16 +36,16 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class charT, class traits = std::char_traits<charT>>
 	requires
-		MoveConstructible<charT> &&
-		DefaultConstructible<charT> &&
-		SignedIntegral<typename traits::off_type>
+		move_constructible<charT> &&
+		default_initializable<charT> &&
+		signed_integral<typename traits::off_type>
 	using istreambuf_iterator =
 		basic_iterator<__istreambuf_iterator::cursor<charT, traits>>;
 
 	namespace __istreambuf_iterator {
 		template<class charT, class traits>
 		requires
-			SignedIntegral<typename traits::off_type>
+			signed_integral<typename traits::off_type>
 		class cursor {
 		public:
 			using value_type = charT;
@@ -127,7 +127,7 @@ STL2_OPEN_NAMESPACE {
 				// Yuck. This can't be simply "basic_iterator<cursor>".
 				// Since basic_iterator<cursor> derives from mixin, mixin must be
 				// instantiable before basic_iterator<cursor> is complete.
-				template<Same<cursor> C>
+				template<same_as<cursor> C>
 				bool equal(const basic_iterator<C>& that) const noexcept {
 					return base_t::get().equal(get_cursor(that));
 				}

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -22,7 +22,7 @@
 #include <stl2/detail/iterator/concepts.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<Semiregular> class move_sentinel;
+	template<semiregular> class move_sentinel;
 
 	namespace __move_iterator {
 		template<InputIterator> class cursor;
@@ -83,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 			noexcept(std::is_nothrow_copy_constructible<I>::value)
 			: current_{i}
 			{}
-			template<ConvertibleTo<I> U>
+			template<convertible_to<I> U>
 			constexpr cursor(const cursor<U>& u)
 			noexcept(std::is_nothrow_constructible<I, const U&>::value)
 			: current_{access::current(u)}
@@ -141,7 +141,7 @@ STL2_OPEN_NAMESPACE {
 				current_ += n;
 			}
 
-			template<EqualityComparableWith<I> I2>
+			template<equality_comparable_with<I> I2>
 			constexpr bool equal(const cursor<I2>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::current(that)
@@ -188,7 +188,7 @@ STL2_OPEN_NAMESPACE {
 		using type = input_iterator_tag;
 	};
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool
 	operator<(const move_iterator<I1>& a, const move_iterator<I2>& b)
 	STL2_NOEXCEPT_RETURN(
@@ -196,21 +196,21 @@ STL2_OPEN_NAMESPACE {
 			__move_iterator::access::current(get_cursor(b))
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool
 	operator>(const move_iterator<I1>& a, const move_iterator<I2>& b)
 	STL2_NOEXCEPT_RETURN(
 		b < a
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool
 	operator<=(const move_iterator<I1>& a, const move_iterator<I2>& b)
 	STL2_NOEXCEPT_RETURN(
 		!(b < a)
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool
 	operator>=(const move_iterator<I1>& a, const move_iterator<I2>& b)
 	STL2_NOEXCEPT_RETURN(
@@ -225,7 +225,7 @@ STL2_OPEN_NAMESPACE {
 		move_iterator<__f<I>>{std::forward<I>(i)}
 	)
 
-	template<Semiregular S>
+	template<semiregular S>
 	class move_sentinel : detail::ebo_box<S, move_sentinel<S>> {
 		friend __move_iterator::access;
 		using box_t = detail::ebo_box<S, move_sentinel<S>>;
@@ -239,14 +239,14 @@ STL2_OPEN_NAMESPACE {
 		: box_t(std::move(s))
 		{}
 		template<class T>
-		requires ConvertibleTo<const T&, S>
+		requires convertible_to<const T&, S>
 		constexpr move_sentinel(const move_sentinel<T>& s)
 		noexcept(std::is_nothrow_constructible<S, const T&>::value)
 		: box_t{__move_iterator::access::sentinel(s)}
 		{}
 
 		template<class T>
-		requires Assignable<S&, const T&>
+		requires assignable_from<S&, const T&>
 		constexpr move_sentinel& operator=(const move_sentinel<T>& s) &
 		noexcept(std::is_nothrow_assignable<S&, const T&>::value)
 		{
@@ -260,7 +260,7 @@ STL2_OPEN_NAMESPACE {
 	};
 
 	template<class S>
-	requires Semiregular<__f<S>>
+	requires semiregular<__f<S>>
 	constexpr auto make_move_sentinel(S&& s)
 	STL2_NOEXCEPT_RETURN(
 		move_sentinel<__f<S>>(std::forward<S>(s))

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr void operator()(I& i, S bound) const
 		// [[expects axiom: reachable(i, bound)]]
 		{
-			if constexpr (Assignable<I&, S>) {
+			if constexpr (assignable_from<I&, S>) {
 				i = std::move(bound);
 			} else if constexpr (SizedSentinel<S, I>) {
 				iter_difference_t<I> d = bound - i;
@@ -60,11 +60,11 @@ STL2_OPEN_NAMESPACE {
 		operator()(I& i, iter_difference_t<I> n, S bound) const
 		// [[expects axiom: 0 == n ||
 		//     (n > 0 && reachable(i, bound)) ||
-		//     (n < 0 && Same<I, S> && BidirectionalIterator<I> && reachable(bound, i))]]
+		//     (n < 0 && same_as<I, S> && BidirectionalIterator<I> && reachable(bound, i))]]
 		{
 			if constexpr (SizedSentinel<S, I>) {
 				const auto d = bound - i;
-				if constexpr (BidirectionalIterator<I> && Same<I, S>) {
+				if constexpr (BidirectionalIterator<I> && same_as<I, S>) {
 					STL2_EXPECT(n >= 0 ? d >= 0 : d <= 0);
 					if (n >= 0 ? n >= d : n <= d) {
 						i = std::move(bound);
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 				(*this)(i, n);
 				return 0;
 			} else {
-				if constexpr (BidirectionalIterator<I> && Same<I, S>) {
+				if constexpr (BidirectionalIterator<I> && same_as<I, S>) {
 					if (n < 0) {
 						while (n != 0 && i != bound) {
 							--i;

--- a/include/stl2/detail/iterator/ostream_iterator.hpp
+++ b/include/stl2/detail/iterator/ostream_iterator.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T = void, class charT = char, class traits = std::char_traits<charT>>
 	requires
-		Same<T, void> ||
+		same_as<T, void> ||
 		StreamInsertable<T, charT, traits>
 	class ostream_iterator {
 	public:
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<class U, class V = meta::if_<std::is_void<T>, U, T>>
 		requires
-			ConvertibleTo<U, V const&> &&
+			convertible_to<U, V const&> &&
 			StreamInsertable<V, charT, traits>
 		ostream_iterator& operator=(U&& u) {
 			*out_stream_ << static_cast<V const &>(std::forward<U>(u));

--- a/include/stl2/detail/iterator/ostreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/ostreambuf_iterator.hpp
@@ -24,7 +24,7 @@
 
 STL2_OPEN_NAMESPACE {
 	// Not to spec:
-	// * Extension: satisfies EqualityComparable and Sentinel<default_sentinel>
+	// * Extension: satisfies equality_comparable and Sentinel<default_sentinel>
 	template<class charT, class traits = std::char_traits<charT>>
 	class ostreambuf_iterator {
 	public:

--- a/include/stl2/detail/iterator/reverse_iterator.hpp
+++ b/include/stl2/detail/iterator/reverse_iterator.hpp
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 			noexcept(std::is_nothrow_move_constructible<I>::value)
 			: current_{std::move(x)}
 			{}
-			template<ConvertibleTo<I> U>
+			template<convertible_to<I> U>
 			constexpr cursor(const cursor<U>& u)
 			noexcept(std::is_nothrow_constructible<I, const U&>::value)
 			: current_{access::current(u)}
@@ -103,7 +103,7 @@ STL2_OPEN_NAMESPACE {
 				current_ -= n;
 			}
 
-			template<EqualityComparableWith<I> J>
+			template<equality_comparable_with<I> J>
 			constexpr bool equal(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::current(that)
@@ -132,7 +132,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	using reverse_iterator = basic_iterator<__reverse_iterator::cursor<I>>;
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool operator<(
 		const reverse_iterator<I1>& x, const reverse_iterator<I2>& y)
 	STL2_NOEXCEPT_RETURN(
@@ -140,21 +140,21 @@ STL2_OPEN_NAMESPACE {
 			__reverse_iterator::access::current(get_cursor(y))
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool operator>(
 		const reverse_iterator<I1>& x, const reverse_iterator<I2>& y)
 	STL2_NOEXCEPT_RETURN(
 		y < x
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool operator<=(
 		const reverse_iterator<I1>& x, const reverse_iterator<I2>& y)
 	STL2_NOEXCEPT_RETURN(
 		!(y < x)
 	)
 
-	template<class I1, StrictTotallyOrderedWith<I1> I2>
+	template<class I1, totally_ordered_with<I1> I2>
 	constexpr bool operator>=(
 		const reverse_iterator<I1>& x, const reverse_iterator<I2>& y)
 	STL2_NOEXCEPT_RETURN(

--- a/include/stl2/detail/memory/concepts.hpp
+++ b/include/stl2/detail/memory/concepts.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT _NoThrowInputIterator =
 		InputIterator<I> &&
 		std::is_lvalue_reference_v<iter_reference_t<I>> &&
-		Same<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
+		same_as<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
 		// Axiom: no exceptions are thrown from increment, copy, move, assignment,
 		//        indirection through valid iterators.
 

--- a/include/stl2/detail/memory/construct_at.hpp
+++ b/include/stl2/detail/memory/construct_at.hpp
@@ -20,13 +20,13 @@
 
 STL2_OPEN_NAMESPACE {
 	template<class T, class... Args>
-	requires Constructible<T, Args...>
+	requires constructible_from<T, Args...>
 	void __construct_at(T& t, Args&&... args) {
 		::new(const_cast<void*>(static_cast<const volatile void*>(std::addressof(t))))
 			T(std::forward<Args>(args)...);
 	}
 
-	template<DefaultConstructible T>
+	template<default_initializable T>
 	void __default_construct_at(T& t)
 	{
 		::new(const_cast<void*>(static_cast<const volatile void*>(std::addressof(t))))

--- a/include/stl2/detail/memory/destroy.hpp
+++ b/include/stl2/detail/memory/destroy.hpp
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 	// destroy_at [specialized.destroy]
 	//
 	struct __destroy_at_fn : private __niebloid {
-		template<Destructible T>
+		template<destructible T>
 		void operator()(T* p) const noexcept;
 	};
 
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __destroy_fn : private __niebloid {
 		template<_NoThrowInputIterator I, _NoThrowSentinel<I> S>
-		requires Destructible<iter_value_t<I>>
+		requires destructible<iter_value_t<I>>
 		I operator()(I first, S last) const noexcept {
 			if constexpr (std::is_trivially_destructible_v<iter_value_t<I>>) {
 				advance(first, last);
@@ -52,10 +52,10 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<_NoThrowInputRange R>
-		requires Destructible<iter_value_t<iterator_t<R>>>
+		requires destructible<iter_value_t<iterator_t<R>>>
 		safe_iterator_t<R> operator()(R&& r) const noexcept {
 			if constexpr (std::is_trivially_destructible_v<iter_value_t<iterator_t<R>>> &&
-			              Same<dangling, safe_iterator_t<R>>) {
+			              same_as<dangling, safe_iterator_t<R>>) {
 				return {};
 			} else {
 				return (*this)(begin(r), end(r));
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 
 	inline constexpr __destroy_fn destroy {};
 
-	template<Destructible T>
+	template<destructible T>
 	inline void __destroy_at_fn::operator()(T* p) const noexcept {
 		if constexpr (!std::is_trivially_destructible_v<T>) {
 			if constexpr (std::is_array_v<T>) {
@@ -81,7 +81,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __destroy_n_fn : private __niebloid {
 		template<_NoThrowInputIterator I>
-		requires Destructible<iter_value_t<I>>
+		requires destructible<iter_value_t<I>>
 		I operator()(I first, iter_difference_t<I> n) const noexcept {
 			if constexpr (std::is_trivially_destructible_v<iter_value_t<I>>) {
 				return next(std::move(first), n);
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace detail {
 		template<_NoThrowForwardIterator I>
-		requires Destructible<iter_value_t<I>>
+		requires destructible<iter_value_t<I>>
 		struct destroy_guard {
 			~destroy_guard() {
 				if (last_) {
@@ -118,7 +118,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<_NoThrowForwardIterator I>
-		requires Destructible<iter_value_t<I>> &&
+		requires destructible<iter_value_t<I>> &&
 			std::is_trivially_destructible_v<iter_value_t<I>>
 		struct destroy_guard<I> {
 			constexpr explicit destroy_guard(I&) noexcept {}

--- a/include/stl2/detail/memory/uninitialized_copy.hpp
+++ b/include/stl2/detail/memory/uninitialized_copy.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 
 	struct __uninitialized_copy_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S1, _NoThrowForwardIterator O, _NoThrowSentinel<O> S2>
-		requires Constructible<iter_value_t<O>, iter_reference_t<I>>
+		requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
 		uninitialized_copy_result<I, O> operator()(I ifirst, S1 ilast, O ofirst, S2 olast) const {
 			auto guard = detail::destroy_guard{ofirst};
 			for (; ifirst != ilast && ofirst != olast; (void) ++ifirst, (void)++ofirst) {
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange IR, _NoThrowForwardRange OR>
-		requires Constructible<iter_value_t<iterator_t<OR>>, iter_reference_t<iterator_t<IR>>>
+		requires constructible_from<iter_value_t<iterator_t<OR>>, iter_reference_t<iterator_t<IR>>>
 		uninitialized_copy_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
 		operator()(IR&& in, OR&& out) const {
 			return (*this)(begin(in), end(in), begin(out), end(out));
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 
 	struct __uninitialized_copy_n_fn : private __niebloid {
 		template<InputIterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
-		requires Constructible<iter_value_t<O>, iter_reference_t<I>>
+		requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
 		uninitialized_copy_n_result<I, O>
 		operator()(I first, iter_difference_t<I> n, O ofirst, S olast) const {
 			auto [in, out] = uninitialized_copy(

--- a/include/stl2/detail/memory/uninitialized_default_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_default_construct.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_default_construct_fn : private __niebloid {
 		template<_NoThrowForwardIterator I, _NoThrowSentinel<I> S>
-		requires DefaultConstructible<iter_value_t<I>>
+		requires default_initializable<iter_value_t<I>>
 		I operator()(I first, S last) const {
 			auto guard = detail::destroy_guard{first};
 			for (; first != last; ++first) {
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<_NoThrowForwardRange Rng>
-		requires DefaultConstructible<iter_value_t<iterator_t<Rng>>>
+		requires default_initializable<iter_value_t<iterator_t<Rng>>>
 		safe_iterator_t<Rng> operator()(Rng&& rng) const {
 			return (*this)(begin(rng), end(rng));
 		}
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_default_construct_n_fn : private __niebloid {
 		template<_NoThrowForwardIterator I>
-		requires DefaultConstructible<iter_value_t<I>>
+		requires default_initializable<iter_value_t<I>>
 		I operator()(I first, iter_difference_t<I> n) const {
 			return uninitialized_default_construct(
 				counted_iterator{std::move(first), n},

--- a/include/stl2/detail/memory/uninitialized_fill.hpp
+++ b/include/stl2/detail/memory/uninitialized_fill.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_fill_fn : private __niebloid {
 		template<_NoThrowForwardIterator I, _NoThrowSentinel<I> S, class T>
-		requires Constructible<iter_value_t<I>, const T&>
+		requires constructible_from<iter_value_t<I>, const T&>
 		I operator()(I first, S last, const T& x) const {
 			auto guard = detail::destroy_guard{first};
 			for (; first != last; ++first) {
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<_NoThrowForwardRange R, class T>
-		requires Constructible<iter_value_t<iterator_t<R>>, const T&>
+		requires constructible_from<iter_value_t<iterator_t<R>>, const T&>
 		safe_iterator_t<R> operator()(R&& r, const T& x) const {
 			return (*this)(begin(r), end(r), x);
 		}
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_fill_n_fn : private __niebloid {
 		template<_NoThrowForwardIterator I, class T>
-		requires Constructible<iter_value_t<I>, const T&>
+		requires constructible_from<iter_value_t<I>, const T&>
 		I operator()(I first, const iter_difference_t<I> n, const T& x) const {
 			return uninitialized_fill(
 				counted_iterator{std::move(first), n},

--- a/include/stl2/detail/memory/uninitialized_move.hpp
+++ b/include/stl2/detail/memory/uninitialized_move.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 	struct __uninitialized_move_fn : private __niebloid {
 		template<InputIterator I, Sentinel<I> S1,
 			_NoThrowForwardIterator O, _NoThrowSentinel<O> S2>
-		requires Constructible<iter_value_t<O>, iter_rvalue_reference_t<I>>
+		requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
 		uninitialized_move_result<I, O>
 		operator()(I ifirst, S1 ilast, O ofirst, S2 olast) const {
 			auto guard = detail::destroy_guard{ofirst};
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<InputRange IR, _NoThrowForwardRange OR>
-		requires Constructible<iter_value_t<iterator_t<OR>>,
+		requires constructible_from<iter_value_t<iterator_t<OR>>,
 		                       iter_rvalue_reference_t<iterator_t<IR>>>
 		uninitialized_move_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
 		operator()(IR&& in, OR&& out) const {
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 
 	struct __uninitialized_move_n_fn : private __niebloid {
 		template<InputIterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
-		requires Constructible<iter_value_t<O>, iter_rvalue_reference_t<I>>
+		requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
 		uninitialized_move_n_result<I, O>
 		operator()(I ifirst, iter_difference_t<I> n, O ofirst, S olast) const {
 			auto [in, out] = uninitialized_move(counted_iterator{std::move(ifirst), n},

--- a/include/stl2/detail/memory/uninitialized_value_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_value_construct.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_value_construct_fn : private __niebloid {
 		template<_NoThrowForwardIterator I, _NoThrowSentinel<I> S>
-		requires DefaultConstructible<iter_value_t<I>>
+		requires default_initializable<iter_value_t<I>>
 		I operator()(I first, S last) const {
 			auto guard = detail::destroy_guard{first};
 			for (; first != last; ++first) {
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<_NoThrowForwardRange Rng>
-		requires DefaultConstructible<iter_value_t<iterator_t<Rng>>>
+		requires default_initializable<iter_value_t<iterator_t<Rng>>>
 		safe_iterator_t<Rng> operator()(Rng&& rng) const {
 			return (*this)(begin(rng), end(rng));
 		}
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	struct __uninitialized_value_construct_n_fn : private __niebloid {
 		template<_NoThrowForwardIterator I>
-		requires DefaultConstructible<iter_value_t<I>>
+		requires default_initializable<iter_value_t<I>>
 		I operator()(I first, iter_difference_t<I> n) const {
 			return uninitialized_value_construct(
 				counted_iterator{first, n},

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -225,12 +225,12 @@ STL2_OPEN_NAMESPACE {
 			{ __decay_copy(rbegin(static_cast<R&&>(r))) } -> Iterator;
 		};
 
-		// Default to make_reverse_iterator(end(r)) for Common ranges of
+		// Default to make_reverse_iterator(end(r)) for common_with ranges of
 		// Bidirectional iterators.
 		template<class R>
 		META_CONCEPT can_make_reverse = requires(R&& r) {
 			{ begin(static_cast<R&&>(r)) } -> BidirectionalIterator;
-			{ end(static_cast<R&&>(r)) } -> Same<__begin_t<R>>;
+			{ end(static_cast<R&&>(r)) } -> same_as<__begin_t<R>>;
 		};
 
 		template<class>
@@ -378,13 +378,13 @@ STL2_OPEN_NAMESPACE {
 		template<class R>
 		META_CONCEPT has_member = requires(R& r) {
 			r.size();
-			{ __decay_copy(r.size()) } -> Integral;
+			{ __decay_copy(r.size()) } -> integral;
 		};
 
 		template<class R>
 		META_CONCEPT has_non_member = requires(R& r) {
 			size(r);
-			{ __decay_copy(size(r)) } -> Integral;
+			{ __decay_copy(size(r)) } -> integral;
 		};
 
 		template<class R>

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -70,10 +70,10 @@ STL2_OPEN_NAMESPACE {
 	template<class T>
 	META_CONCEPT _ContainerLike =
 		Range<T> && Range<const T> &&
-		!Same<iter_reference_t<iterator_t<T>>, iter_reference_t<iterator_t<const T>>>;
+		!same_as<iter_reference_t<iterator_t<T>>, iter_reference_t<iterator_t<const T>>>;
 
 	template<class T>
-	META_CONCEPT __enable_view_default = DerivedFrom<T, view_base> || !_ContainerLike<T>;
+	META_CONCEPT __enable_view_default = derived_from<T, view_base> || !_ContainerLike<T>;
 
 	template<class T>
 	inline constexpr bool enable_view = __enable_view_default<T>;
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 	template<class T>
 	META_CONCEPT View =
 		Range<T> &&
-		Semiregular<T> &&
+		semiregular<T> &&
 		enable_view<__uncvref<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
@@ -100,7 +100,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class T>
 	META_CONCEPT CommonRange =
-		Range<T> && Same<iterator_t<T>, sentinel_t<T>>;
+		Range<T> && same_as<iterator_t<T>, sentinel_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
 	// OutputRange [ranges.output]
@@ -144,15 +144,15 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT ContiguousRange =
 		RandomAccessRange<R> && ContiguousIterator<iterator_t<R>> &&
 		requires(R& r) {
-			{ data(r) } -> Same<std::add_pointer_t<iter_reference_t<iterator_t<R>>>>;
+			{ data(r) } -> same_as<std::add_pointer_t<iter_reference_t<iterator_t<R>>>>;
 		};
 
 	namespace ext {
 		template<class R>
 		META_CONCEPT SimpleView =
 			View<R> && Range<const R> &&
-			Same<iterator_t<R>, iterator_t<const R>> &&
-			Same<sentinel_t<R>, sentinel_t<const R>>;
+			same_as<iterator_t<R>, iterator_t<const R>> &&
+			same_as<sentinel_t<R>, sentinel_t<const R>>;
 	}
 
 	template<class Rng>

--- a/include/stl2/detail/range/primitives.hpp
+++ b/include/stl2/detail/range/primitives.hpp
@@ -30,12 +30,12 @@ STL2_OPEN_NAMESPACE {
 			C count;
 
 			template<class I2, class C2>
-			requires ConvertibleTo<const I&, I2> && ConvertibleTo<const C&, C2>
+			requires convertible_to<const I&, I2> && convertible_to<const C&, C2>
 			operator enumerate_result<I2, C2>() const& {
 				return {end, count};
 			}
 			template<class I2, class C2>
-			requires ConvertibleTo<I, I2> && ConvertibleTo<C, C2>
+			requires convertible_to<I, I2> && convertible_to<C, C2>
 			operator enumerate_result<I2, C2>() && {
 				return {std::move(end), std::move(count)};
 			}
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 			operator()(I first, S last) const {
 				if constexpr (SizedSentinel<S, I>) {
 					auto d = last - first;
-					STL2_EXPECT(Same<I, S> || d >= 0);
+					STL2_EXPECT(same_as<I, S> || d >= 0);
 					return {next(std::move(first), std::move(last)), d};
 				} else if constexpr (SizedSentinel<I, I>) {
 					auto end = next(first, std::move(last));
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 			iter_difference_t<I> n = 0;
 			if constexpr (SizedSentinel<S, I>) {
 				n = last - first;
-				STL2_EXPECT(Same<I, S> || n >= 0);
+				STL2_EXPECT(same_as<I, S> || n >= 0);
 			} else if constexpr (SizedSentinel<I, I>) {
 				auto end = next(first, std::move(last));
 				n = end - first;

--- a/include/stl2/detail/semiregular_box.hpp
+++ b/include/stl2/detail/semiregular_box.hpp
@@ -21,47 +21,47 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace detail {
-		// If T models MoveConstructible, semiregular_box<T> models Movable &&
-		// DefaultConstructible (so-called "MoveSemiregular"). If T models
-		// CopyConstructible, semiregular_box<T> models Semiregular.
+		// If T models move_constructible, semiregular_box<T> models movable &&
+		// default_initializable (so-called "MoveSemiregular"). If T models
+		// copy_constructible, semiregular_box<T> models semiregular.
 		template<ext::MoveConstructibleObject T>
 		struct semiregular_box {
 			semiregular_box() = default;
 			constexpr semiregular_box()
 			noexcept(std::is_nothrow_default_constructible_v<T>)
-			requires DefaultConstructible<T>
+			requires default_initializable<T>
 			: o_{std::in_place} {}
 
 #if STL2_WORKAROUND_CLANGC_42
 			template<class U>
-			requires _NotSameAs<U, semiregular_box> && ConvertibleTo<U, T>
+			requires _NotSameAs<U, semiregular_box> && convertible_to<U, T>
 #else
 			template<_NotSameAs<semiregular_box> U>
-			requires ConvertibleTo<U, T>
+			requires convertible_to<U, T>
 #endif
 			constexpr semiregular_box(U&& u)
 			noexcept(std::is_nothrow_constructible_v<T, U>)
 			: o_{std::in_place, static_cast<U&&>(u)} {}
 
-			semiregular_box(const semiregular_box&) requires CopyConstructible<T> = default;
+			semiregular_box(const semiregular_box&) requires copy_constructible<T> = default;
 			semiregular_box(semiregular_box&&) = default;
 
 			template<class... Args>
-			requires Constructible<T, Args...>
+			requires constructible_from<T, Args...>
 			constexpr semiregular_box(std::in_place_t, Args&&... args)
 			noexcept(std::is_nothrow_constructible_v<T, Args...>)
 			: o_{std::in_place, static_cast<Args&&>(args)...} {}
 
 			constexpr semiregular_box& operator=(const semiregular_box& that) &
 			noexcept(std::is_nothrow_copy_constructible_v<T>)
-			requires CopyConstructible<T>
+			requires copy_constructible<T>
 			{
 				o_.reset();
 				if (that.o_)
 					o_.emplace(*that.o_);
 				return *this;
 			}
-			semiregular_box& operator=(const semiregular_box&) & requires Copyable<T> = default;
+			semiregular_box& operator=(const semiregular_box&) & requires copyable<T> = default;
 
 			constexpr semiregular_box& operator=(semiregular_box&& that) &
 			noexcept(std::is_nothrow_move_constructible_v<T>)
@@ -71,7 +71,7 @@ STL2_OPEN_NAMESPACE {
 					o_.emplace(static_cast<T&&>(*that.o_));
 				return *this;
 			}
-			semiregular_box& operator=(semiregular_box&&) & requires Movable<T> = default;
+			semiregular_box& operator=(semiregular_box&&) & requires movable<T> = default;
 
 			constexpr semiregular_box& operator=(T&& t) &
 			noexcept(std::is_nothrow_move_constructible_v<T>)
@@ -82,7 +82,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr semiregular_box& operator=(T&& t) &
 			noexcept(std::is_nothrow_move_constructible_v<T> &&
 				std::is_nothrow_move_assignable_v<T>)
-			requires Movable<T>
+			requires movable<T>
 			{
 				o_ = static_cast<T&&>(t);
 				return *this;
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr semiregular_box& operator=(const T& t) &
 			noexcept(std::is_nothrow_copy_constructible_v<T>)
-			requires CopyConstructible<T>
+			requires copy_constructible<T>
 			{
 				o_.emplace(t);
 				return *this;
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr semiregular_box& operator=(const T& t) &
 			noexcept(std::is_nothrow_copy_constructible_v<T> &&
 				std::is_nothrow_copy_assignable_v<T>)
-			requires Copyable<T>
+			requires copyable<T>
 			{
 				o_ = t;
 				return *this;
@@ -125,13 +125,13 @@ STL2_OPEN_NAMESPACE {
 			std::optional<T> o_;
 		};
 
-		template<Semiregular T>
+		template<semiregular T>
 		requires ext::Object<T>
 		struct semiregular_box<T> : ebo_box<T, semiregular_box<T>> {
 			using semiregular_box::ebo_box::ebo_box;
 
 			template<class... Args>
-			requires Constructible<T, Args...>
+			requires constructible_from<T, Args...>
 			constexpr semiregular_box(std::in_place_t, Args&&... args)
 			noexcept(std::is_nothrow_constructible_v<T, Args...>)
 			: semiregular_box::ebo_box{static_cast<Args&&>(args)...} {}

--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -99,11 +99,11 @@ STL2_OPEN_NAMESPACE {
 
 			template<class Range, class ElementType>
 			META_CONCEPT compatible = SizedContiguousRange<Range> &&
-				ConvertibleTo<
+				convertible_to<
 					std::remove_pointer_t<data_pointer_t<Range>>(*)[],
 					ElementType(*)[]>;
 
-			template<Integral To, Integral From>
+			template<integral To, integral From>
 			constexpr To narrow_cast(From from) noexcept {
 				using C = common_type_t<To, From>;
 				auto to = static_cast<To>(from);
@@ -278,36 +278,36 @@ STL2_OPEN_NAMESPACE {
 			friend constexpr iterator end(span s) noexcept { return s.end(); }
 
 			// [span.comparison], span comparison operators
-			template<EqualityComparableWith<ElementType> U, index_type UExtent>
+			template<equality_comparable_with<ElementType> U, index_type UExtent>
 			bool operator==(span<U, UExtent> that) const
 			{
 				STL2_EXPECT(!size() || data());
 				STL2_EXPECT(!that.size() || that.data());
 				return equal(*this, that);
 			}
-			template<EqualityComparableWith<ElementType> U, index_type UExtent>
+			template<equality_comparable_with<ElementType> U, index_type UExtent>
 			bool operator!=(span<U, UExtent> that) const
 			{
 				return !(*this == that);
 			}
-			template<StrictTotallyOrderedWith<ElementType> U, index_type UExtent>
+			template<totally_ordered_with<ElementType> U, index_type UExtent>
 			bool operator<(span<U, UExtent> that) const
 			{
 				STL2_EXPECT(!size() || data());
 				STL2_EXPECT(!that.size() || that.data());
 				return lexicographical_compare(*this, that);
 			}
-			template<StrictTotallyOrderedWith<ElementType> U, index_type UExtent>
+			template<totally_ordered_with<ElementType> U, index_type UExtent>
 			bool operator>(span<U, UExtent> that)
 			{
 				return that < *this;
 			}
-			template<StrictTotallyOrderedWith<ElementType> U, index_type UExtent>
+			template<totally_ordered_with<ElementType> U, index_type UExtent>
 			bool operator<=(span<U, UExtent> that)
 			{
 				return !(that < *this);
 			}
-			template<StrictTotallyOrderedWith<ElementType> U, index_type UExtent>
+			template<totally_ordered_with<ElementType> U, index_type UExtent>
 			bool operator>=(span<U, UExtent> that)
 			{
 				return !(*this < that);

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -26,7 +26,7 @@ STL2_OPEN_NAMESPACE {
 	// Not to spec: this wasn't proposed for C++20, but I'm keeping it around
 	// until the libraries we want to support implement constexpr std::exchange.
 	template<class T, class U = T>
-	requires MoveConstructible<T> && Assignable<T&, U>
+	requires move_constructible<T> && assignable_from<T&, U>
 	constexpr T exchange(T& t, U&& u)
 	noexcept(std::is_nothrow_move_constructible<T>::value &&
 		std::is_nothrow_assignable<T&, U>::value)
@@ -74,8 +74,8 @@ STL2_OPEN_NAMESPACE {
 				(void)swap(std::forward<T>(t), std::forward<U>(u))
 			)
 			template<class T>
-			requires (!has_customization<T&, T&> && MoveConstructible<T>
-				&& Assignable<T&, T&&>)
+			requires (!has_customization<T&, T&> && move_constructible<T>
+				&& assignable_from<T&, T&&>)
 			constexpr void operator()(T& a, T& b) const
 			STL2_NOEXCEPT_RETURN(
 				(void)(b = __stl2::exchange(a, std::move(b)))
@@ -95,20 +95,20 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	///////////////////////////////////////////////////////////////////////////
-	// Swappable [concepts.lib.corelang.swappable]
+	// swappable [concepts.lib.corelang.swappable]
 	//
 	template<class T>
-	META_CONCEPT Swappable =
+	META_CONCEPT swappable =
 		requires(T& a, T& b) {
 			__stl2::swap(a, b);
 		};
 
 	template<class T, class U>
-	META_CONCEPT SwappableWith =
+	META_CONCEPT swappable_with =
 #if 1 // P/R of unfiled LWG issue
-		CommonReference<T, U> &&
+		common_reference_with<T, U> &&
 #else
-		CommonReference<
+		common_reference_with<
 			const remove_reference_t<T>&,
 			const remove_reference_t<U>&> &&
 #endif
@@ -123,7 +123,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T, class U>
 		inline constexpr bool is_nothrow_swappable_v = false;
 
-		template<class T, SwappableWith<T> U>
+		template<class T, swappable_with<T> U>
 		inline constexpr bool is_nothrow_swappable_v<T, U> =
 			noexcept(__stl2::swap(std::declval<T>(), std::declval<U>())) &&
 			noexcept(__stl2::swap(std::declval<U>(), std::declval<T>()));

--- a/include/stl2/detail/temporary_vector.hpp
+++ b/include/stl2/detail/temporary_vector.hpp
@@ -143,7 +143,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			template<class... Args>
-			requires Constructible<T, Args...>
+			requires constructible_from<T, Args...>
 			void emplace_back(Args&&... args)
 			noexcept(std::is_nothrow_constructible<T, Args...>::value)
 			{
@@ -153,11 +153,11 @@ STL2_OPEN_NAMESPACE {
 			}
 			void push_back(const T& t)
 			noexcept(std::is_nothrow_copy_constructible<T>::value)
-			requires CopyConstructible<T>
+			requires copy_constructible<T>
 			{ emplace_back(t); }
 			void push_back(T&& t)
 			noexcept(std::is_nothrow_move_constructible<T>::value)
-			requires MoveConstructible<T>
+			requires move_constructible<T>
 			{ emplace_back(std::move(t)); }
 		};
 

--- a/include/stl2/detail/variant.hpp
+++ b/include/stl2/detail/variant.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 		std::size_t I = meta::_v<meta::find_index<TypeList, T>>>
 	requires
 		(I != meta::_v<meta::npos> &&
-		Same<meta::find_index<meta::drop_c<TypeList, I + 1>, T>, meta::npos>)
+		same_as<meta::find_index<meta::drop_c<TypeList, I + 1>, T>, meta::npos>)
 	constexpr std::size_t __index_of_type = I;
 
 	// Like std::get<I>(v), but with a precondition that v.index() == I

--- a/include/stl2/type_traits.hpp
+++ b/include/stl2/type_traits.hpp
@@ -134,8 +134,8 @@ STL2_OPEN_NAMESPACE {
 
 	template<class T, class U>
 	requires meta::Valid<__common_ref, T&, U&> &&
-		ConvertibleTo<T&&, __rref_res<T, U>> &&
-		ConvertibleTo<U&&, __rref_res<T, U>>
+		convertible_to<T&&, __rref_res<T, U>> &&
+		convertible_to<U&&, __rref_res<T, U>>
 	struct __common_ref_<T&&, U&&> {
 		using type = __rref_res<T, U>;
 	};
@@ -143,7 +143,7 @@ STL2_OPEN_NAMESPACE {
 	// [meta.trans.other]/2.7
 	template<class T, class U>
 	requires requires { typename __common_ref<const T&, U&>; } &&
-		ConvertibleTo<T&&, __common_ref<const T&, U&>>
+		convertible_to<T&&, __common_ref<const T&, U&>>
 	struct __common_ref_<T&&, U&> {
 		using type = __common_ref<const T&, U&>;
 	};
@@ -151,7 +151,7 @@ STL2_OPEN_NAMESPACE {
 	// [meta.trans.other]/2.8
 	template<class T, class U>
 	requires requires { typename __common_ref<T&, const U&>; } &&
-		ConvertibleTo<U&&, __common_ref<T&, const U&>>
+		convertible_to<U&&, __common_ref<T&, const U&>>
 	struct __common_ref_<T&, U&&> {
 		using type = __common_ref<T&, const U&>;
 	};
@@ -239,34 +239,34 @@ STL2_OPEN_NAMESPACE {
 	: common_reference<common_reference_t<T, U>, V, W...> {};
 
 	///////////////////////////////////////////////////////////////////////////
-	// CommonReference [concept.commonref]
+	// common_reference_with [concept.commonref]
 	//
 	template<class T, class U>
-	META_CONCEPT CommonReference =
+	META_CONCEPT common_reference_with =
 		requires {
 			typename common_reference_t<T, U>;
 			typename common_reference_t<U, T>;
 		} &&
-		Same<common_reference_t<T, U>, common_reference_t<U, T>> &&
-		ConvertibleTo<T, common_reference_t<T, U>> &&
-		ConvertibleTo<U, common_reference_t<T, U>>;
+		same_as<common_reference_t<T, U>, common_reference_t<U, T>> &&
+		convertible_to<T, common_reference_t<T, U>> &&
+		convertible_to<U, common_reference_t<T, U>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// Common [concept.common]
+	// common_with [concept.common]
 	//
 	template<class T, class U>
-	META_CONCEPT Common =
+	META_CONCEPT common_with =
 		requires {
 			typename common_type_t<T, U>;
 			typename common_type_t<U, T>;
-			requires Same<common_type_t<T, U>, common_type_t<U, T>>;
+			requires same_as<common_type_t<T, U>, common_type_t<U, T>>;
 			static_cast<common_type_t<T, U>>(std::declval<T>());
 			static_cast<common_type_t<T, U>>(std::declval<U>());
 		} &&
-		CommonReference<
+		common_reference_with<
 			std::add_lvalue_reference_t<const T>,
 			std::add_lvalue_reference_t<const U>> &&
-		CommonReference<
+		common_reference_with<
 			std::add_lvalue_reference_t<common_type_t<T, U>>,
 			common_reference_t<
 				std::add_lvalue_reference_t<const T>,

--- a/include/stl2/view/drop.hpp
+++ b/include/stl2/view/drop.hpp
@@ -105,7 +105,7 @@ STL2_OPEN_NAMESPACE {
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
-			template<Integral D>
+			template<integral D>
 			constexpr auto operator()(D count) const
 			{
 				return detail::view_closure(*this, static_cast<D>(count));

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -134,11 +134,11 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		friend constexpr bool operator==(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<iterator_t<V>>
+		requires equality_comparable<iterator_t<V>>
 		{ return x.current_ == y.current_; }
 
 		friend constexpr bool operator!=(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<iterator_t<V>>
+		requires equality_comparable<iterator_t<V>>
 		{ return !(x == y); }
 
 		friend constexpr iter_rvalue_reference_t<iterator_t<V>>
@@ -200,7 +200,7 @@ STL2_OPEN_NAMESPACE {
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
-			template<CopyConstructible Pred>
+			template<copy_constructible Pred>
 			constexpr auto operator()(Pred pred) const {
 				return detail::view_closure{*this, std::move(pred)};
 			}

--- a/include/stl2/view/generate.hpp
+++ b/include/stl2/view/generate.hpp
@@ -30,12 +30,12 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class F>
 		META_CONCEPT __ConstInvocable =
-			Invocable<F&> &&
-			Invocable<const F&> &&
-			Same<invoke_result_t<F&>, invoke_result_t<const F&>>;
+			invocable<F&> &&
+			invocable<const F&> &&
+			same_as<invoke_result_t<F&>, invoke_result_t<const F&>>;
 
 		template<CopyConstructibleObject F>
-		requires Invocable<F&>
+		requires invocable<F&>
 		struct STL2_EMPTY_BASES generate_view
 		: view_interface<generate_view<F>>
 		, private detail::semiregular_box<F>
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<CopyConstructibleObject F>
-		requires Invocable<F&>
+		requires invocable<F&>
 		struct generate_view<F>::__iterator {
 			using value_type = result_t;
 			using difference_type = std::intmax_t;

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 				{ it_ += n; }
 			};
 		public:
-			indirect_view() requires DefaultConstructible<Rng> = default;
+			indirect_view() requires default_initializable<Rng> = default;
 			indirect_view(Rng rng) : base_t{std::move(rng)} {}
 
 			basic_iterator<cursor<false>> begin()

--- a/include/stl2/view/iota.hpp
+++ b/include/stl2/view/iota.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 
-	template<WeaklyIncrementable I, Semiregular Bound = unreachable>
+	template<WeaklyIncrementable I, semiregular Bound = unreachable>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view;
 
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	}
 
-	template<WeaklyIncrementable I, Semiregular Bound>
+	template<WeaklyIncrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct STL2_EMPTY_BASES iota_view
 	: private __iota_view_detail::__adl_hook
@@ -84,23 +84,23 @@ STL2_OPEN_NAMESPACE {
 		{ return __iterator{value_}; }
 		constexpr __sentinel end() const
 		{ return __sentinel{bound_}; }
-		constexpr __iterator end() const requires Same<I, Bound>
+		constexpr __iterator end() const requires same_as<I, Bound>
 		{ return __iterator{bound_}; }
 
 		template<class II = I, class BB = Bound> // gcc_bugs_bugs_bugs
 		constexpr auto size() const
-		requires (Same<II, BB> && ext::RandomAccessIncrementable<II>) ||
-			(Integral<II> && Integral<BB>) ||
+		requires (same_as<II, BB> && ext::RandomAccessIncrementable<II>) ||
+			(integral<II> && integral<BB>) ||
 			SizedSentinel<BB, II>
 		{ return bound_ - value_; }
 	};
 
-	template<WeaklyIncrementable I, Semiregular Bound>
+	template<WeaklyIncrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound> &&
-		(!Integral<I> || !Integral<Bound> || std::is_signed_v<I> == std::is_signed_v<Bound>)
+		(!integral<I> || !integral<Bound> || std::is_signed_v<I> == std::is_signed_v<Bound>)
 	iota_view(I, Bound) -> iota_view<I, Bound>;
 
-	template<WeaklyIncrementable I, Semiregular Bound>
+	template<WeaklyIncrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::__iterator
 	: detail::iota_view_iterator_base<I> {
@@ -159,23 +159,23 @@ STL2_OPEN_NAMESPACE {
 		{ return value_ + n; }
 
 		friend constexpr bool operator==(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<I>
+		requires equality_comparable<I>
 		{ return x.value_ == y.value_; }
 		friend constexpr bool operator!=(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<I>
+		requires equality_comparable<I>
 		{ return !(x == y); }
 
 		friend constexpr bool operator<(const __iterator& x, const __iterator& y)
-		requires StrictTotallyOrdered<I>
+		requires totally_ordered<I>
 		{ return x.value_ < y.value_; }
 		friend constexpr bool operator>(const __iterator& x, const __iterator& y)
-		requires StrictTotallyOrdered<I>
+		requires totally_ordered<I>
 		{ return y < x; }
 		friend constexpr bool operator<=(const __iterator& x, const __iterator& y)
-		requires StrictTotallyOrdered<I>
+		requires totally_ordered<I>
 		{ return !(y < x); }
 		friend constexpr bool operator>=(const __iterator& x, const __iterator& y)
-		requires StrictTotallyOrdered<I>
+		requires totally_ordered<I>
 		{ return !(x < y); }
 
 		friend constexpr __iterator operator+(__iterator i, difference_type n)
@@ -196,7 +196,7 @@ STL2_OPEN_NAMESPACE {
 		I value_ {};
 	};
 
-	template<WeaklyIncrementable I, Semiregular Bound>
+	template<WeaklyIncrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::__sentinel {
 		__sentinel() = default;
@@ -227,9 +227,9 @@ STL2_OPEN_NAMESPACE {
 				return iota_view{value};
 			}
 
-			template<WeaklyIncrementable I, Semiregular Bound>
+			template<WeaklyIncrementable I, semiregular Bound>
 			requires WeaklyEqualityComparable<I, Bound> &&
-				(!Integral<I> || !Integral<Bound> ||
+				(!integral<I> || !integral<Bound> ||
 					std::is_signed_v<I> == std::is_signed_v<Bound>)
 			constexpr auto operator()(I value, Bound bound) const {
 				return iota_view{value, bound};

--- a/include/stl2/view/istream.hpp
+++ b/include/stl2/view/istream.hpp
@@ -25,8 +25,8 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<Movable Val>
-		requires DefaultConstructible<Val> && StreamExtractable<Val>
+		template<movable Val>
+		requires default_initializable<Val> && StreamExtractable<Val>
 		struct STL2_EMPTY_BASES istream_view
 		: view_interface<istream_view<Val>>
 		, detail::semiregular_box<Val> {
@@ -50,8 +50,8 @@ STL2_OPEN_NAMESPACE {
 			constexpr default_sentinel end() const noexcept { return {}; }
 		};
 
-		template<Movable Val>
-		requires DefaultConstructible<Val> && StreamExtractable<Val>
+		template<movable Val>
+		requires default_initializable<Val> && StreamExtractable<Val>
 		struct istream_view<Val>::__iterator {
 			using iterator_category = input_iterator_tag;
 			using difference_type = std::ptrdiff_t;

--- a/include/stl2/view/join.hpp
+++ b/include/stl2/view/join.hpp
@@ -165,8 +165,8 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		constexpr __iterator(__iterator<!Const> i) requires Const &&
-			ConvertibleTo<iterator_t<V>, iterator_t<Base>> &&
-			ConvertibleTo<
+			convertible_to<iterator_t<V>, iterator_t<Base>> &&
+			convertible_to<
 				iterator_t<InnerRng>,
 				iterator_t<iter_reference_t<iterator_t<Base>>>>
 		: outer_(std::move(i.outer_))
@@ -230,13 +230,13 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		friend constexpr bool operator==(const __iterator& x, const __iterator& y)
-		requires ref_is_glvalue && EqualityComparable<iterator_t<Base>> &&
-			EqualityComparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
+		requires ref_is_glvalue && equality_comparable<iterator_t<Base>> &&
+			equality_comparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
 		{ return bool(x.outer_ == y.outer_) && bool(x.inner_ == y.inner_); } // TODO: file LWG issue
 
 		friend constexpr bool operator!=(const __iterator& x, const __iterator& y)
-		requires ref_is_glvalue && EqualityComparable<iterator_t<Base>> &&
-			EqualityComparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
+		requires ref_is_glvalue && equality_comparable<iterator_t<Base>> &&
+			equality_comparable<iterator_t<iter_reference_t<iterator_t<Base>>>>
 		{ return !(x == y); }
 
 		friend constexpr decltype(auto) iter_move(const __iterator& i)
@@ -270,7 +270,7 @@ STL2_OPEN_NAMESPACE {
 		: end_(__stl2::end(parent.base_)) {}
 
 		constexpr __sentinel(__sentinel<!Const> s) requires Const &&
-			ConvertibleTo<sentinel_t<V>, sentinel_t<Base>>
+			convertible_to<sentinel_t<V>, sentinel_t<Base>>
 		: end_(std::move(s.end_)) {}
 
 		friend constexpr bool operator==(const __iterator<Const>& x, const __sentinel& y)

--- a/include/stl2/view/move.hpp
+++ b/include/stl2/view/move.hpp
@@ -32,7 +32,7 @@ STL2_OPEN_NAMESPACE {
 			using base_t = detail::ebo_box<Rng, move_view<Rng>>;
 			using base_t::get;
 		public:
-			move_view() requires DefaultConstructible<Rng> = default;
+			move_view() requires default_initializable<Rng> = default;
 
 			constexpr move_view(Rng rng)
 			noexcept(std::is_nothrow_move_constructible<Rng>::value)

--- a/include/stl2/view/repeat.hpp
+++ b/include/stl2/view/repeat.hpp
@@ -64,10 +64,10 @@ STL2_OPEN_NAMESPACE {
 			repeat_view() = default;
 #if STL2_WORKAROUND_CLANGC_42
 			template<class U>
-			requires _NotSameAs<U, repeat_view> && ConvertibleTo<U, T>
+			requires _NotSameAs<U, repeat_view> && convertible_to<U, T>
 #else
 			template<_NotSameAs<repeat_view> U>
-			requires ConvertibleTo<U, T>
+			requires convertible_to<U, T>
 #endif
 			explicit constexpr repeat_view(U&& u)
 			noexcept(std::is_nothrow_constructible_v<T, U>)

--- a/include/stl2/view/single.hpp
+++ b/include/stl2/view/single.hpp
@@ -22,7 +22,7 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<CopyConstructible T>
+	template<copy_constructible T>
 	requires std::is_object_v<T>
 	class single_view : public view_interface<single_view<T>> {
 	private:
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 		: value_(std::move(t)) {}
 
 		template<class... Args>
-		requires Constructible<T, Args...>
+		requires constructible_from<T, Args...>
 		constexpr single_view(std::in_place_t, Args&&... args)
 		: value_(std::in_place, std::forward<Args>(args)...) {}
 

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 		, pattern_(std::move(pattern)) {}
 
 		constexpr split_view(Rng base, iter_value_t<iterator_t<Rng>> e)
-		requires Constructible<Pattern, single_view<iter_value_t<iterator_t<Rng>>>>
+		requires constructible_from<Pattern, single_view<iter_value_t<iterator_t<Rng>>>>
 		: base_(std::move(base))
 		, pattern_(single_view{std::move(e)}) {}
 
@@ -152,7 +152,7 @@ STL2_OPEN_NAMESPACE {
 		, parent_(std::addressof(parent)) {}
 
 		constexpr __outer_iterator(__outer_iterator<!Const> i)
-		requires Const && ConvertibleTo<iterator_t<Rng>, iterator_t<Base>>
+		requires Const && convertible_to<iterator_t<Rng>, iterator_t<Base>>
 		: __split_view_outer_base<Rng, Const>{i.current_}
 		, parent_(i.parent_) {}
 
@@ -328,7 +328,7 @@ STL2_OPEN_NAMESPACE {
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
-			template<CopyConstructible T>
+			template<copy_constructible T>
 			constexpr auto operator()(T&& t) const
 			{ return detail::view_closure{*this, std::forward<T>(t)}; }
 		};

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -25,7 +25,7 @@
 STL2_OPEN_NAMESPACE {
 	template<class From, class To>
 	META_CONCEPT _ConvertibleToNotSlicing =
-		ConvertibleTo<From, To> &&
+		convertible_to<From, To> &&
 		// A conversion is a slicing conversion if the source and the destination
 		// are both pointers, and if the pointed-to types differ after removing
 		// cv qualifiers.
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT _PairLike =
 		!std::is_reference_v<T> && requires {
 			typename std::tuple_size<T>::type;
-			requires DerivedFrom<std::tuple_size<T>, std::integral_constant<std::size_t, 2>>;
+			requires derived_from<std::tuple_size<T>, std::integral_constant<std::size_t, 2>>;
 			typename std::tuple_element_t<0, std::remove_const_t<T>>;
 			typename std::tuple_element_t<1, std::remove_const_t<T>>;
 			requires _PairLikeGCCBugs<T>; // Separate named concept to avoid
@@ -56,11 +56,11 @@ STL2_OPEN_NAMESPACE {
 		!std::is_reference_v<std::tuple_element_t<0, T>> &&
 		!std::is_reference_v<std::tuple_element_t<1, T>> &&
 		_ConvertibleToNotSlicing<U, std::tuple_element_t<0, T>> &&
-		ConvertibleTo<V, std::tuple_element_t<1, T>>;
+		convertible_to<V, std::tuple_element_t<1, T>>;
 
 	template<class T, class U, class V>
 	META_CONCEPT _PairLikeConvertibleFrom =
-		!Range<T> && _PairLike<T> && Constructible<T, U, V> &&
+		!Range<T> && _PairLike<T> && constructible_from<T, U, V> &&
 		_PairLikeConvertibleFromGCCBugs<T, U, V>; // Separate named concept to avoid
 		                                          // premature substitution.
 
@@ -149,7 +149,7 @@ STL2_OPEN_NAMESPACE {
 		requires _ForwardingRange<R> &&
 #endif
 			_ConvertibleToNotSlicing<iterator_t<R>, I> &&
-			ConvertibleTo<sentinel_t<R>, S>
+			convertible_to<sentinel_t<R>, S>
 		constexpr subrange(R&& r) requires (!StoreSize)
 		: subrange{__stl2::begin(r), __stl2::end(r)} {}
 
@@ -161,14 +161,14 @@ STL2_OPEN_NAMESPACE {
 		requires _ForwardingRange<R> &&
 #endif
 			_ConvertibleToNotSlicing<iterator_t<R>, I> &&
-			ConvertibleTo<sentinel_t<R>, S>
+			convertible_to<sentinel_t<R>, S>
 		constexpr subrange(R&& r) requires StoreSize && SizedRange<R>
 		: subrange{__stl2::begin(r), __stl2::end(r), distance(r)} {}
 
 		template<_ForwardingRange R>
 		requires
 			_ConvertibleToNotSlicing<iterator_t<R>, I> &&
-			ConvertibleTo<sentinel_t<R>, S>
+			convertible_to<sentinel_t<R>, S>
 		constexpr subrange(R&& r, iter_difference_t<I> n)
 			requires (K == subrange_kind::sized)
 		: subrange{__stl2::begin(r), __stl2::end(r), n} {

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -100,7 +100,7 @@ STL2_OPEN_NAMESPACE {
 		: end_(end) {}
 
 		constexpr __sentinel(__sentinel<!Const> s)
-		requires Const && ConvertibleTo<sentinel_t<R>, sentinel_t<Base>>
+		requires Const && convertible_to<sentinel_t<R>, sentinel_t<Base>>
 		: end_(s.base()) {}
 
 		constexpr sentinel_t<Base> base() const { return end_; }
@@ -128,7 +128,7 @@ STL2_OPEN_NAMESPACE {
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
-			template<Integral D>
+			template<integral D>
 			constexpr auto operator()(D count) const
 			{ return detail::view_closure{*this, static_cast<D>(count)}; }
 		};

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 	#else
 			template<class B = Base>
 			requires
-				(Same<B, Base> &&
+				(same_as<B, Base> &&
 				!Range<B const> &&
 				requires(B& b) { __stl2::data(b); })
 			constexpr auto data()
@@ -83,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 	#else
 			template<class B = Base>
 			requires
-				Same<B, Base> &&
+				same_as<B, Base> &&
 				Range<B const> &&
 				requires(B const& b) { __stl2::data(b); }
 			constexpr auto data() const
@@ -120,7 +120,7 @@ STL2_OPEN_NAMESPACE {
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
-			template<Integral D>
+			template<integral D>
 			constexpr auto operator()(D count) const {
 				return detail::view_closure(*this, static_cast<D>(count));
 			}

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -83,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 			: end_(end), pred_(pred) {}
 
 			constexpr __sentinel(__sentinel<!Const> s)
-			requires Const && ConvertibleTo<sentinel_t<R>, sentinel_t<Base>>
+			requires Const && convertible_to<sentinel_t<R>, sentinel_t<Base>>
 			: end_(s.base()), pred_(s.pred_) {}
 
 			constexpr sentinel_t<Base> base() const { return end_; }

--- a/include/stl2/view/transform.hpp
+++ b/include/stl2/view/transform.hpp
@@ -27,9 +27,9 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<InputRange V, CopyConstructible F>
+	template<InputRange V, copy_constructible F>
 	requires View<V> && std::is_object_v<F> &&
-		RegularInvocable<F&, iter_reference_t<iterator_t<V>>>
+		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	class transform_view : public view_interface<transform_view<V, F>> {
 	private:
 		template<bool> class __iterator;
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 		// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		template<class ConstV = const V>
 		constexpr __iterator<true> begin() const requires Range<ConstV> &&
-			RegularInvocable<const F&, iter_reference_t<iterator_t<ConstV>>>
+			regular_invocable<const F&, iter_reference_t<iterator_t<ConstV>>>
 		{ return {*this, __stl2::begin(base_)}; }
 
 		constexpr auto end() {
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 		// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		template<class ConstV = const V>
 		constexpr auto end() const requires Range<ConstV> &&
-			RegularInvocable<const F&, iter_reference_t<iterator_t<ConstV>>>
+			regular_invocable<const F&, iter_reference_t<iterator_t<ConstV>>>
 		{
 			if constexpr (CommonRange<const V>) {
 				return __iterator<true>{*this, __stl2::end(base_)};
@@ -85,9 +85,9 @@ STL2_OPEN_NAMESPACE {
 	template<class R, class F>
 	transform_view(R&& r, F fun) -> transform_view<all_view<R>, F>;
 
-	template<InputRange V, CopyConstructible F>
+	template<InputRange V, copy_constructible F>
 	requires View<V> && std::is_object_v<F> &&
-		RegularInvocable<F&, iter_reference_t<iterator_t<V>>>
+		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	template<bool Const>
 	class transform_view<V, F>::__iterator {
 	private:
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 		: current_(current), parent_(&parent) {}
 
 		constexpr __iterator(__iterator<!Const> i)
-		requires Const && ConvertibleTo<iterator_t<V>, iterator_t<Base>>
+		requires Const && convertible_to<iterator_t<V>, iterator_t<Base>>
 		: current_(std::move(i.current_)), parent_(i.parent_) {}
 
 		constexpr iterator_t<Base> base() const
@@ -162,11 +162,11 @@ STL2_OPEN_NAMESPACE {
 		{ return invoke(parent_->fun_.get(), current_[n]); }
 
 		friend constexpr bool operator==(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<iterator_t<Base>>
+		requires equality_comparable<iterator_t<Base>>
 		{ return x.current_ == y.current_; }
 
 		friend constexpr bool operator!=(const __iterator& x, const __iterator& y)
-		requires EqualityComparable<iterator_t<Base>>
+		requires equality_comparable<iterator_t<Base>>
 		{ return !(x == y); }
 
 		friend constexpr bool operator<(const __iterator& x, const __iterator& y)
@@ -215,9 +215,9 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.current_, y.current_); }
 	};
 
-	template<InputRange V, CopyConstructible F>
+	template<InputRange V, copy_constructible F>
 	requires View<V> && std::is_object_v<F> &&
-		RegularInvocable<F&, iter_reference_t<iterator_t<V>>>
+		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	template<bool Const>
 	class transform_view<V, F>::__sentinel {
 	private:
@@ -238,7 +238,7 @@ STL2_OPEN_NAMESPACE {
 		explicit constexpr __sentinel(sentinel_t<Base> end)
 		: end_(end) {}
 		constexpr __sentinel(__sentinel<!Const> i)
-		requires Const && ConvertibleTo<sentinel_t<V>, sentinel_t<Base>>
+		requires Const && convertible_to<sentinel_t<V>, sentinel_t<Base>>
 		: end_(std::move(i.end_)) {}
 
 		constexpr sentinel_t<Base> base() const
@@ -269,14 +269,14 @@ STL2_OPEN_NAMESPACE {
 
 	namespace view {
 		struct __transform_fn {
-			template<InputRange Rng, CopyConstructible F>
+			template<InputRange Rng, copy_constructible F>
 			requires
-				ViewableRange<Rng> && Invocable<F&, iter_reference_t<iterator_t<Rng>>>
+				ViewableRange<Rng> && invocable<F&, iter_reference_t<iterator_t<Rng>>>
 			constexpr auto operator()(Rng&& rng, F fun) const {
 				return transform_view{std::forward<Rng>(rng), std::move(fun)};
 			}
 
-			template<CopyConstructible F>
+			template<copy_constructible F>
 			constexpr auto operator()(F fun) const {
 				return detail::view_closure{*this, std::move(fun)};
 			}

--- a/include/stl2/view/view_interface.hpp
+++ b/include/stl2/view/view_interface.hpp
@@ -39,8 +39,8 @@ STL2_OPEN_NAMESPACE {
 		META_CONCEPT SizedSentinelForwardRange = ForwardRange<R> && SizedSentinel<sentinel_t<R>, iterator_t<R>>;
 		template<class C, class R> // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		META_CONCEPT ContainerConvertibleGCCBugs = InputRange<R> &&
-			ConvertibleTo<iter_reference_t<iterator_t<R>>, iter_value_t<iterator_t<C>>> &&
-			Constructible<C, __range_common_iterator<R>, __range_common_iterator<R>>;
+			convertible_to<iter_reference_t<iterator_t<R>>, iter_value_t<iterator_t<C>>> &&
+			constructible_from<C, __range_common_iterator<R>, __range_common_iterator<R>>;
 		template<class C, class R>
 		META_CONCEPT ContainerConvertible = ForwardRange<C> && !View<C> &&
 			ContainerConvertibleGCCBugs<C, R>;
@@ -67,11 +67,11 @@ STL2_OPEN_NAMESPACE {
 	class view_interface : public view_base {
 	private:
 		constexpr D& derived() noexcept {
-			static_assert(DerivedFrom<D, view_interface>);
+			static_assert(derived_from<D, view_interface>);
 			return static_cast<D&>(*this);
 		}
 		constexpr const D& derived() const noexcept {
-			static_assert(DerivedFrom<D, view_interface>);
+			static_assert(derived_from<D, view_interface>);
 			return static_cast<const D&>(*this);
 		}
 	public:

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -20,7 +20,7 @@
 namespace ranges = __stl2;
 
 template<ranges::InputIterator I>
-	requires ranges::Regular<ranges::iter_value_t<I>>
+	requires ranges::regular<ranges::iter_value_t<I>>
 struct delimiter {
 	delimiter() = default;
 	delimiter(ranges::iter_value_t<I> value) :

--- a/test/algorithm/copy_if.cpp
+++ b/test/algorithm/copy_if.cpp
@@ -60,7 +60,7 @@ int main() {
 		std::fill_n(target, n, -1);
 
 		auto res = ranges::copy_if(std::move(source), target, is_even);
-		static_assert(ranges::Same<decltype(res.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res.in), ranges::dangling>);
 		CHECK(res.out == target + n / 2);
 
 		CHECK(std::equal(target, target + n / 2, evens));

--- a/test/algorithm/next_permutation.cpp
+++ b/test/algorithm/next_permutation.cpp
@@ -33,7 +33,7 @@
 
 namespace ranges = __stl2;
 
-constexpr ranges::Integral factorial(ranges::Integral x)
+constexpr ranges::integral factorial(ranges::integral x)
 {
 	decltype(x) r = 1;
 	for (; 1 < x; --x)

--- a/test/algorithm/partial_sort_copy.cpp
+++ b/test/algorithm/partial_sort_copy.cpp
@@ -153,7 +153,7 @@ int main()
         std::shuffle(input, input+N, gen);
         auto r = ranges::partial_sort_copy(input, std::move(output), std::less<int>(), &S::i, &U::i);
         U* e = output + std::min(N, M);
-        static_assert(ranges::Same<decltype(r), ranges::dangling>);
+        static_assert(ranges::same_as<decltype(r), ranges::dangling>);
         int i = 0;
         for (U* x = output; x < e; ++x, ++i)
             CHECK(x->i == i);

--- a/test/algorithm/partition_copy.cpp
+++ b/test/algorithm/partition_copy.cpp
@@ -107,7 +107,7 @@ void test_rvalue() {
 	S r1[10] = {S{0}};
 	S r2[10] = {S{0}};
 	auto p = ranges::partition_copy(std::move(ia), r1, r2, is_odd(), &S::i);
-	static_assert(ranges::Same<decltype(p.in), ranges::dangling>);
+	static_assert(ranges::same_as<decltype(p.in), ranges::dangling>);
 	CHECK(p.out1 == r1 + 4);
 	CHECK(r1[0].i == 1);
 	CHECK(r1[1].i == 3);

--- a/test/algorithm/prev_permutation.cpp
+++ b/test/algorithm/prev_permutation.cpp
@@ -32,7 +32,7 @@
 
 namespace ranges = __stl2;
 
-constexpr auto factorial(ranges::Integral x)
+constexpr auto factorial(ranges::integral x)
 {
 	decltype(x) r = 1;
 	for (; 1 < x; --x) {

--- a/test/algorithm/remove.cpp
+++ b/test/algorithm/remove.cpp
@@ -158,7 +158,7 @@ int main()
 	// Check rvalue range
 	S ia2[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
 	auto r2 = ranges::remove(std::move(ia2), 2, &S::i);
-	static_assert(ranges::Same<decltype(r2), ranges::dangling>);
+	static_assert(ranges::same_as<decltype(r2), ranges::dangling>);
 	CHECK(ia2[0].i == 0);
 	CHECK(ia2[1].i == 1);
 	CHECK(ia2[2].i == 3);

--- a/test/algorithm/remove_copy.cpp
+++ b/test/algorithm/remove_copy.cpp
@@ -153,7 +153,7 @@ int main() {
 		constexpr unsigned sa = ranges::size(ia);
 		S ib[sa];
 		auto r = ranges::remove_copy(std::move(ia), ib, 2, &S::i);
-		static_assert(ranges::Same<decltype(r.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r.in), ranges::dangling>);
 		CHECK(r.out == ib + sa-3);
 		CHECK(ib[0].i == 0);
 		CHECK(ib[1].i == 1);

--- a/test/algorithm/remove_copy_if.cpp
+++ b/test/algorithm/remove_copy_if.cpp
@@ -155,7 +155,7 @@ int main() {
 		constexpr unsigned sa = ranges::size(ia);
 		S ib[sa];
 		auto r = ranges::remove_copy_if(std::move(ia), ib, [](int i){ return i == 2; }, &S::i);
-		static_assert(ranges::Same<decltype(r.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r.in), ranges::dangling>);
 		CHECK(r.out == ib + sa-3);
 		CHECK(ib[0].i == 0);
 		CHECK(ib[1].i == 1);

--- a/test/algorithm/remove_if.cpp
+++ b/test/algorithm/remove_if.cpp
@@ -181,7 +181,7 @@ int main()
 		S ia[] = {S{0}, S{1}, S{2}, S{3}, S{4}, S{2}, S{3}, S{4}, S{2}};
 		using namespace std::placeholders;
 		auto r = ranges::remove_if(std::move(ia), std::bind(std::equal_to<int>(), _1, 2), &S::i);
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		CHECK(ia[0].i == 0);
 		CHECK(ia[1].i == 1);
 		CHECK(ia[2].i == 3);

--- a/test/algorithm/replace.cpp
+++ b/test/algorithm/replace.cpp
@@ -101,7 +101,7 @@ int main()
 		using P = std::pair<int,std::string>;
 		P ia[] = {{0,"0"}, {1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}};
 		auto i = ranges::replace(std::move(ia), 2, std::make_pair(42,"42"), &std::pair<int,std::string>::first);
-		static_assert(ranges::Same<decltype(i), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(i), ranges::dangling>);
 		CHECK(ia[0] == P{0,"0"});
 		CHECK(ia[1] == P{1,"1"});
 		CHECK(ia[2] == P{42,"42"});

--- a/test/algorithm/replace_if.cpp
+++ b/test/algorithm/replace_if.cpp
@@ -103,7 +103,7 @@ int main()
 		P ia[] = {{0,"0"}, {1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}};
 		auto i = ranges::replace_if(std::move(ia), [](int i){return i==2;}, std::make_pair(42,"42"),
 			&std::pair<int,std::string>::first);
-		static_assert(ranges::Same<decltype(i), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(i), ranges::dangling>);
 		CHECK(ia[0] == P{0,"0"});
 		CHECK(ia[1] == P{1,"1"});
 		CHECK(ia[2] == P{42,"42"});

--- a/test/algorithm/rotate.cpp
+++ b/test/algorithm/rotate.cpp
@@ -264,7 +264,7 @@ int main()
 	{
 		int rgi[] = {0,1,2,3,4,5};
 		auto r = ranges::rotate(std::move(rgi), rgi+2);
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		CHECK(rgi[0] == 2);
 		CHECK(rgi[1] == 3);
 		CHECK(rgi[2] == 4);

--- a/test/algorithm/rotate_copy.cpp
+++ b/test/algorithm/rotate_copy.cpp
@@ -309,7 +309,7 @@ int main()
 		int rgi[] = {0,1,2,3,4,5};
 		int rgo[6] = {0};
 		auto r = ranges::rotate_copy(std::move(rgi), rgi+2, rgo);
-		static_assert(ranges::Same<decltype(r.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r.in), ranges::dangling>);
 		CHECK(r.out == ranges::end(rgo));
 		CHECK(rgo[0] == 2);
 		CHECK(rgo[1] == 3);

--- a/test/algorithm/set_difference6.cpp
+++ b/test/algorithm/set_difference6.cpp
@@ -52,7 +52,7 @@ int main() {
 
 		auto res = ranges::set_difference(std::move(ia), std::move(ib), ic,
 			std::less<int>(), &S::i, &T::j);
-		static_assert(ranges::Same<decltype(res.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res.in), ranges::dangling>);
 		CHECK((res.out - ic) == sr);
 		CHECK(!ranges::lexicographical_compare(ic, res.out, ir, ir+sr,
 			std::less<int>(), &U::k));
@@ -62,7 +62,7 @@ int main() {
 		const int srr = sizeof(irr)/sizeof(irr[0]);
 		auto res2 = ranges::set_difference(std::move(ib), std::move(ia), ic,
 			std::less<int>(), &T::j, &S::i);
-		static_assert(ranges::Same<decltype(res2.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res2.in), ranges::dangling>);
 		CHECK((res2.out - ic) == srr);
 		CHECK(!ranges::lexicographical_compare(ic, res2.out, ir, irr+srr,
 			std::less<int>(), &U::k));

--- a/test/algorithm/set_symmetric_difference6.cpp
+++ b/test/algorithm/set_symmetric_difference6.cpp
@@ -44,16 +44,16 @@ int main() {
 
 		auto res1 =
 			ranges::set_symmetric_difference(std::move(ia), std::move(ib), ic, std::less<int>(), &S::i, &T::j);
-		static_assert(ranges::Same<decltype(res1.in1), ranges::dangling>);
-		static_assert(ranges::Same<decltype(res1.in2), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res1.in1), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res1.in2), ranges::dangling>);
 		CHECK((res1.out - ic) == sr);
 		CHECK(!ranges::lexicographical_compare(ic, res1.out, ir, ir+sr, std::less<int>(), &U::k));
 		ranges::fill(ic, U{0});
 
 		auto res2 =
 			ranges::set_symmetric_difference(std::move(ib), std::move(ia), ic, std::less<int>(), &T::j, &S::i);
-		static_assert(ranges::Same<decltype(res2.in1), ranges::dangling>);
-		static_assert(ranges::Same<decltype(res2.in2), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res2.in1), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res2.in2), ranges::dangling>);
 		CHECK((res2.out - ic) == sr);
 		CHECK(!ranges::lexicographical_compare(ic, res2.out, ir, ir+sr, std::less<int>(), &U::k));
 	}

--- a/test/algorithm/set_union6.cpp
+++ b/test/algorithm/set_union6.cpp
@@ -44,15 +44,15 @@ int main()
 		const int sr = sizeof(ir)/sizeof(ir[0]);
 
 		auto res = ranges::set_union(std::move(ia), std::move(ib), ic, std::less<int>(), &S::i, &T::j);
-		static_assert(ranges::Same<decltype(res.in1), ranges::dangling>);
-		static_assert(ranges::Same<decltype(res.in2), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res.in1), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res.in2), ranges::dangling>);
 		CHECK((res.out - ic) == sr);
 		CHECK(!ranges::lexicographical_compare(ic, res.out, ir, ir+sr, std::less<int>(), &U::k));
 		ranges::fill(ic, U{0});
 
 		auto res2 = ranges::set_union(std::move(ib), std::move(ia), ic, std::less<int>(), &T::j, &S::i);
-		static_assert(ranges::Same<decltype(res2.in1), ranges::dangling>);
-		static_assert(ranges::Same<decltype(res2.in2), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res2.in1), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(res2.in2), ranges::dangling>);
 		CHECK((res2.out - ic) == sr);
 		CHECK(!ranges::lexicographical_compare(ic, res2.out, ir, ir+sr, std::less<int>(), &U::k));
 	}

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -287,7 +287,7 @@ int main()
 			v[i].j = i;
 		}
 		auto r = ranges::sort(std::move(v), std::less<int>{}, &S::i);
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		for(int i = 0; (std::size_t)i < v.size(); ++i)
 		{
 			CHECK(v[i].i == i);

--- a/test/algorithm/stable_partition.cpp
+++ b/test/algorithm/stable_partition.cpp
@@ -407,7 +407,7 @@ int main() {
 	{	// check mixed
 		S ap[] = { {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}, {{2, 2}}, {{3, 1}}, {{3, 2}}, {{4, 1}}, {{4, 2}} };
 		auto r = ranges::stable_partition(std::move(ap), odd_first(), &S::p);
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		CHECK(ap[0].p == P{1, 1});
 		CHECK(ap[1].p == P{1, 2});
 		CHECK(ap[2].p == P{3, 1});

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -212,7 +212,7 @@ int main() {
 			v[i].j = i;
 		}
 		auto r = ranges::stable_sort(std::move(v), std::less<int>{}, &S::i);
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		for(int i = 0; (std::size_t)i < v.size(); ++i)
 		{
 			CHECK(v[i].i == i);

--- a/test/algorithm/unique.cpp
+++ b/test/algorithm/unique.cpp
@@ -150,7 +150,7 @@ int main()
 	{
 		int a[] = {0, 1, 1, 1, 2, 2, 2};
 		auto r = ranges::unique(std::move(a));
-		static_assert(ranges::Same<decltype(r), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r), ranges::dangling>);
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
 		CHECK(a[2] == 2);

--- a/test/algorithm/unique_copy.cpp
+++ b/test/algorithm/unique_copy.cpp
@@ -300,7 +300,7 @@ int main() {
 		S const ia[] = {{1,1},{2,2},{3,3},{3,4},{4,5},{5,6},{5,7},{5,8},{6,9},{7,10}};
 		S ib[ranges::size(ia)];
 		auto r = ranges::unique_copy(std::move(ia), ib, ranges::equal_to(), &S::i);
-		static_assert(ranges::Same<decltype(r.in), ranges::dangling>);
+		static_assert(ranges::same_as<decltype(r.in), ranges::dangling>);
 		CHECK(r.out == ib + 7);
 		CHECK_EQUAL(ranges::subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
 	}

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -158,9 +158,9 @@ struct common_type<Y2, X2>
 static_assert(is_same_v<common_type_t<X2 &, Y2 const &>, Z2>);
 static_assert(is_same_v<common_reference_t<X2 &, Y2 const &>, Z2>);
 
-static_assert(CommonReference<void, void>);
+static_assert(common_reference_with<void, void>);
 static_assert(is_same_v<common_reference_t<void, void>, void>);
-static_assert(Common<void, void>);
+static_assert(common_with<void, void>);
 static_assert(is_same_v<common_type_t<void, void>, void>);
 
 static_assert(is_same_v<common_type_t<reference_wrapper<int>, int>, int>);
@@ -304,7 +304,7 @@ namespace libstdcpp_tests
 	struct is_type : std::false_type {};
 
 	template<meta::Trait T, typename Expected>
-		requires Same<meta::_t<T>, Expected>
+		requires same_as<meta::_t<T>, Expected>
 	struct is_type<T, Expected> : std::true_type {};
 
 	// Inspection types:

--- a/test/concepts/compare.cpp
+++ b/test/concepts/compare.cpp
@@ -14,7 +14,7 @@
 #if VALIDATE_RANGES
 namespace ranges {
 template<class T>
-constexpr bool Boolean =
+constexpr bool boolean =
 	std::is_same<T, bool>(); // Obviously many tests will fail ;)
 }
 #elif VALIDATE_STL2
@@ -28,18 +28,18 @@ constexpr bool Boolean =
 namespace boolean_test {
 // Better have at least these three, since we use them as
 // examples in the TS draft.
-CONCEPT_ASSERT(ranges::Boolean<bool>);
-CONCEPT_ASSERT(ranges::Boolean<std::true_type>);
-CONCEPT_ASSERT(ranges::Boolean<std::bitset<42>::reference>);
+CONCEPT_ASSERT(ranges::boolean<bool>);
+CONCEPT_ASSERT(ranges::boolean<std::true_type>);
+CONCEPT_ASSERT(ranges::boolean<std::bitset<42>::reference>);
 
-CONCEPT_ASSERT(ranges::Boolean<int>);
-CONCEPT_ASSERT(!ranges::Boolean<void*>);
+CONCEPT_ASSERT(ranges::boolean<int>);
+CONCEPT_ASSERT(!ranges::boolean<void*>);
 
 struct A {};
 struct B { operator bool() const; };
 
-CONCEPT_ASSERT(!ranges::Boolean<A>);
-CONCEPT_ASSERT(ranges::Boolean<B>);
+CONCEPT_ASSERT(!ranges::boolean<A>);
+CONCEPT_ASSERT(ranges::boolean<B>);
 }
 
 namespace equality_comparable_test {
@@ -48,27 +48,27 @@ struct A {
 	friend bool operator!=(const A&, const A&);
 };
 
-CONCEPT_ASSERT(ranges::EqualityComparable<int>);
-CONCEPT_ASSERT(ranges::EqualityComparable<A>);
-CONCEPT_ASSERT(!ranges::EqualityComparable<void>);
-CONCEPT_ASSERT(ranges::EqualityComparable<int&>);
-CONCEPT_ASSERT(ranges::EqualityComparable<std::nullptr_t>);
+CONCEPT_ASSERT(ranges::equality_comparable<int>);
+CONCEPT_ASSERT(ranges::equality_comparable<A>);
+CONCEPT_ASSERT(!ranges::equality_comparable<void>);
+CONCEPT_ASSERT(ranges::equality_comparable<int&>);
+CONCEPT_ASSERT(ranges::equality_comparable<std::nullptr_t>);
 
-CONCEPT_ASSERT(ranges::EqualityComparableWith<int, int>);
-CONCEPT_ASSERT(ranges::EqualityComparableWith<A, A>);
-CONCEPT_ASSERT(!ranges::EqualityComparableWith<void, void>);
-CONCEPT_ASSERT(ranges::EqualityComparableWith<int&, int>);
+CONCEPT_ASSERT(ranges::equality_comparable_with<int, int>);
+CONCEPT_ASSERT(ranges::equality_comparable_with<A, A>);
+CONCEPT_ASSERT(!ranges::equality_comparable_with<void, void>);
+CONCEPT_ASSERT(ranges::equality_comparable_with<int&, int>);
 } // namespace equality_comparable_test
 
-CONCEPT_ASSERT(ranges::StrictTotallyOrdered<int>);
-CONCEPT_ASSERT(ranges::StrictTotallyOrdered<float>);
-CONCEPT_ASSERT(!ranges::StrictTotallyOrdered<void>);
-CONCEPT_ASSERT(ranges::StrictTotallyOrdered<int&>);
+CONCEPT_ASSERT(ranges::totally_ordered<int>);
+CONCEPT_ASSERT(ranges::totally_ordered<float>);
+CONCEPT_ASSERT(!ranges::totally_ordered<void>);
+CONCEPT_ASSERT(ranges::totally_ordered<int&>);
 
-CONCEPT_ASSERT(ranges::StrictTotallyOrderedWith<int, int>);
-CONCEPT_ASSERT(ranges::StrictTotallyOrderedWith<int, double>);
-CONCEPT_ASSERT(!ranges::StrictTotallyOrderedWith<int, void>);
-CONCEPT_ASSERT(ranges::StrictTotallyOrderedWith<int&, int>);
+CONCEPT_ASSERT(ranges::totally_ordered_with<int, int>);
+CONCEPT_ASSERT(ranges::totally_ordered_with<int, double>);
+CONCEPT_ASSERT(!ranges::totally_ordered_with<int, void>);
+CONCEPT_ASSERT(ranges::totally_ordered_with<int&, int>);
 
 int main() {
 	return ::test_result();

--- a/test/concepts/core.cpp
+++ b/test/concepts/core.cpp
@@ -31,21 +31,21 @@ using __stl2::common_type_t;
 
 #include "../simple_test.hpp"
 
-CONCEPT_ASSERT(ranges::Same<int, int>);
-CONCEPT_ASSERT(ranges::Same<double, double>);
-CONCEPT_ASSERT(!ranges::Same<double, int>);
-CONCEPT_ASSERT(!ranges::Same<int, double>);
+CONCEPT_ASSERT(ranges::same_as<int, int>);
+CONCEPT_ASSERT(ranges::same_as<double, double>);
+CONCEPT_ASSERT(!ranges::same_as<double, int>);
+CONCEPT_ASSERT(!ranges::same_as<int, double>);
 
 #if VALIDATE_STL2
-// Test that `Same<A,B> && X` subsumes `Same<B,A>` (with reversed args).
+// Test that `same_as<A,B> && X` subsumes `same_as<B,A>` (with reversed args).
 template<class A, class B>
-  requires __stl2::Same<B, A>
+  requires __stl2::same_as<B, A>
 constexpr bool test_same() {
   return false;
 }
 
 template<class A, class B>
-  requires __stl2::Same<A, B> && __stl2::Integral<A>
+  requires __stl2::same_as<A, B> && __stl2::integral<A>
 constexpr bool test_same() {
   return true;
 }
@@ -58,38 +58,38 @@ namespace convertible_to_test {
 struct A {};
 struct B : A {};
 
-CONCEPT_ASSERT(ranges::ConvertibleTo<A, A>);
-CONCEPT_ASSERT(ranges::ConvertibleTo<B, B>);
-CONCEPT_ASSERT(!ranges::ConvertibleTo<A, B>);
-CONCEPT_ASSERT(ranges::ConvertibleTo<B, A>);
-CONCEPT_ASSERT(ranges::ConvertibleTo<int, double>);
-CONCEPT_ASSERT(ranges::ConvertibleTo<double, int>);
-CONCEPT_ASSERT(ranges::ConvertibleTo<void, void>);
+CONCEPT_ASSERT(ranges::convertible_to<A, A>);
+CONCEPT_ASSERT(ranges::convertible_to<B, B>);
+CONCEPT_ASSERT(!ranges::convertible_to<A, B>);
+CONCEPT_ASSERT(ranges::convertible_to<B, A>);
+CONCEPT_ASSERT(ranges::convertible_to<int, double>);
+CONCEPT_ASSERT(ranges::convertible_to<double, int>);
+CONCEPT_ASSERT(ranges::convertible_to<void, void>);
 }
 
 namespace common_test {
-CONCEPT_ASSERT(ranges::Same<ns::common_type_t<int, int>, int>);
-//CONCEPT_ASSERT(ranges::Same<ns::common_type_t<int, float, double>, double>);
+CONCEPT_ASSERT(ranges::same_as<ns::common_type_t<int, int>, int>);
+//CONCEPT_ASSERT(ranges::same_as<ns::common_type_t<int, float, double>, double>);
 
-CONCEPT_ASSERT(ranges::Common<int, int>);
-CONCEPT_ASSERT(ranges::Common<int, double>);
-CONCEPT_ASSERT(ranges::Common<double, int>);
-CONCEPT_ASSERT(ranges::Common<double, double>);
-CONCEPT_ASSERT(!ranges::Common<void, int>);
-CONCEPT_ASSERT(!ranges::Common<int*, int>);
-CONCEPT_ASSERT(ranges::Common<void*, int*>);
-CONCEPT_ASSERT(ranges::Common<double,long long>);
-CONCEPT_ASSERT(ranges::Common<void, void>);
-//CONCEPT_ASSERT(ranges::Common<int, float, double>);
-//CONCEPT_ASSERT(!ranges::Common<int, float, double, void>);
+CONCEPT_ASSERT(ranges::common_with<int, int>);
+CONCEPT_ASSERT(ranges::common_with<int, double>);
+CONCEPT_ASSERT(ranges::common_with<double, int>);
+CONCEPT_ASSERT(ranges::common_with<double, double>);
+CONCEPT_ASSERT(!ranges::common_with<void, int>);
+CONCEPT_ASSERT(!ranges::common_with<int*, int>);
+CONCEPT_ASSERT(ranges::common_with<void*, int*>);
+CONCEPT_ASSERT(ranges::common_with<double,long long>);
+CONCEPT_ASSERT(ranges::common_with<void, void>);
+//CONCEPT_ASSERT(ranges::common_with<int, float, double>);
+//CONCEPT_ASSERT(!ranges::common_with<int, float, double, void>);
 
 struct B {};
 struct C { C() = default; C(B) {} C(int) {} };
-CONCEPT_ASSERT(ranges::Common<B,C>);
-//CONCEPT_ASSERT(ranges::Common<int, C, B>);
+CONCEPT_ASSERT(ranges::common_with<B,C>);
+//CONCEPT_ASSERT(ranges::common_with<int, C, B>);
 
 struct incomplete;
-CONCEPT_ASSERT(ranges::Common<void*, incomplete*>);
+CONCEPT_ASSERT(ranges::common_with<void*, incomplete*>);
 }
 
 namespace {
@@ -106,7 +106,7 @@ result f(A) {
 	return result::exact;
 }
 
-template<__stl2::ConvertibleTo<A> T>
+template<__stl2::convertible_to<A> T>
 result f(T) {
 	std::cout << "Convertible to A\n";
 	return result::convertible;
@@ -126,15 +126,15 @@ result f(A) {
 }
 
 template<class, class, class = void>
-constexpr bool ConvertibleTo = false;
+constexpr bool convertible_to = false;
 template<class T, class U>
-constexpr bool ConvertibleTo<T, U, std::enable_if_t<
+constexpr bool convertible_to<T, U, std::enable_if_t<
 	std::is_convertible<T, U>::value,
 	decltype(static_cast<U>(std::declval<T>()))>> = true;
 
 template<class T>
 meta::if_c<
-	ConvertibleTo<T,A> &&
+	convertible_to<T,A> &&
 		!std::is_same<A,T>::value,
 	result>
 f(T) {
@@ -144,7 +144,7 @@ f(T) {
 
 template<class T>
 meta::if_c<
-	!(ConvertibleTo<T, A> ||
+	!(convertible_to<T, A> ||
 		std::is_same<A,T>::value),
 	result>
 f(T) {

--- a/test/concepts/fundamental.cpp
+++ b/test/concepts/fundamental.cpp
@@ -19,26 +19,26 @@
 #include <cstddef>
 #include "../simple_test.hpp"
 
-CONCEPT_ASSERT(ranges::Integral<int>);
-CONCEPT_ASSERT(!ranges::Integral<double>);
-CONCEPT_ASSERT(ranges::Integral<unsigned>);
-CONCEPT_ASSERT(!ranges::Integral<void>);
-CONCEPT_ASSERT(ranges::Integral<std::ptrdiff_t>);
-CONCEPT_ASSERT(ranges::Integral<std::size_t>);
+CONCEPT_ASSERT(ranges::integral<int>);
+CONCEPT_ASSERT(!ranges::integral<double>);
+CONCEPT_ASSERT(ranges::integral<unsigned>);
+CONCEPT_ASSERT(!ranges::integral<void>);
+CONCEPT_ASSERT(ranges::integral<std::ptrdiff_t>);
+CONCEPT_ASSERT(ranges::integral<std::size_t>);
 
-CONCEPT_ASSERT(ranges::SignedIntegral<int>);
-CONCEPT_ASSERT(!ranges::SignedIntegral<double>);
-CONCEPT_ASSERT(!ranges::SignedIntegral<unsigned>);
-CONCEPT_ASSERT(!ranges::SignedIntegral<void>);
-CONCEPT_ASSERT(ranges::SignedIntegral<std::ptrdiff_t>);
-CONCEPT_ASSERT(!ranges::SignedIntegral<std::size_t>);
+CONCEPT_ASSERT(ranges::signed_integral<int>);
+CONCEPT_ASSERT(!ranges::signed_integral<double>);
+CONCEPT_ASSERT(!ranges::signed_integral<unsigned>);
+CONCEPT_ASSERT(!ranges::signed_integral<void>);
+CONCEPT_ASSERT(ranges::signed_integral<std::ptrdiff_t>);
+CONCEPT_ASSERT(!ranges::signed_integral<std::size_t>);
 
-CONCEPT_ASSERT(!ranges::UnsignedIntegral<int>);
-CONCEPT_ASSERT(!ranges::UnsignedIntegral<double>);
-CONCEPT_ASSERT(ranges::UnsignedIntegral<unsigned>);
-CONCEPT_ASSERT(!ranges::UnsignedIntegral<void>);
-CONCEPT_ASSERT(!ranges::UnsignedIntegral<std::ptrdiff_t>);
-CONCEPT_ASSERT(ranges::UnsignedIntegral<std::size_t>);
+CONCEPT_ASSERT(!ranges::unsigned_integral<int>);
+CONCEPT_ASSERT(!ranges::unsigned_integral<double>);
+CONCEPT_ASSERT(ranges::unsigned_integral<unsigned>);
+CONCEPT_ASSERT(!ranges::unsigned_integral<void>);
+CONCEPT_ASSERT(!ranges::unsigned_integral<std::ptrdiff_t>);
+CONCEPT_ASSERT(ranges::unsigned_integral<std::size_t>);
 
 #if VALIDATE_STL2
 namespace scalar_types {
@@ -47,19 +47,19 @@ enum class t {
 	integral, signed_integral, unsigned_integral, ull
 };
 
-template<__stl2::Regular T>
+template<__stl2::regular T>
 constexpr t f(T) { return t::regular; }
 template<__stl2::ext::Scalar T>
 constexpr t f(T) { return t::scalar; }
 template<__stl2::ext::Arithmetic T>
 constexpr t f(T) { return t::arithmetic; }
-template<__stl2::ext::FloatingPoint T>
+template<__stl2::floating_point T>
 constexpr t f(T) { return t::floating_point; }
-template<__stl2::Integral T>
+template<__stl2::integral T>
 constexpr t f(T) { return t::integral; }
-template<__stl2::SignedIntegral T>
+template<__stl2::signed_integral T>
 constexpr t f(T) { return t::signed_integral; }
-template<__stl2::UnsignedIntegral T>
+template<__stl2::unsigned_integral T>
 constexpr t f(T) { return t::unsigned_integral; }
 constexpr t f(unsigned long long) { return t::ull; }
 

--- a/test/concepts/iterator.cpp
+++ b/test/concepts/iterator.cpp
@@ -69,47 +69,47 @@ namespace associated_type_test {
 	template<class T>
 	constexpr bool has_member_value_type<T, std::void_t<typename T::value_type>> = true;
 
-	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<int&, ns::iter_reference_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<const int&, ns::iter_reference_t<const int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int&, ns::iter_reference_t<int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int&, ns::iter_reference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::same_as<int&, ns::iter_reference_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::same_as<int&, ns::iter_reference_t<A>>);
+	CONCEPT_ASSERT(ranges::same_as<int&, ns::iter_reference_t<B>>);
+	CONCEPT_ASSERT(ranges::same_as<const int&, ns::iter_reference_t<const int*>>);
 
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<int&&, ns::iter_rvalue_reference_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<const int&&, ns::iter_rvalue_reference_t<const int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int&&, ns::iter_rvalue_reference_t<int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int&&, ns::iter_rvalue_reference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::same_as<int&&, ns::iter_rvalue_reference_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::same_as<int&&, ns::iter_rvalue_reference_t<A>>);
+	CONCEPT_ASSERT(ranges::same_as<int&&, ns::iter_rvalue_reference_t<B>>);
+	CONCEPT_ASSERT(ranges::same_as<const int&&, ns::iter_rvalue_reference_t<const int*>>);
 
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<int[4]>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<A>>);
-	CONCEPT_ASSERT(ranges::Same<double, ns::iter_value_t<B>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<int*>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<int[]>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<A>>);
+	CONCEPT_ASSERT(ranges::same_as<double, ns::iter_value_t<B>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<const int*>>);
 	CONCEPT_ASSERT(!has_member_value_type<ns::readable_traits<void>>);
 	CONCEPT_ASSERT(!has_member_value_type<ns::readable_traits<void*>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int* const>>);
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_value_t<const int[2]>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<const int* const>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_value_t<const int[2]>>);
 	struct S { using value_type = int; using element_type = int const; };
 	// ns::readable_traits<S> // ill-formed, hard error
 
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int*>>);
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int[]>>);
-	CONCEPT_ASSERT(ranges::Same<std::ptrdiff_t, ns::iter_difference_t<int[4]>>);
+	CONCEPT_ASSERT(ranges::same_as<std::ptrdiff_t, ns::iter_difference_t<int*>>);
+	CONCEPT_ASSERT(ranges::same_as<std::ptrdiff_t, ns::iter_difference_t<int[]>>);
+	CONCEPT_ASSERT(ranges::same_as<std::ptrdiff_t, ns::iter_difference_t<int[4]>>);
 
 	CONCEPT_ASSERT(!meta::is_trait<ns::incrementable_traits<void>>());
 	CONCEPT_ASSERT(!meta::is_trait<ns::incrementable_traits<void*>>());
 
-	CONCEPT_ASSERT(ranges::Same<int, ns::iter_difference_t<int>>);
+	CONCEPT_ASSERT(ranges::same_as<int, ns::iter_difference_t<int>>);
 #if VALIDATE_STL2
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<int*>, ns::contiguous_iterator_tag>);
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<const int*>, ns::contiguous_iterator_tag>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_category_t<int*>, ns::contiguous_iterator_tag>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_category_t<const int*>, ns::contiguous_iterator_tag>);
 #elif VALIDATE_RANGES
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<int*>, ns::random_access_iterator_tag>);
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_category_t<const int*>, ns::random_access_iterator_tag>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_category_t<int*>, ns::random_access_iterator_tag>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_category_t<const int*>, ns::random_access_iterator_tag>);
 #endif
 
 	template<class T>
@@ -172,7 +172,7 @@ namespace readable_test {
 	CONCEPT_ASSERT(ranges::Readable<int*>);
 	CONCEPT_ASSERT(ranges::Readable<const int*>);
 	CONCEPT_ASSERT(ranges::Readable<A>);
-	CONCEPT_ASSERT(ranges::Same<ns::iter_value_t<A>,int>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iter_value_t<A>,int>);
 
 	struct MoveOnlyReadable {
 		using value_type = std::unique_ptr<int>;
@@ -266,7 +266,7 @@ namespace indirectly_callable_test {
 namespace indirect_invoke_result_test {
 	template<class R, class... Args>
 	using fn_t = R(Args...);
-	CONCEPT_ASSERT(ranges::Same<ns::indirect_result_t<fn_t<void, int>&, const int*>, void>);
+	CONCEPT_ASSERT(ranges::same_as<ns::indirect_result_t<fn_t<void, int>&, const int*>, void>);
 }
 
 namespace contiguous_test {

--- a/test/concepts/object.cpp
+++ b/test/concepts/object.cpp
@@ -85,146 +85,146 @@ struct XXX
 	explicit XXX(int) {}
 };
 
-CONCEPT_ASSERT(ranges::Destructible<int>);
-CONCEPT_ASSERT(ranges::Destructible<const int>);
-CONCEPT_ASSERT(!ranges::Destructible<void>);
-CONCEPT_ASSERT(ranges::Destructible<int&>);
-CONCEPT_ASSERT(!ranges::Destructible<void()>);
-CONCEPT_ASSERT(ranges::Destructible<void(*)()>);
-CONCEPT_ASSERT(ranges::Destructible<void(&)()>);
-CONCEPT_ASSERT(!ranges::Destructible<int[]>);
-CONCEPT_ASSERT(ranges::Destructible<int[2]>);
-CONCEPT_ASSERT(ranges::Destructible<int(*)[2]>);
-CONCEPT_ASSERT(ranges::Destructible<int(&)[2]>);
-CONCEPT_ASSERT(ranges::Destructible<moveonly>);
-CONCEPT_ASSERT(ranges::Destructible<nonmovable>);
-CONCEPT_ASSERT(!ranges::Destructible<indestructible>);
-CONCEPT_ASSERT(!ranges::Destructible<throwing_destructor>);
+CONCEPT_ASSERT(ranges::destructible<int>);
+CONCEPT_ASSERT(ranges::destructible<const int>);
+CONCEPT_ASSERT(!ranges::destructible<void>);
+CONCEPT_ASSERT(ranges::destructible<int&>);
+CONCEPT_ASSERT(!ranges::destructible<void()>);
+CONCEPT_ASSERT(ranges::destructible<void(*)()>);
+CONCEPT_ASSERT(ranges::destructible<void(&)()>);
+CONCEPT_ASSERT(!ranges::destructible<int[]>);
+CONCEPT_ASSERT(ranges::destructible<int[2]>);
+CONCEPT_ASSERT(ranges::destructible<int(*)[2]>);
+CONCEPT_ASSERT(ranges::destructible<int(&)[2]>);
+CONCEPT_ASSERT(ranges::destructible<moveonly>);
+CONCEPT_ASSERT(ranges::destructible<nonmovable>);
+CONCEPT_ASSERT(!ranges::destructible<indestructible>);
+CONCEPT_ASSERT(!ranges::destructible<throwing_destructor>);
 
-CONCEPT_ASSERT(ranges::Constructible<int>);
-CONCEPT_ASSERT(ranges::Constructible<int const>);
-CONCEPT_ASSERT(!ranges::Constructible<int const&>);
-CONCEPT_ASSERT(!ranges::Constructible<int()>);
-CONCEPT_ASSERT(!ranges::Constructible<int(&)()>);
-CONCEPT_ASSERT(!ranges::Constructible<int[]>);
-CONCEPT_ASSERT(ranges::Constructible<int[5]>);
-CONCEPT_ASSERT(!ranges::Constructible<nondefaultconstructible>);
-CONCEPT_ASSERT(ranges::Constructible<int const(&)[5], int(&)[5]>);
-CONCEPT_ASSERT(!ranges::Constructible<int, int(&)[3]>);
+CONCEPT_ASSERT(ranges::constructible_from<int>);
+CONCEPT_ASSERT(ranges::constructible_from<int const>);
+CONCEPT_ASSERT(!ranges::constructible_from<int const&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int()>);
+CONCEPT_ASSERT(!ranges::constructible_from<int(&)()>);
+CONCEPT_ASSERT(!ranges::constructible_from<int[]>);
+CONCEPT_ASSERT(ranges::constructible_from<int[5]>);
+CONCEPT_ASSERT(!ranges::constructible_from<nondefaultconstructible>);
+CONCEPT_ASSERT(ranges::constructible_from<int const(&)[5], int(&)[5]>);
+CONCEPT_ASSERT(!ranges::constructible_from<int, int(&)[3]>);
 
-CONCEPT_ASSERT(ranges::Constructible<int, int>);
-CONCEPT_ASSERT(ranges::Constructible<int, int&>);
-CONCEPT_ASSERT(ranges::Constructible<int, int&&>);
-CONCEPT_ASSERT(ranges::Constructible<int, const int>);
-CONCEPT_ASSERT(ranges::Constructible<int, const int&>);
-CONCEPT_ASSERT(ranges::Constructible<int, const int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<int, int>);
+CONCEPT_ASSERT(ranges::constructible_from<int, int&>);
+CONCEPT_ASSERT(ranges::constructible_from<int, int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<int, const int>);
+CONCEPT_ASSERT(ranges::constructible_from<int, const int&>);
+CONCEPT_ASSERT(ranges::constructible_from<int, const int&&>);
 
-CONCEPT_ASSERT(ranges::Constructible<copyable, copyable>);
-CONCEPT_ASSERT(ranges::Constructible<copyable, copyable&>);
-CONCEPT_ASSERT(ranges::Constructible<copyable, copyable&&>);
-CONCEPT_ASSERT(ranges::Constructible<copyable, const copyable>);
-CONCEPT_ASSERT(ranges::Constructible<copyable, const copyable&>);
-CONCEPT_ASSERT(ranges::Constructible<copyable, const copyable&&>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, copyable>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, copyable&>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, copyable&&>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, const copyable>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, const copyable&>);
+CONCEPT_ASSERT(ranges::constructible_from<copyable, const copyable&&>);
 
-CONCEPT_ASSERT(!ranges::Constructible<int&, int>);
-CONCEPT_ASSERT(ranges::Constructible<int&, int&>);
-CONCEPT_ASSERT(!ranges::Constructible<int&, int&&>);
-CONCEPT_ASSERT(!ranges::Constructible<int&, const int>);
-CONCEPT_ASSERT(!ranges::Constructible<int&, const int&>);
-CONCEPT_ASSERT(!ranges::Constructible<int&, const int&&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, int>);
+CONCEPT_ASSERT(ranges::constructible_from<int&, int&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, int&&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, const int>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, const int&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, const int&&>);
 
-CONCEPT_ASSERT(ranges::Constructible<const int&, int>);
-CONCEPT_ASSERT(ranges::Constructible<const int&, int&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&, int&&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&, const int>);
-CONCEPT_ASSERT(ranges::Constructible<const int&, const int&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&, const int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, int>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, int&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, const int>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, const int&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&, const int&&>);
 
-CONCEPT_ASSERT(ranges::Constructible<int&&, int>);
-CONCEPT_ASSERT(!ranges::Constructible<int&&, int&>);
-CONCEPT_ASSERT(ranges::Constructible<int&&, int&&>);
-CONCEPT_ASSERT(!ranges::Constructible<int&&, const int>);
-CONCEPT_ASSERT(!ranges::Constructible<int&&, const int&>);
-CONCEPT_ASSERT(!ranges::Constructible<int&&, const int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<int&&, int>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&&, int&>);
+CONCEPT_ASSERT(ranges::constructible_from<int&&, int&&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&&, const int>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&&, const int&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&&, const int&&>);
 
-CONCEPT_ASSERT(ranges::Constructible<const int&&, int>);
-CONCEPT_ASSERT(!ranges::Constructible<const int&&, int&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&&, int&&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&&, const int>);
-CONCEPT_ASSERT(!ranges::Constructible<const int&&, const int&>);
-CONCEPT_ASSERT(ranges::Constructible<const int&&, const int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&&, int>);
+CONCEPT_ASSERT(!ranges::constructible_from<const int&&, int&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&&, int&&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&&, const int>);
+CONCEPT_ASSERT(!ranges::constructible_from<const int&&, const int&>);
+CONCEPT_ASSERT(ranges::constructible_from<const int&&, const int&&>);
 
-CONCEPT_ASSERT(ranges::Constructible<XXX, int>);
+CONCEPT_ASSERT(ranges::constructible_from<XXX, int>);
 
-CONCEPT_ASSERT(ranges::DefaultConstructible<int>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<int const>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<int&>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<int const&>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<int()>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<int(&)()>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<double>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<void>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<int[]>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<int[2]>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<nondefaultconstructible>);
+CONCEPT_ASSERT(ranges::default_initializable<int>);
+CONCEPT_ASSERT(ranges::default_initializable<int const>);
+CONCEPT_ASSERT(!ranges::default_initializable<int&>);
+CONCEPT_ASSERT(!ranges::default_initializable<int const&>);
+CONCEPT_ASSERT(!ranges::default_initializable<int()>);
+CONCEPT_ASSERT(!ranges::default_initializable<int(&)()>);
+CONCEPT_ASSERT(ranges::default_initializable<double>);
+CONCEPT_ASSERT(!ranges::default_initializable<void>);
+CONCEPT_ASSERT(!ranges::default_initializable<int[]>);
+CONCEPT_ASSERT(ranges::default_initializable<int[2]>);
+CONCEPT_ASSERT(!ranges::default_initializable<nondefaultconstructible>);
 
 namespace pathological_explicit_default_constructor {
 	struct S0 { explicit S0() = default; };
 	struct S1 { S0 x; };
 #if STL2_WORKAROUND_GCC_UNKNOWN0
-	CONCEPT_ASSERT(ranges::DefaultConstructible<S1>);
+	CONCEPT_ASSERT(ranges::default_initializable<S1>);
 #else // ^^^ workaround / no workaround vvv
-	CONCEPT_ASSERT(!ranges::DefaultConstructible<S1>);
+	CONCEPT_ASSERT(!ranges::default_initializable<S1>);
 #endif // STL2_WORKAROUND_GCC_UNKNOWN0
 }
 
-CONCEPT_ASSERT(ranges::DefaultConstructible<explicit_move>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<explicit_copy>);
-CONCEPT_ASSERT(!ranges::DefaultConstructible<deleted_default>);
+CONCEPT_ASSERT(ranges::default_initializable<explicit_move>);
+CONCEPT_ASSERT(ranges::default_initializable<explicit_copy>);
+CONCEPT_ASSERT(!ranges::default_initializable<deleted_default>);
 
-CONCEPT_ASSERT(!ranges::MoveConstructible<void>);
-CONCEPT_ASSERT(ranges::MoveConstructible<int>);
-CONCEPT_ASSERT(ranges::MoveConstructible<const int>);
-CONCEPT_ASSERT(!ranges::MoveConstructible<int[4]>);
-CONCEPT_ASSERT(!ranges::MoveConstructible<void()>);
-CONCEPT_ASSERT(ranges::MoveConstructible<int &>);
-CONCEPT_ASSERT(ranges::MoveConstructible<int &&>);
-CONCEPT_ASSERT(ranges::MoveConstructible<const int &>);
-CONCEPT_ASSERT(ranges::MoveConstructible<const int &&>);
+CONCEPT_ASSERT(!ranges::move_constructible<void>);
+CONCEPT_ASSERT(ranges::move_constructible<int>);
+CONCEPT_ASSERT(ranges::move_constructible<const int>);
+CONCEPT_ASSERT(!ranges::move_constructible<int[4]>);
+CONCEPT_ASSERT(!ranges::move_constructible<void()>);
+CONCEPT_ASSERT(ranges::move_constructible<int &>);
+CONCEPT_ASSERT(ranges::move_constructible<int &&>);
+CONCEPT_ASSERT(ranges::move_constructible<const int &>);
+CONCEPT_ASSERT(ranges::move_constructible<const int &&>);
 
-CONCEPT_ASSERT(ranges::Constructible<moveonly, moveonly>);
-CONCEPT_ASSERT(ranges::MoveConstructible<copyable>);
-CONCEPT_ASSERT(ranges::MoveConstructible<moveonly>);
-CONCEPT_ASSERT(!ranges::MoveConstructible<nonmovable>);
-CONCEPT_ASSERT(!ranges::MoveConstructible<copyonly>);
-CONCEPT_ASSERT(!ranges::MoveConstructible<explicit_move>);
-CONCEPT_ASSERT(ranges::MoveConstructible<explicit_copy>);
+CONCEPT_ASSERT(ranges::constructible_from<moveonly, moveonly>);
+CONCEPT_ASSERT(ranges::move_constructible<copyable>);
+CONCEPT_ASSERT(ranges::move_constructible<moveonly>);
+CONCEPT_ASSERT(!ranges::move_constructible<nonmovable>);
+CONCEPT_ASSERT(!ranges::move_constructible<copyonly>);
+CONCEPT_ASSERT(!ranges::move_constructible<explicit_move>);
+CONCEPT_ASSERT(ranges::move_constructible<explicit_copy>);
 
-CONCEPT_ASSERT(ranges::MoveConstructible<nonmovable &>);
-CONCEPT_ASSERT(ranges::MoveConstructible<nonmovable &&>);
-CONCEPT_ASSERT(ranges::MoveConstructible<const nonmovable &>);
-CONCEPT_ASSERT(ranges::MoveConstructible<const nonmovable &&>);
+CONCEPT_ASSERT(ranges::move_constructible<nonmovable &>);
+CONCEPT_ASSERT(ranges::move_constructible<nonmovable &&>);
+CONCEPT_ASSERT(ranges::move_constructible<const nonmovable &>);
+CONCEPT_ASSERT(ranges::move_constructible<const nonmovable &&>);
 
-CONCEPT_ASSERT(!ranges::CopyConstructible<void>);
-CONCEPT_ASSERT(ranges::CopyConstructible<int>);
-CONCEPT_ASSERT(ranges::CopyConstructible<const int>);
-CONCEPT_ASSERT(ranges::CopyConstructible<int&>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<int&&>);
-CONCEPT_ASSERT(ranges::CopyConstructible<const int&>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<const int&&>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<int[4]>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<void()>);
+CONCEPT_ASSERT(!ranges::copy_constructible<void>);
+CONCEPT_ASSERT(ranges::copy_constructible<int>);
+CONCEPT_ASSERT(ranges::copy_constructible<const int>);
+CONCEPT_ASSERT(ranges::copy_constructible<int&>);
+CONCEPT_ASSERT(!ranges::copy_constructible<int&&>);
+CONCEPT_ASSERT(ranges::copy_constructible<const int&>);
+CONCEPT_ASSERT(!ranges::copy_constructible<const int&&>);
+CONCEPT_ASSERT(!ranges::copy_constructible<int[4]>);
+CONCEPT_ASSERT(!ranges::copy_constructible<void()>);
 
-CONCEPT_ASSERT(ranges::CopyConstructible<copyable>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<moveonly>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<nonmovable>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<copyonly>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<explicit_move>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<explicit_copy>);
-CONCEPT_ASSERT(ranges::CopyConstructible<nonmovable &>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<nonmovable &&>);
-CONCEPT_ASSERT(ranges::CopyConstructible<const nonmovable &>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<const nonmovable &&>);
+CONCEPT_ASSERT(ranges::copy_constructible<copyable>);
+CONCEPT_ASSERT(!ranges::copy_constructible<moveonly>);
+CONCEPT_ASSERT(!ranges::copy_constructible<nonmovable>);
+CONCEPT_ASSERT(!ranges::copy_constructible<copyonly>);
+CONCEPT_ASSERT(!ranges::copy_constructible<explicit_move>);
+CONCEPT_ASSERT(!ranges::copy_constructible<explicit_copy>);
+CONCEPT_ASSERT(ranges::copy_constructible<nonmovable &>);
+CONCEPT_ASSERT(!ranges::copy_constructible<nonmovable &&>);
+CONCEPT_ASSERT(ranges::copy_constructible<const nonmovable &>);
+CONCEPT_ASSERT(!ranges::copy_constructible<const nonmovable &&>);
 
 // https://github.com/ericniebler/stl2/issues/301
 struct not_mutable_ref {
@@ -239,63 +239,63 @@ struct not_const_ref_ref {
 	not_const_ref_ref(not_const_ref_ref&&) = default;
 	not_const_ref_ref(const not_const_ref_ref&&) = delete;
 };
-CONCEPT_ASSERT(!ranges::CopyConstructible<not_mutable_ref>);
-CONCEPT_ASSERT(!ranges::CopyConstructible<not_const_ref_ref>);
+CONCEPT_ASSERT(!ranges::copy_constructible<not_mutable_ref>);
+CONCEPT_ASSERT(!ranges::copy_constructible<not_const_ref_ref>);
 
-CONCEPT_ASSERT(ranges::Movable<int>);
-CONCEPT_ASSERT(!ranges::Movable<const int>);
-CONCEPT_ASSERT(ranges::Movable<double>);
-CONCEPT_ASSERT(!ranges::Movable<void>);
-CONCEPT_ASSERT(ranges::Movable<copyable>);
-CONCEPT_ASSERT(ranges::Movable<moveonly>);
-CONCEPT_ASSERT(!ranges::Movable<nonmovable>);
-CONCEPT_ASSERT(!ranges::Movable<copyonly>);
+CONCEPT_ASSERT(ranges::movable<int>);
+CONCEPT_ASSERT(!ranges::movable<const int>);
+CONCEPT_ASSERT(ranges::movable<double>);
+CONCEPT_ASSERT(!ranges::movable<void>);
+CONCEPT_ASSERT(ranges::movable<copyable>);
+CONCEPT_ASSERT(ranges::movable<moveonly>);
+CONCEPT_ASSERT(!ranges::movable<nonmovable>);
+CONCEPT_ASSERT(!ranges::movable<copyonly>);
 
-CONCEPT_ASSERT(ranges::Copyable<int>);
-CONCEPT_ASSERT(!ranges::Copyable<const int>);
-CONCEPT_ASSERT(ranges::Copyable<double>);
-CONCEPT_ASSERT(!ranges::Copyable<void>);
-CONCEPT_ASSERT(ranges::Copyable<copyable>);
-CONCEPT_ASSERT(!ranges::Copyable<moveonly>);
-CONCEPT_ASSERT(!ranges::Copyable<nonmovable>);
-CONCEPT_ASSERT(!ranges::Copyable<copyonly>);
+CONCEPT_ASSERT(ranges::copyable<int>);
+CONCEPT_ASSERT(!ranges::copyable<const int>);
+CONCEPT_ASSERT(ranges::copyable<double>);
+CONCEPT_ASSERT(!ranges::copyable<void>);
+CONCEPT_ASSERT(ranges::copyable<copyable>);
+CONCEPT_ASSERT(!ranges::copyable<moveonly>);
+CONCEPT_ASSERT(!ranges::copyable<nonmovable>);
+CONCEPT_ASSERT(!ranges::copyable<copyonly>);
 
-CONCEPT_ASSERT(ranges::Semiregular<int>);
-CONCEPT_ASSERT(ranges::Semiregular<double>);
-CONCEPT_ASSERT(!ranges::Semiregular<void>);
-CONCEPT_ASSERT(!ranges::Semiregular<int&>);
-CONCEPT_ASSERT(ranges::Semiregular<semiregular>);
-CONCEPT_ASSERT(ranges::Semiregular<regular>);
-CONCEPT_ASSERT(ranges::Semiregular<copyable>);
-CONCEPT_ASSERT(!ranges::Semiregular<moveonly>);
-CONCEPT_ASSERT(!ranges::Semiregular<nonmovable>);
-CONCEPT_ASSERT(!ranges::Semiregular<copyonly>);
-CONCEPT_ASSERT(!ranges::Semiregular<explicit_move>);
-CONCEPT_ASSERT(!ranges::Semiregular<explicit_copy>);
+CONCEPT_ASSERT(ranges::semiregular<int>);
+CONCEPT_ASSERT(ranges::semiregular<double>);
+CONCEPT_ASSERT(!ranges::semiregular<void>);
+CONCEPT_ASSERT(!ranges::semiregular<int&>);
+CONCEPT_ASSERT(ranges::semiregular<semiregular>);
+CONCEPT_ASSERT(ranges::semiregular<regular>);
+CONCEPT_ASSERT(ranges::semiregular<copyable>);
+CONCEPT_ASSERT(!ranges::semiregular<moveonly>);
+CONCEPT_ASSERT(!ranges::semiregular<nonmovable>);
+CONCEPT_ASSERT(!ranges::semiregular<copyonly>);
+CONCEPT_ASSERT(!ranges::semiregular<explicit_move>);
+CONCEPT_ASSERT(!ranges::semiregular<explicit_copy>);
 
-CONCEPT_ASSERT(ranges::Regular<int>);
-CONCEPT_ASSERT(ranges::Regular<double>);
-CONCEPT_ASSERT(!ranges::Regular<void>);
-CONCEPT_ASSERT(!ranges::Regular<int&>);
-CONCEPT_ASSERT(!ranges::Regular<semiregular>);
-CONCEPT_ASSERT(ranges::Regular<regular>);
-CONCEPT_ASSERT(!ranges::Regular<copyable>);
-CONCEPT_ASSERT(!ranges::Regular<moveonly>);
-CONCEPT_ASSERT(!ranges::Regular<nonmovable>);
-CONCEPT_ASSERT(!ranges::Regular<copyonly>);
-CONCEPT_ASSERT(!ranges::Regular<explicit_move>);
-CONCEPT_ASSERT(!ranges::Regular<explicit_copy>);
+CONCEPT_ASSERT(ranges::regular<int>);
+CONCEPT_ASSERT(ranges::regular<double>);
+CONCEPT_ASSERT(!ranges::regular<void>);
+CONCEPT_ASSERT(!ranges::regular<int&>);
+CONCEPT_ASSERT(!ranges::regular<semiregular>);
+CONCEPT_ASSERT(ranges::regular<regular>);
+CONCEPT_ASSERT(!ranges::regular<copyable>);
+CONCEPT_ASSERT(!ranges::regular<moveonly>);
+CONCEPT_ASSERT(!ranges::regular<nonmovable>);
+CONCEPT_ASSERT(!ranges::regular<copyonly>);
+CONCEPT_ASSERT(!ranges::regular<explicit_move>);
+CONCEPT_ASSERT(!ranges::regular<explicit_copy>);
 
-CONCEPT_ASSERT(ranges::Constructible<std::initializer_list<int>>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<std::initializer_list<int>>);
+CONCEPT_ASSERT(ranges::constructible_from<std::initializer_list<int>>);
+CONCEPT_ASSERT(ranges::default_initializable<std::initializer_list<int>>);
 
-CONCEPT_ASSERT(ranges::Constructible<int*>);
-CONCEPT_ASSERT(ranges::DefaultConstructible<int*>);
+CONCEPT_ASSERT(ranges::constructible_from<int*>);
+CONCEPT_ASSERT(ranges::default_initializable<int*>);
 
 // https://github.com/ericniebler/stl2/issues/301
-CONCEPT_ASSERT(!ranges::Constructible<int&, long&>);
+CONCEPT_ASSERT(!ranges::constructible_from<int&, long&>);
 
 // https://github.com/ericniebler/stl2/issues/310
-CONCEPT_ASSERT(!ranges::Movable<int&&>);
+CONCEPT_ASSERT(!ranges::movable<int&&>);
 
 int main() {}

--- a/test/concepts/range.cpp
+++ b/test/concepts/range.cpp
@@ -161,72 +161,72 @@ void ridiculously_exhaustive_range_property_test() {
 	CONCEPT_ASSERT(ranges::Iterator<I>);
 	CONCEPT_ASSERT(ranges::Iterator<CI>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<int[2]>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<int[2]>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<int[2]>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<int[2]>, I>);
 	CONCEPT_ASSERT(ranges::Range<int[2]>);
 	CONCEPT_ASSERT(ranges::SizedRange<int[2]>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<int[2]>);
 	CONCEPT_ASSERT(!ranges::View<int[2]>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<int(&)[2]>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<int(&)[2]>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<int(&)[2]>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<int(&)[2]>, I>);
 	CONCEPT_ASSERT(ranges::Range<int(&)[2]>);
 	CONCEPT_ASSERT(ranges::SizedRange<int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::View<int(&)[2]>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const int[2]>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const int[2]>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const int[2]>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const int[2]>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const int[2]>);
 	CONCEPT_ASSERT(ranges::SizedRange<const int[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const int[2]>);
 	CONCEPT_ASSERT(!ranges::View<const int[2]>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const int(&)[2]>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const int(&)[2]>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const int(&)[2]>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const int(&)[2]>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const int(&)[2]>);
 	CONCEPT_ASSERT(ranges::SizedRange<const int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::View<const int(&)[2]>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_unsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_unsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_unsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_unsized_range>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::View<mutable_unsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_unsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_unsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_unsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_unsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::View<mutable_unsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<const mutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_unsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<const mutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_unsized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_no_size_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_no_size_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_no_size_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_no_size_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_no_size_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_no_size_range>);
 	CONCEPT_ASSERT(ranges::View<mutable_only_no_size_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_no_size_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_no_size_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_no_size_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_no_size_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_no_size_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_no_size_range&>);
@@ -243,73 +243,73 @@ void ridiculously_exhaustive_range_property_test() {
 	CONCEPT_ASSERT(!ranges::View<const mutable_only_no_size_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<immutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::View<immutable_unsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<immutable_unsized_range&>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_unsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<const immutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_unsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_unsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<const immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_unsized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_sized_range>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_sized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_sized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_sized_range>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_sized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_sized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::View<mutable_sized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_sized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_sized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_sized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_sized_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_sized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::View<mutable_sized_range&>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_sized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<const mutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_sized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_sized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<const mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_sized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_sized_range>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_sized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_sized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_sized_range>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_sized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_sized_range>);
 	CONCEPT_ASSERT(ranges::View<mutable_only_sized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_sized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_sized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_sized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_sized_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_sized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_sized_range&>);
@@ -326,73 +326,73 @@ void ridiculously_exhaustive_range_property_test() {
 	CONCEPT_ASSERT(!ranges::View<const mutable_only_sized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_sized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<immutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_sized_range>);
 	CONCEPT_ASSERT(ranges::View<immutable_sized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_sized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::View<immutable_sized_range&>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_sized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_sized_range>);
 	CONCEPT_ASSERT(ranges::SizedRange<const immutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_sized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_sized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_sized_range&>);
 	CONCEPT_ASSERT(ranges::SizedRange<const immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_sized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_badsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_badsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_badsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_badsized_range>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::SizedRange<mutable_badsized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::View<mutable_badsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_badsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_badsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_badsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_badsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::SizedRange<mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<mutable_badsized_range&>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_badsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const mutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const mutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const mutable_badsized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_badsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_badsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_badsized_range>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_badsized_range>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_badsized_range>);
 	CONCEPT_ASSERT(!ranges::SizedRange<mutable_only_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_badsized_range>);
 	CONCEPT_ASSERT(ranges::View<mutable_only_badsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<mutable_only_badsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<mutable_only_badsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_badsized_range&>, I>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_badsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::Range<mutable_only_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::SizedRange<mutable_only_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_badsized_range&>);
@@ -409,37 +409,37 @@ void ridiculously_exhaustive_range_property_test() {
 	CONCEPT_ASSERT(!ranges::View<const mutable_only_badsized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::SizedRange<immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_badsized_range>);
 	CONCEPT_ASSERT(ranges::View<immutable_badsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<immutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<immutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::SizedRange<immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<immutable_badsized_range&>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_badsized_range>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::SizedRange<const immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_badsized_range>);
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<const immutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<const immutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_badsized_range&>, CI>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::Range<const immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::SizedRange<const immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::View<const immutable_badsized_range&>);
 
 
-	CONCEPT_ASSERT(ranges::Same<ns::iterator_t<std::vector<int>>, std::vector<int>::iterator>);
-	CONCEPT_ASSERT(ranges::Same<ns::sentinel_t<std::vector<int>>, std::vector<int>::iterator>);
+	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<std::vector<int>>, std::vector<int>::iterator>);
+	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<std::vector<int>>, std::vector<int>::iterator>);
 	CONCEPT_ASSERT(ranges::Range<std::vector<int>>);
 	CONCEPT_ASSERT(ranges::SizedRange<std::vector<int>>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<std::vector<int>>);

--- a/test/concepts/swap.cpp
+++ b/test/concepts/swap.cpp
@@ -29,15 +29,15 @@ using ranges::ext::is_nothrow_swappable_v;
 using namespace ranges;
 
 namespace swappable_test {
-	CONCEPT_ASSERT(Swappable<int>);
-	CONCEPT_ASSERT(SwappableWith<int&, int&>);
-	CONCEPT_ASSERT(Swappable<int[4]>);
-	CONCEPT_ASSERT(SwappableWith<int(&)[4], int(&)[4]>);
-	CONCEPT_ASSERT(!SwappableWith<int, int>);
-	CONCEPT_ASSERT(!SwappableWith<int&, double&>);
-	CONCEPT_ASSERT(!SwappableWith<int(&)[4], bool(&)[4]>);
-	CONCEPT_ASSERT(!Swappable<int[]>);
-	CONCEPT_ASSERT(!Swappable<int[][4]>);
+	CONCEPT_ASSERT(swappable<int>);
+	CONCEPT_ASSERT(swappable_with<int&, int&>);
+	CONCEPT_ASSERT(swappable<int[4]>);
+	CONCEPT_ASSERT(swappable_with<int(&)[4], int(&)[4]>);
+	CONCEPT_ASSERT(!swappable_with<int, int>);
+	CONCEPT_ASSERT(!swappable_with<int&, double&>);
+	CONCEPT_ASSERT(!swappable_with<int(&)[4], bool(&)[4]>);
+	CONCEPT_ASSERT(!swappable<int[]>);
+	CONCEPT_ASSERT(!swappable<int[][4]>);
 
 	CONCEPT_ASSERT(noexcept(swap(std::declval<int&>(), std::declval<int&>())));
 	CONCEPT_ASSERT(is_nothrow_swappable_v<int&, int&>);
@@ -45,11 +45,11 @@ namespace swappable_test {
 
 #if VALIDATE_STL2
 	// range-v3 doesn't support swapping multidimensional arrays
-	CONCEPT_ASSERT(Swappable<int[3][4]>);
-	CONCEPT_ASSERT(SwappableWith<int(&)[3][4], int(&)[3][4]>);
-	CONCEPT_ASSERT(Swappable<int[3][4][1][2]>);
-	CONCEPT_ASSERT(SwappableWith<int(&)[3][4][1][2], int(&)[3][4][1][2]>);
-	CONCEPT_ASSERT(!SwappableWith<int(&)[3][4][1][2], int(&)[4][4][1][2]>);
+	CONCEPT_ASSERT(swappable<int[3][4]>);
+	CONCEPT_ASSERT(swappable_with<int(&)[3][4], int(&)[3][4]>);
+	CONCEPT_ASSERT(swappable<int[3][4][1][2]>);
+	CONCEPT_ASSERT(swappable_with<int(&)[3][4][1][2], int(&)[3][4][1][2]>);
+	CONCEPT_ASSERT(!swappable_with<int(&)[3][4][1][2], int(&)[4][4][1][2]>);
 	CONCEPT_ASSERT(is_nothrow_swappable_v<int(&)[6][7], int(&)[6][7]>);
 
 	struct unswappable : std::string { // Has std:: as an associated namespace
@@ -57,7 +57,7 @@ namespace swappable_test {
 		unswappable(const unswappable&) = delete;
 		unswappable(unswappable&&) = delete;
 	};
-	CONCEPT_ASSERT(!SwappableWith<unswappable&, unswappable&>);
+	CONCEPT_ASSERT(!swappable_with<unswappable&, unswappable&>);
 	namespace __constrained_swappable {
 		// Has a constrained swap findable via ADL:
 		struct constrained_swappable {
@@ -66,15 +66,15 @@ namespace swappable_test {
 			constrained_swappable(constrained_swappable&&) = default;
 		};
 		template<class T>
-		META_CONCEPT ConstrainedSwappable = Same<T, constrained_swappable>;
+		META_CONCEPT ConstrainedSwappable = same_as<T, constrained_swappable>;
 		template<ConstrainedSwappable T, ConstrainedSwappable U>
 		void swap(T&, U&) {}
 		template<ConstrainedSwappable T>
 		void swap(T &, T &) {}
 	}
 	using __constrained_swappable::constrained_swappable;
-	CONCEPT_ASSERT(SwappableWith<constrained_swappable&, constrained_swappable&>);
-	CONCEPT_ASSERT(!SwappableWith<const volatile constrained_swappable&, const volatile constrained_swappable&>);
+	CONCEPT_ASSERT(swappable_with<constrained_swappable&, constrained_swappable&>);
+	CONCEPT_ASSERT(!swappable_with<const volatile constrained_swappable&, const volatile constrained_swappable&>);
 #endif
 
 	namespace {
@@ -85,7 +85,7 @@ namespace swappable_test {
 			friend void swap(A&, A&) noexcept {}
 		};
 
-		CONCEPT_ASSERT(Swappable<A>);
+		CONCEPT_ASSERT(swappable<A>);
 		CONCEPT_ASSERT(noexcept(swap(std::declval<A&>(), std::declval<A&>())));
 		CONCEPT_ASSERT(is_nothrow_swappable_v<A&, A&>);
 	}
@@ -95,7 +95,7 @@ namespace swappable_test {
 			friend void swap(B&, B&) {}
 		};
 
-		CONCEPT_ASSERT(Swappable<B>);
+		CONCEPT_ASSERT(swappable<B>);
 		CONCEPT_ASSERT(!noexcept(swap(std::declval<B&>(), std::declval<B&>())));
 		CONCEPT_ASSERT(!is_nothrow_swappable_v<B&, B&>);
 	}
@@ -103,12 +103,12 @@ namespace swappable_test {
 
 #if VALIDATE_STL2
 namespace example {
-	template<class T, ranges::SwappableWith<T> U>
+	template<class T, ranges::swappable_with<T> U>
 	void value_swap(T&& t, U&& u) {
 		ranges::swap(std::forward<T>(t), std::forward<U>(u));
 	}
 
-	template<ranges::Swappable T>
+	template<ranges::swappable T>
 	void lv_swap(T& t1, T& t2) {
 		ranges::swap(t1, t2);
 	}
@@ -163,7 +163,7 @@ int main() {
 		int a[2][2] = {{0, 1}, {2, 3}};
 		int b[2][2] = {{4, 5}, {6, 7}};
 
-		CONCEPT_ASSERT(SwappableWith<decltype((a)),decltype((b))>);
+		CONCEPT_ASSERT(swappable_with<decltype((a)),decltype((b))>);
 		swap(a, b);
 		CONCEPT_ASSERT(noexcept(swap(a, b)));
 

--- a/test/detail/raw_ptr.cpp
+++ b/test/detail/raw_ptr.cpp
@@ -24,10 +24,10 @@ int main() {
 	using RA = raw_ptr<A>;
 	using RB = raw_ptr<B>;
 
-	static_assert(ranges::Regular<RA>);
-	static_assert(ranges::StrictTotallyOrdered<RA>);
-	static_assert(ranges::Regular<RB>);
-	static_assert(ranges::StrictTotallyOrdered<RB>);
+	static_assert(ranges::regular<RA>);
+	static_assert(ranges::totally_ordered<RA>);
+	static_assert(ranges::regular<RB>);
+	static_assert(ranges::totally_ordered<RB>);
 
 	CHECK(RA{} == RA{});
 	CHECK(!(RA{} != RA{}));

--- a/test/functional/invoke.cpp
+++ b/test/functional/invoke.cpp
@@ -15,7 +15,7 @@
 
 namespace ranges = __stl2;
 
-static_assert(ranges::Copyable<ranges::reference_wrapper<int>>);
+static_assert(ranges::copyable<ranges::reference_wrapper<int>>);
 
 constexpr struct {
 	template<class T>
@@ -99,8 +99,8 @@ int main() {
 		CHECK(a.i == 0);
 		ranges::invoke(&A::i, &a) = 1;
 		CHECK(a.i == 1);
-		static_assert(ranges::Same<decltype(ranges::invoke(&A::i, ca)), const int&>);
-		static_assert(ranges::Same<decltype(ranges::invoke(&A::i, &ca)), const int&>);
+		static_assert(ranges::same_as<decltype(ranges::invoke(&A::i, ca)), const int&>);
+		static_assert(ranges::same_as<decltype(ranges::invoke(&A::i, &ca)), const int&>);
 	}
 
 	{

--- a/test/functional/not_fn.cpp
+++ b/test/functional/not_fn.cpp
@@ -18,7 +18,7 @@
 namespace stl2 = __stl2;
 
 constexpr struct {
-	template<stl2::Integral T>
+	template<stl2::integral T>
 	constexpr bool operator()(T i) const {
 		return i % 2 != 0;
 	}

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -12,14 +12,14 @@ namespace ranges = __stl2;
 
 template<class> class show_type;
 
-template<ranges::Destructible T>
+template<ranges::destructible T>
 class forward_list {
 	struct node {
 		std::unique_ptr<node> next_;
 		T data_;
 
 		template<class... Args>
-		requires ranges::Constructible<T, Args...>
+		requires ranges::constructible_from<T, Args...>
 		constexpr node(Args&&... args)
 		noexcept(std::is_nothrow_constructible<T, Args...>::value)
 		: data_(std::forward<Args>(args)...) {}
@@ -71,7 +71,7 @@ public:
 
 	forward_list() = default;
 	forward_list(std::initializer_list<T> il)
-	requires ranges::CopyConstructible<T>
+	requires ranges::copy_constructible<T>
 	{ ranges::reverse_copy(il, ranges::front_inserter(*this)); }
 
 	constexpr iterator begin() noexcept {
@@ -83,7 +83,7 @@ public:
 	constexpr ranges::default_sentinel end() const noexcept { return {}; }
 
 	template<class... Args>
-	requires ranges::Constructible<T, Args...>
+	requires ranges::constructible_from<T, Args...>
 	void emplace(Args&&... args) {
 		auto p = std::make_unique<node>(std::forward<Args>(args)...);
 		p->next_ = std::move(head_);
@@ -91,10 +91,10 @@ public:
 	}
 
 	void push_front(T&& t)
-	requires ranges::MoveConstructible<T>
+	requires ranges::move_constructible<T>
 	{ emplace(std::move(t)); }
 	void push_front(const T& t)
-	requires ranges::CopyConstructible<T>
+	requires ranges::copy_constructible<T>
 	{ emplace(t); }
 };
 
@@ -117,7 +117,7 @@ public:
 	: ptr_{ptr} {}
 
 	template<class U>
-	requires ranges::ConvertibleTo<U*, T*>
+	requires ranges::convertible_to<U*, T*>
 	constexpr pointer_cursor(const pointer_cursor<U>& that) noexcept
 	: ptr_{that.arrow()} {}
 
@@ -159,7 +159,7 @@ private:
 	T* ptr_;
 };
 
-template<ranges::Semiregular T, std::size_t N>
+template<ranges::semiregular T, std::size_t N>
 class array {
 public:
 	using value_type = T;
@@ -202,7 +202,7 @@ struct proxy_wrapper {
 
 	proxy_wrapper& operator=(const T& t)
 	noexcept(std::is_nothrow_copy_assignable<T>::value)
-	requires ranges::CopyConstructible<T>
+	requires ranges::copy_constructible<T>
 	{
 		get() = t;
 		return *this;
@@ -210,7 +210,7 @@ struct proxy_wrapper {
 
 	proxy_wrapper& operator=(T&& t)
 	noexcept(std::is_nothrow_move_assignable<T>::value)
-	requires ranges::MoveConstructible<T>
+	requires ranges::move_constructible<T>
 	{
 		get() = std::move(t);
 		return *this;
@@ -218,7 +218,7 @@ struct proxy_wrapper {
 
 	proxy_wrapper const& operator=(const T& t) const
 	noexcept(std::is_nothrow_copy_assignable<T>::value)
-	requires ranges::Copyable<T>
+	requires ranges::copyable<T>
 	{
 		get() = t;
 		return *this;
@@ -226,7 +226,7 @@ struct proxy_wrapper {
 
 	proxy_wrapper const& operator=(T&& t) const
 	noexcept(std::is_nothrow_move_assignable<T>::value)
-	requires ranges::Movable<T>
+	requires ranges::movable<T>
 	{
 		get() = std::move(t);
 		return *this;
@@ -283,11 +283,11 @@ struct proxy_array {
 
 	static_assert(ranges::cursor::Readable<cursor<false>>);
 	static_assert(ranges::cursor::IndirectMove<cursor<false>>);
-	static_assert(ranges::Same<T&&, ranges::cursor::rvalue_reference_t<cursor<false>>>);
+	static_assert(ranges::same_as<T&&, ranges::cursor::rvalue_reference_t<cursor<false>>>);
 
 	static_assert(ranges::cursor::Readable<cursor<true>>);
 	static_assert(ranges::cursor::IndirectMove<cursor<true>>);
-	static_assert(ranges::Same<const T&&, ranges::cursor::rvalue_reference_t<cursor<true>>>);
+	static_assert(ranges::same_as<const T&&, ranges::cursor::rvalue_reference_t<cursor<true>>>);
 
 	using iterator = ranges::basic_iterator<cursor<false>>;
 	using const_iterator = ranges::basic_iterator<cursor<true>>;
@@ -315,7 +315,7 @@ struct proxy_array {
 template<ranges::InputRange R>
 requires
 	(ranges::StreamInsertable<ranges::iter_value_t<ranges::iterator_t<R>>> &&
-	 !ranges::Same<char, std::remove_cv_t<
+	 !ranges::same_as<char, std::remove_cv_t<
 		std::remove_all_extents_t<std::remove_reference_t<R>>>>)
 std::ostream& operator<<(std::ostream& os, R&& rng) {
 	os << '{';
@@ -339,21 +339,21 @@ void test_fl() {
 	using I = decltype(list.begin());
 	using S = decltype(list.end());
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, int&>);
-	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int&&>);
-	static_assert(ranges::Copyable<I>);
-	static_assert(ranges::DefaultConstructible<I>);
-	static_assert(ranges::Semiregular<I>);
+	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
+	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
+	static_assert(ranges::copyable<I>);
+	static_assert(ranges::default_initializable<I>);
+	static_assert(ranges::semiregular<I>);
 	static_assert(ranges::Incrementable<I>);
-	static_assert(ranges::EqualityComparable<I>);
+	static_assert(ranges::equality_comparable<I>);
 	static_assert(ranges::ForwardIterator<I>);
 	static_assert(ranges::Sentinel<S, I>);
 	static_assert(ranges::ForwardRange<Rng>);
-	static_assert(ranges::Common<S, I>);
-	static_assert(ranges::Same<ranges::common_type_t<S, I>, I>);
+	static_assert(ranges::common_with<S, I>);
+	static_assert(ranges::same_as<ranges::common_type_t<S, I>, I>);
 	std::cout << list << '\n';
 	*ranges::front_inserter(list) = 3.14;
 	std::cout << list << '\n';
@@ -380,11 +380,11 @@ void test_rv() {
 	using Rng = decltype(rv);
 	using I = decltype(rv.begin());
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, int&>);
-	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int&&>);
+	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
+	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(ranges::RandomAccessRange<Rng>);
 	CHECK(I{} == I{});
@@ -419,11 +419,11 @@ void test_array() {
 	using I = decltype(a.begin());
 	CHECK(noexcept(a.begin()));
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, int&>);
-	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int&&>);
+	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
+	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
 	static_assert(ranges::ContiguousIterator<I>);
 	static_assert(ranges::RandomAccessRange<Rng>);
 	static_assert(ranges::RandomAccessRange<const Rng>);
@@ -462,11 +462,11 @@ void test_counted() {
 	int some_ints[] = {0,1,2,3};
 	using I = counted_iterator<const int*>;
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, const int&>);
-	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, const int&&>);
+	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, const int&>);
+	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, const int&&>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(ranges::ContiguousIterator<I>);
 	CHECK(I{} == I{});
@@ -513,11 +513,11 @@ void test_always() {
 	static_assert(std::is_empty<I>());
 	static_assert(sizeof(I) == 1);
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
-	static_assert(ranges::Same<ranges::iter_value_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, int>);
-	static_assert(ranges::Same<ranges::iter_rvalue_reference_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int>);
+	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	CHECK(I{} == I{});
 	ranges::copy_n(i, 13, ranges::ostream_iterator<>{std::cout, " "});
@@ -534,12 +534,12 @@ void test_back_inserter() {
 	auto i = ranges::back_inserter(vec);
 	using I = decltype(i);
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Same<ranges::iter_reference_t<I>, I&>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_reference_t<I>, I&>);
 	static_assert(!ranges::Readable<I>);
 	static_assert(ranges::OutputIterator<I, int>);
 	static_assert(!ranges::InputIterator<I>);
-	static_assert(!ranges::EqualityComparable<I>);
+	static_assert(!ranges::equality_comparable<I>);
 	ranges::copy_n(always_iterator<int, 42>{}, 13, i);
 	CHECK(vec.size() == 13u);
 }
@@ -559,19 +559,19 @@ void test_proxy_array() {
 
 	using I = ranges::iterator_t<Rng>;
 	static_assert(ranges::WeaklyIncrementable<I>);
-	static_assert(ranges::Same<ranges::iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::Readable<I>);
 	using R = ranges::iter_reference_t<I>;
-	static_assert(ranges::Same<proxy_wrapper<int>, R>);
+	static_assert(ranges::same_as<proxy_wrapper<int>, R>);
 	using V = ranges::iter_value_t<I>;
-	static_assert(ranges::Same<int, V>);
-	static_assert(ranges::Same<int&&, decltype(iter_move(std::declval<const I&>()))>);
-	static_assert(ranges::Same<int&&, decltype(iter_move(std::declval<I&>()))>);
+	static_assert(ranges::same_as<int, V>);
+	static_assert(ranges::same_as<int&&, decltype(iter_move(std::declval<const I&>()))>);
+	static_assert(ranges::same_as<int&&, decltype(iter_move(std::declval<I&>()))>);
 
 	static_assert(ranges::__iter_move::has_customization<const I&>);
 	static_assert(ranges::__iter_move::has_customization<I&>);
 	using RR = ranges::iter_rvalue_reference_t<I>;
-	static_assert(ranges::Same<int&&, RR>);
+	static_assert(ranges::same_as<int&&, RR>);
 	static_assert(ranges::RandomAccessIterator<I>);
 	static_assert(!ranges::ContiguousIterator<I>);
 	static_assert(ranges::RandomAccessRange<Rng>);
@@ -579,35 +579,35 @@ void test_proxy_array() {
 
 	using CI = ranges::iterator_t<const Rng>;
 	static_assert(ranges::WeaklyIncrementable<CI>);
-	static_assert(ranges::Same<ranges::iter_difference_t<CI>, std::ptrdiff_t>);
+	static_assert(ranges::same_as<ranges::iter_difference_t<CI>, std::ptrdiff_t>);
 	using CR = ranges::iter_reference_t<CI>;
-	static_assert(ranges::Same<proxy_wrapper<const int>, CR>);
+	static_assert(ranges::same_as<proxy_wrapper<const int>, CR>);
 	using CV = ranges::iter_value_t<CI>;
-	static_assert(ranges::Same<int, CV>);
+	static_assert(ranges::same_as<int, CV>);
 
 	static_assert(ranges::__iter_move::has_customization<const CI&>);
 	static_assert(ranges::__iter_move::has_customization<CI&>);
 	using CRR = ranges::iter_rvalue_reference_t<CI>;
-	static_assert(ranges::Same<const int&&, CRR>);
+	static_assert(ranges::same_as<const int&&, CRR>);
 
-	static_assert(ranges::CommonReference<CR, CV&>);
-	static_assert(ranges::CommonReference<CR, CRR>);
-	static_assert(ranges::CommonReference<CRR, const CV&>);
+	static_assert(ranges::common_reference_with<CR, CV&>);
+	static_assert(ranges::common_reference_with<CR, CRR>);
+	static_assert(ranges::common_reference_with<CRR, const CV&>);
 	static_assert(ranges::Readable<CI>);
-	static_assert(ranges::Same<const int&&, decltype(iter_move(std::declval<const CI&>()))>);
-	static_assert(ranges::Same<const int&&, decltype(iter_move(std::declval<CI&>()))>);
+	static_assert(ranges::same_as<const int&&, decltype(iter_move(std::declval<const CI&>()))>);
+	static_assert(ranges::same_as<const int&&, decltype(iter_move(std::declval<CI&>()))>);
 
 	static_assert(ranges::RandomAccessIterator<CI>);
 	static_assert(!ranges::ContiguousIterator<CI>);
 	static_assert(ranges::RandomAccessRange<const Rng>);
 	static_assert(ranges::CommonRange<const Rng>);
 
-	static_assert(ranges::Same<I, decltype(a.begin() + 2)>);
-	static_assert(ranges::CommonReference<const R&, const R&>);
-	static_assert(!ranges::SwappableWith<R, R>);
+	static_assert(ranges::same_as<I, decltype(a.begin() + 2)>);
+	static_assert(ranges::common_reference_with<const R&, const R&>);
+	static_assert(!ranges::swappable_with<R, R>);
 	static_assert(ranges::IndirectlyMovableStorable<I, I>);
 
-	// Swappable<R, R> is not satisfied, and
+	// swappable<R, R> is not satisfied, and
 	// IndirectlyMovableStorable<I, I> is satisfied,
 	// so this should resolve to the second overload of iter_swap.
 	ranges::iter_swap(a.begin() + 1, a.begin() + 3);

--- a/test/iterator/common_iterator.cpp
+++ b/test/iterator/common_iterator.cpp
@@ -56,26 +56,26 @@ namespace {
 		{
 			int i = 42;
 			auto ci = ranges::common_iterator<int*, ranges::unreachable>{&i};
-			static_assert(ranges::Same<int* const&, decltype(ci.operator->())>);
+			static_assert(ranges::same_as<int* const&, decltype(ci.operator->())>);
 			CHECK(ci.operator->() == &i);
 		}
 		// the expression i.operator->() is well-formed
 		{
 			using I = ranges::basic_iterator<silly_arrow_cursor>;
 			auto ci = ranges::common_iterator<I, ranges::unreachable>{};
-			static_assert(ranges::Same<const I&, decltype(ci.operator->())>);
+			static_assert(ranges::same_as<const I&, decltype(ci.operator->())>);
 			CHECK(ci.operator->().operator->() == 42);
 		}
 		// the expression *i is a glvalue [lvalue case]
 		{
 			auto ci = ranges::common_iterator<lvalue_iterator, ranges::unreachable>{};
-			static_assert(ranges::Same<int*, decltype(ci.operator->())>);
+			static_assert(ranges::same_as<int*, decltype(ci.operator->())>);
 			CHECK(ci.operator->() == &forty_two);
 		}
 		// the expression *i is a glvalue [xvalue case]
 		{
 			auto ci = ranges::common_iterator<xvalue_iterator, ranges::unreachable>{};
-			static_assert(ranges::Same<int*, decltype(ci.operator->())>);
+			static_assert(ranges::same_as<int*, decltype(ci.operator->())>);
 			CHECK(ci.operator->() == &forty_two);
 		}
 		// Otherwise, returns a proxy object

--- a/test/iterator/counted_iterator.cpp
+++ b/test/iterator/counted_iterator.cpp
@@ -116,7 +116,7 @@ int main()
 	{
 		counted_iterator<char*> c{nullptr, 0};
 		counted_iterator<char const*> d{c};
-		static_assert(!Assignable<decltype(c)&, decltype(d)>);
+		static_assert(!assignable_from<decltype(c)&, decltype(d)>);
 		CHECK((c - c) == 0);
 		CHECK((d - d) == 0);
 		CHECK((c - d) == 0);

--- a/test/iterator/incomplete.cpp
+++ b/test/iterator/incomplete.cpp
@@ -4,8 +4,8 @@
 namespace ranges = __stl2;
 
 struct foo;
-static_assert(ranges::Same<std::ptrdiff_t,ranges::iter_difference_t<foo*>>);
-static_assert(ranges::Same<foo*,ranges::common_type_t<foo*, foo*>>);
+static_assert(ranges::same_as<std::ptrdiff_t,ranges::iter_difference_t<foo*>>);
+static_assert(ranges::same_as<foo*,ranges::common_type_t<foo*, foo*>>);
 struct foo {};
 
 static_assert(ranges::ContiguousIterator<foo*>);

--- a/test/iterator/istream_iterator.cpp
+++ b/test/iterator/istream_iterator.cpp
@@ -29,28 +29,28 @@ int main() {
 	{
 		using I = istream_iterator<int>;
 		static_assert(WeaklyIncrementable<I>);
-		static_assert(Same<iter_difference_t<I>, std::ptrdiff_t>);
+		static_assert(same_as<iter_difference_t<I>, std::ptrdiff_t>);
 		static_assert(Readable<I>);
-		static_assert(Same<iter_value_t<I>, int>);
-		static_assert(Same<iter_reference_t<I>, const int&>);
-		static_assert(Same<iter_rvalue_reference_t<I>, const int&&>);
+		static_assert(same_as<iter_value_t<I>, int>);
+		static_assert(same_as<iter_reference_t<I>, const int&>);
+		static_assert(same_as<iter_rvalue_reference_t<I>, const int&&>);
 		static_assert(Iterator<I>);
 		static_assert(InputIterator<I>);
 		static_assert(!ForwardIterator<I>);
 
 		static_assert(Sentinel<I, I>);
 		static_assert(Sentinel<default_sentinel, I>);
-		static_assert(Common<default_sentinel, I>);
-		static_assert(Same<I, common_type_t<I, default_sentinel>>);
+		static_assert(common_with<default_sentinel, I>);
+		static_assert(same_as<I, common_type_t<I, default_sentinel>>);
 
-		static_assert(Same<I::difference_type, std::ptrdiff_t>);
-		static_assert(Same<I::iterator_category, input_iterator_tag>);
-		static_assert(Same<I::value_type, int>);
-		static_assert(Same<I::reference, const int&>);
-		static_assert(Same<I::pointer, const int*>);
-		static_assert(Same<I::char_type, char>);
-		static_assert(Same<I::traits_type, std::char_traits<char>>);
-		static_assert(Same<I::istream_type, std::istream>);
+		static_assert(same_as<I::difference_type, std::ptrdiff_t>);
+		static_assert(same_as<I::iterator_category, input_iterator_tag>);
+		static_assert(same_as<I::value_type, int>);
+		static_assert(same_as<I::reference, const int&>);
+		static_assert(same_as<I::pointer, const int*>);
+		static_assert(same_as<I::char_type, char>);
+		static_assert(same_as<I::traits_type, std::char_traits<char>>);
+		static_assert(same_as<I::istream_type, std::istream>);
 
 		I{};
 		I{default_sentinel{}};
@@ -59,27 +59,27 @@ int main() {
 		I{i};
 		static_assert(std::is_trivially_copy_constructible<I>());
 
-		static_assert(Same<const int&, decltype(*i)>);
+		static_assert(same_as<const int&, decltype(*i)>);
 		CHECK(*i == 42);
-		static_assert(Same<const int*, decltype(i.operator->())>);
+		static_assert(same_as<const int*, decltype(i.operator->())>);
 		CHECK(&*i == i.operator->());
-		static_assert(Same<I&, decltype(++i)>);
+		static_assert(same_as<I&, decltype(++i)>);
 		CHECK(&++i == &i);
 		CHECK(*i == 13);
-		static_assert(Same<I, decltype(i++)>);
+		static_assert(same_as<I, decltype(i++)>);
 		{ I j{i}; CHECK(j == i++); }
 
-		static_assert(Same<bool, decltype(i == i)>);
+		static_assert(same_as<bool, decltype(i == i)>);
 		CHECK(i == i);
-		static_assert(Same<bool, decltype(default_sentinel{} == i)>);
+		static_assert(same_as<bool, decltype(default_sentinel{} == i)>);
 		CHECK(default_sentinel{} == i);
-		static_assert(Same<bool, decltype(i == default_sentinel{})>);
+		static_assert(same_as<bool, decltype(i == default_sentinel{})>);
 		CHECK(i == default_sentinel{});
-		static_assert(Same<bool, decltype(i != i)>);
+		static_assert(same_as<bool, decltype(i != i)>);
 		CHECK(!(i != i));
-		static_assert(Same<bool, decltype(default_sentinel{} != i)>);
+		static_assert(same_as<bool, decltype(default_sentinel{} != i)>);
 		CHECK(!(default_sentinel{} != i));
-		static_assert(Same<bool, decltype(i != default_sentinel{})>);
+		static_assert(same_as<bool, decltype(i != default_sentinel{})>);
 		CHECK(!(i != default_sentinel{}));
 	}
 	{

--- a/test/iterator/istreambuf_iterator.cpp
+++ b/test/iterator/istreambuf_iterator.cpp
@@ -22,11 +22,11 @@ namespace {
 	void validate_one() {
 		using C = __istreambuf_iterator::cursor<charT, traits>;
 		static_assert(cursor::Cursor<C>);
-		static_assert(Same<typename traits::off_type, cursor::difference_type_t<C>>);
+		static_assert(same_as<typename traits::off_type, cursor::difference_type_t<C>>);
 		static_assert(cursor::Next<C>);
-		static_assert(Same<charT, cursor::value_type_t<C>>);
+		static_assert(same_as<charT, cursor::value_type_t<C>>);
 		static_assert(cursor::Readable<C>);
-		static_assert(Same<charT, cursor::reference_t<C>>);
+		static_assert(same_as<charT, cursor::reference_t<C>>);
 		static_assert(cursor::Input<C>);
 		static_assert(cursor::Sentinel<C, C>);
 		static_assert(cursor::Sentinel<default_sentinel, C>);
@@ -35,28 +35,28 @@ namespace {
 
 		using I = istreambuf_iterator<charT, traits>;
 		static_assert(WeaklyIncrementable<I>);
-		static_assert(Same<typename traits::off_type, iter_difference_t<I>>);
-		static_assert(Same<charT, iter_value_t<I>>);
+		static_assert(same_as<typename traits::off_type, iter_difference_t<I>>);
+		static_assert(same_as<charT, iter_value_t<I>>);
 		static_assert(Readable<I>);
-		static_assert(Same<charT, iter_reference_t<I>>);
-		static_assert(Same<charT, iter_rvalue_reference_t<I>>);
+		static_assert(same_as<charT, iter_reference_t<I>>);
+		static_assert(same_as<charT, iter_rvalue_reference_t<I>>);
 		static_assert(Iterator<I>);
-		static_assert(Same<input_iterator_tag, iterator_category_t<I>>);
+		static_assert(same_as<input_iterator_tag, iterator_category_t<I>>);
 		static_assert(InputIterator<I>);
 		static_assert(!ForwardIterator<I>);
 		static_assert(Sentinel<I, I>);
 		static_assert(Sentinel<default_sentinel, I>);
-		static_assert(Common<I, default_sentinel>);
-		static_assert(Same<I, common_type_t<I, default_sentinel>>);
+		static_assert(common_with<I, default_sentinel>);
+		static_assert(same_as<I, common_type_t<I, default_sentinel>>);
 
-		static_assert(Same<iter_value_t<I>, typename I::value_type>);
-		static_assert(Same<iter_difference_t<I>, typename I::difference_type>);
-		static_assert(Same<input_iterator_tag, typename I::iterator_category>);
-		static_assert(Same<charT, typename I::reference>);
-		static_assert(Same<traits, typename I::traits_type>);
-		static_assert(Same<typename traits::int_type, typename I::int_type>);
-		static_assert(Same<std::basic_streambuf<charT, traits>, typename I::streambuf_type>);
-		static_assert(Same<std::basic_istream<charT, traits>, typename I::istream_type>);
+		static_assert(same_as<iter_value_t<I>, typename I::value_type>);
+		static_assert(same_as<iter_difference_t<I>, typename I::difference_type>);
+		static_assert(same_as<input_iterator_tag, typename I::iterator_category>);
+		static_assert(same_as<charT, typename I::reference>);
+		static_assert(same_as<traits, typename I::traits_type>);
+		static_assert(same_as<typename traits::int_type, typename I::int_type>);
+		static_assert(same_as<std::basic_streambuf<charT, traits>, typename I::streambuf_type>);
+		static_assert(same_as<std::basic_istream<charT, traits>, typename I::istream_type>);
 
 		auto i = I{};
 		auto ci = const_cast<const I&>(i);
@@ -68,14 +68,14 @@ namespace {
 		CHECK(!(ci != default_sentinel{}));
 		CHECK(!(i != default_sentinel{}));
 
-		static_assert(Same<decltype(i.operator->()), typename C::pointer>);
-		static_assert(Same<decltype(i.operator++(0)), typename C::__proxy>);
+		static_assert(same_as<decltype(i.operator->()), typename C::pointer>);
+		static_assert(same_as<decltype(i.operator++(0)), typename C::__proxy>);
 
-		static_assert(Constructible<I, default_sentinel>);
-		static_assert(ConvertibleTo<default_sentinel, I>);
-		static_assert(Constructible<I, std::basic_istream<charT, traits>&>);
-		static_assert(Constructible<I, std::basic_streambuf<charT, traits>*>);
-		static_assert(Constructible<I, decltype(i++)>);
+		static_assert(constructible_from<I, default_sentinel>);
+		static_assert(convertible_to<default_sentinel, I>);
+		static_assert(constructible_from<I, std::basic_istream<charT, traits>&>);
+		static_assert(constructible_from<I, std::basic_streambuf<charT, traits>*>);
+		static_assert(constructible_from<I, decltype(i++)>);
 	}
 
 	template<class... Cs>

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -191,7 +191,7 @@ struct arbitrary_iterator {
 	requires EC;
 };
 
-template<ranges::DerivedFrom<ranges::input_iterator_tag> C, bool EC, class R>
+template<ranges::derived_from<ranges::input_iterator_tag> C, bool EC, class R>
 struct arbitrary_iterator<C, EC, R> {
 	using iterator_category = C;
 	using value_type = std::remove_reference_t<R>;
@@ -203,43 +203,43 @@ struct arbitrary_iterator<C, EC, R> {
 	arbitrary_iterator operator++(int);
 
 	bool operator==(arbitrary_iterator) const
-	requires EC || ranges::DerivedFrom<C, ranges::forward_iterator_tag>;
+	requires EC || ranges::derived_from<C, ranges::forward_iterator_tag>;
 	bool operator!=(arbitrary_iterator) const
-	requires EC || ranges::DerivedFrom<C, ranges::forward_iterator_tag>;
+	requires EC || ranges::derived_from<C, ranges::forward_iterator_tag>;
 
 	arbitrary_iterator& operator--()
-	requires ranges::DerivedFrom<C, ranges::bidirectional_iterator_tag>;
+	requires ranges::derived_from<C, ranges::bidirectional_iterator_tag>;
 	arbitrary_iterator operator--(int)
-	requires ranges::DerivedFrom<C, ranges::bidirectional_iterator_tag>;
+	requires ranges::derived_from<C, ranges::bidirectional_iterator_tag>;
 
 	bool operator<(arbitrary_iterator) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 	bool operator>(arbitrary_iterator) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 	bool operator<=(arbitrary_iterator) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 	bool operator>=(arbitrary_iterator) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 
 	arbitrary_iterator& operator+=(difference_type)
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 	arbitrary_iterator& operator-=(difference_type)
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 
 	arbitrary_iterator operator-(difference_type) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 	difference_type operator-(arbitrary_iterator) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 
 	value_type& operator[](difference_type) const
-	requires ranges::DerivedFrom<C, ranges::random_access_iterator_tag>;
+	requires ranges::derived_from<C, ranges::random_access_iterator_tag>;
 };
 
-template<ranges::DerivedFrom<ranges::random_access_iterator_tag> C, bool B, class R>
+template<ranges::derived_from<ranges::random_access_iterator_tag> C, bool B, class R>
 arbitrary_iterator<C, B, R> operator+(
 	arbitrary_iterator<C, B, R>, typename arbitrary_iterator<C, B, R>::difference_type);
 
-template<ranges::DerivedFrom<ranges::random_access_iterator_tag> C, bool B, class R>
+template<ranges::derived_from<ranges::random_access_iterator_tag> C, bool B, class R>
 arbitrary_iterator<C, B, R> operator+(
 	typename arbitrary_iterator<C, B, R>::difference_type, arbitrary_iterator<C, B, R>);
 
@@ -260,7 +260,7 @@ void test_iterator_dispatch() {
 	{
 		using I = arbitrary_iterator<ranges::input_iterator_tag, true>;
 		static_assert(ranges::InputIterator<I>);
-		static_assert(ranges::EqualityComparable<I>);
+		static_assert(ranges::equality_comparable<I>);
 		CHECK(iterator_dispatch<I>() == category::input);
 	}
 	{
@@ -293,7 +293,7 @@ void test_iterator_dispatch() {
 	{
 		using I = arbitrary_iterator<void, true>;
 		static_assert(ranges::OutputIterator<I, const int&>);
-		static_assert(ranges::EqualityComparable<I>);
+		static_assert(ranges::equality_comparable<I>);
 		static_assert(!ranges::InputIterator<I>);
 		CHECK(iterator_dispatch<I>() == category::output);
 	}
@@ -312,7 +312,7 @@ template<ranges::ContiguousIterator I, ranges::SizedSentinel<I> S,
 	ranges::ContiguousIterator O>
 requires
 	ranges::IndirectlyCopyable<I, O> &&
-	ranges::Same<ranges::iter_value_t<I>, ranges::iter_value_t<O>> &&
+	ranges::same_as<ranges::iter_value_t<I>, ranges::iter_value_t<O>> &&
 	std::is_trivially_copyable<ranges::iter_value_t<I>>::value
 bool copy(I first, S last, O o) {
 	auto n = last - first;
@@ -370,15 +370,15 @@ void test_iter_swap2() {
 		auto a = std::make_unique<int>(42);
 		auto b = std::make_unique<int>(13);
 		using I = decltype(a);
-		static_assert(ranges::Same<I, decltype(b)>);
+		static_assert(ranges::same_as<I, decltype(b)>);
 		static_assert(ranges::Readable<I>);
 		using R = ranges::iter_reference_t<I>;
-		static_assert(ranges::Same<int&, R>);
+		static_assert(ranges::same_as<int&, R>);
 		using RR = ranges::iter_rvalue_reference_t<I>;
-		static_assert(ranges::Same<int&&, RR>);
-		static_assert(ranges::SwappableWith<R, R>);
+		static_assert(ranges::same_as<int&&, RR>);
+		static_assert(ranges::swappable_with<R, R>);
 
-		// Swappable<R, R> is true, calls the first overload of
+		// swappable<R, R> is true, calls the first overload of
 		// iter_swap (which delegates to swap(*a, *b)):
 		ranges::iter_swap(a, b);
 		CHECK(*a == 13);
@@ -393,18 +393,18 @@ void test_iter_swap2() {
 		using I = decltype(a.begin());
 		static_assert(ranges::Readable<I>);
 		using V = ranges::iter_value_t<I>;
-		static_assert(ranges::Same<int, V>);
+		static_assert(ranges::same_as<int, V>);
 		using R = ranges::iter_reference_t<I>;
-		static_assert(ranges::Same<reference_wrapper<int>, R>);
+		static_assert(ranges::same_as<reference_wrapper<int>, R>);
 		using RR = ranges::iter_rvalue_reference_t<I>;
-		static_assert(ranges::Same<int&&, RR>);
+		static_assert(ranges::same_as<int&&, RR>);
 
-		static_assert(ranges::Same<I, decltype(a.begin() + 2)>);
-		static_assert(ranges::CommonReference<const R&, const R&>);
-		static_assert(!ranges::SwappableWith<R, R>);
+		static_assert(ranges::same_as<I, decltype(a.begin() + 2)>);
+		static_assert(ranges::common_reference_with<const R&, const R&>);
+		static_assert(!ranges::swappable_with<R, R>);
 		static_assert(ranges::IndirectlyMovableStorable<I, I>);
 
-		// Swappable<R, R> is not satisfied, and
+		// swappable<R, R> is not satisfied, and
 		// IndirectlyMovableStorable<I, I> is satisfied,
 		// so this should resolve to the second overload of iter_swap.
 		ranges::iter_swap(a.begin() + 1, a.begin() + 3);
@@ -423,50 +423,50 @@ constexpr bool has_category<T> = true;
 
 void test_std_traits() {
 	using WO = arbitrary_iterator<void, false>;
-	static_assert(ranges::Same<std::iterator_traits<WO>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<WO>::iterator_category,
 		std::output_iterator_tag>);
 
 	using O = arbitrary_iterator<void, true>;
-	static_assert(ranges::Same<std::iterator_traits<O>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<O>::iterator_category,
 		std::output_iterator_tag>);
 
 	using WI = arbitrary_iterator<ranges::input_iterator_tag, false>;
 	static_assert(!has_category<std::iterator_traits<WI>>);
 
 	using I = arbitrary_iterator<ranges::input_iterator_tag, true>;
-	static_assert(ranges::Same<std::iterator_traits<I>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<I>::iterator_category,
 		std::input_iterator_tag>);
 
 	using F = arbitrary_iterator<ranges::forward_iterator_tag, true>;
-	static_assert(ranges::Same<std::iterator_traits<F>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<F>::iterator_category,
 		std::forward_iterator_tag>);
 
 	using B = arbitrary_iterator<ranges::bidirectional_iterator_tag, true>;
-	static_assert(ranges::Same<std::iterator_traits<B>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<B>::iterator_category,
 		std::bidirectional_iterator_tag>);
 
 	using R = arbitrary_iterator<ranges::random_access_iterator_tag, true>;
-	static_assert(ranges::Same<std::iterator_traits<R>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<R>::iterator_category,
 		std::random_access_iterator_tag>);
 
 	using C = arbitrary_iterator<ranges::contiguous_iterator_tag, true>;
-	static_assert(ranges::Same<std::iterator_traits<C>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<C>::iterator_category,
 		std::random_access_iterator_tag>);
 
 	using IV = arbitrary_iterator<ranges::input_iterator_tag, true, int>;
-	static_assert(ranges::Same<std::iterator_traits<IV>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<IV>::iterator_category,
 		std::input_iterator_tag>);
 
 	using FV = arbitrary_iterator<ranges::forward_iterator_tag, true, int>;
-	static_assert(ranges::Same<std::iterator_traits<FV>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<FV>::iterator_category,
 		std::input_iterator_tag>);
 
 	using BV = arbitrary_iterator<ranges::bidirectional_iterator_tag, true, int>;
-	static_assert(ranges::Same<std::iterator_traits<BV>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<BV>::iterator_category,
 		std::input_iterator_tag>);
 
 	using RV = arbitrary_iterator<ranges::random_access_iterator_tag, true, int>;
-	static_assert(ranges::Same<std::iterator_traits<RV>::iterator_category,
+	static_assert(ranges::same_as<std::iterator_traits<RV>::iterator_category,
 		std::input_iterator_tag>);
 }
 

--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -188,21 +188,21 @@ void test_proxy_iterator() {
 	vec2.reserve(ranges::size(vec));
 
 	static_assert(
-		ranges::Same<
+		ranges::same_as<
 			ranges::iter_reference_t<proxy_iterator<A>>,
 			ranges::reference_wrapper<A>>);
 	static_assert(
-		ranges::Same<
+		ranges::same_as<
 			ranges::iter_reference_t<const proxy_iterator<A>>,
 			ranges::reference_wrapper<A>>);
 	static_assert(
-		ranges::Same<
+		ranges::same_as<
 			ranges::iter_rvalue_reference_t<proxy_iterator<A>>,
 			A&&>);
 
 	{
 		static_assert(
-			ranges::Same<
+			ranges::same_as<
 				ranges::iter_rvalue_reference_t<
 					ranges::move_iterator<proxy_iterator<A>>>,
 				A&&>);
@@ -237,12 +237,12 @@ void test_proxy_iterator() {
 
 	{
 		static_assert(
-			ranges::Same<
+			ranges::same_as<
 				ranges::iter_rvalue_reference_t<
 					ranges::counted_iterator<proxy_iterator<A>>>,
 				A&&>);
 		static_assert(
-			ranges::Same<
+			ranges::same_as<
 				ranges::iter_rvalue_reference_t<
 					ranges::move_iterator<
 						ranges::counted_iterator<proxy_iterator<A>>>>,

--- a/test/iterator/ostream_iterator.cpp
+++ b/test/iterator/ostream_iterator.cpp
@@ -39,22 +39,22 @@ int main() {
 
 	using I = ostream_iterator<int>;
 	static_assert(WeaklyIncrementable<I>);
-	static_assert(Same<iter_difference_t<I>, std::ptrdiff_t>);
+	static_assert(same_as<iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(Iterator<I>);
-	static_assert(Same<iter_reference_t<I>, I&>);
+	static_assert(same_as<iter_reference_t<I>, I&>);
 	static_assert(OutputIterator<I, const int&>);
 	static_assert(!InputIterator<I>);
 
 	I i{ss, " "};
-	static_assert(Same<I::difference_type, std::ptrdiff_t>);
-	static_assert(Same<I::char_type, char>);
-	static_assert(Same<I::traits_type, std::char_traits<char>>);
-	static_assert(Same<I::ostream_type, std::ostream>);
+	static_assert(same_as<I::difference_type, std::ptrdiff_t>);
+	static_assert(same_as<I::char_type, char>);
+	static_assert(same_as<I::traits_type, std::char_traits<char>>);
+	static_assert(same_as<I::ostream_type, std::ostream>);
 
-	static_assert(Same<I&, decltype(*i)>);
-	static_assert(Same<I&, decltype(*i = 42)>);
-	static_assert(Same<I&, decltype(++i)>);
-	static_assert(Same<I&, decltype(i++)>);
+	static_assert(same_as<I&, decltype(*i)>);
+	static_assert(same_as<I&, decltype(*i = 42)>);
+	static_assert(same_as<I&, decltype(++i)>);
+	static_assert(same_as<I&, decltype(i++)>);
 
 	static_assert(noexcept(I{}));
 #if defined(__GNUC__) && __GNUC__ < 8 || (__GNUC__ == 7 && __GNUC_MINOR__ >= 2)
@@ -74,7 +74,7 @@ int main() {
 		subrange(istream_iterator<int>{ss}, default_sentinel{}),
 			some_ints);
 
-	static_assert(Same<
+	static_assert(same_as<
 		ostream_iterator<int>&,
 		decltype(*std::declval<ostream_iterator<int>&>())>);
 

--- a/test/iterator/ostreambuf_iterator.cpp
+++ b/test/iterator/ostreambuf_iterator.cpp
@@ -43,7 +43,7 @@ int main() {
 	using I = ostreambuf_iterator<char>;
 	static_assert(OutputIterator<I, const char&>);
 	static_assert(Sentinel<default_sentinel, I>);
-	static_assert(Common<I, default_sentinel>);
+	static_assert(common_with<I, default_sentinel>);
 	static_assert(std::is_same<I, common_type_t<I, default_sentinel>>());
 
 	{

--- a/test/iterator/reverse_iterator.cpp
+++ b/test/iterator/reverse_iterator.cpp
@@ -504,8 +504,8 @@ int main() {
 		// Verify that reverse_iterator's constructor that accepts a base iterator
 		// is explicit.
 		using RI = ranges::reverse_iterator<char*>;
-		static_assert(ranges::Constructible<RI, char*>);
-		static_assert(!ranges::ConvertibleTo<char*, RI>);
+		static_assert(ranges::constructible_from<RI, char*>);
+		static_assert(!ranges::convertible_to<char*, RI>);
 	}
 
 	return test_result();

--- a/test/memory/uninitialized_copy.cpp
+++ b/test/memory/uninitialized_copy.cpp
@@ -28,7 +28,7 @@ namespace ranges = __stl2;
 
 namespace {
 	template<typename T>
-	requires ranges::CopyConstructible<T> && ranges::EqualityComparable<T>
+	requires ranges::copy_constructible<T> && ranges::equality_comparable<T>
 	void uninitialized_copy_test(const Array<T>& control) {
 		auto independent = make_buffer<T>(control.size());
 		auto test = [](const auto& control, const auto& independent, const auto p) {

--- a/test/memory/uninitialized_default_construct.cpp
+++ b/test/memory/uninitialized_default_construct.cpp
@@ -30,7 +30,7 @@ namespace {
 	constexpr int N = 1 << 12;
 
 	template<typename T>
-	requires ranges::DefaultConstructible<T> && ranges::EqualityComparable<T>
+	requires ranges::default_initializable<T> && ranges::equality_comparable<T>
 	void test(const raw_buffer<T>& independent, ranges::iterator_t<const raw_buffer<T>> p) {
 		T t{};
 		CHECK(p == independent.cend());
@@ -39,7 +39,7 @@ namespace {
 	}
 
 	template<typename T>
-	requires ranges::DefaultConstructible<T> && ranges::EqualityComparable<T>
+	requires ranges::default_initializable<T> && ranges::equality_comparable<T>
 	void uninitialized_default_construct_test() {
 		auto independent = make_buffer<T>(N);
 
@@ -52,7 +52,7 @@ namespace {
 	}
 
 	template<typename T>
-	requires ranges::DefaultConstructible<T> && ranges::EqualityComparable<T> && std::is_fundamental<T>::value
+	requires ranges::default_initializable<T> && ranges::equality_comparable<T> && std::is_fundamental<T>::value
 	void test(const raw_buffer<T>& independent, ranges::iterator_t<const raw_buffer<T>> p) {
 		T t;
 		std::memset(&t, 0xCC, sizeof(T));
@@ -62,7 +62,7 @@ namespace {
 	}
 
 	template<typename T>
-	requires ranges::DefaultConstructible<T> && ranges::EqualityComparable<T> && std::is_fundamental<T>::value
+	requires ranges::default_initializable<T> && ranges::equality_comparable<T> && std::is_fundamental<T>::value
 	void uninitialized_default_construct_test() {
 		auto independent = make_buffer<T>(N);
 

--- a/test/memory/uninitialized_fill.cpp
+++ b/test/memory/uninitialized_fill.cpp
@@ -26,7 +26,7 @@ namespace {
 	constexpr auto test_size{1 << 10};
 
 	template<typename T>
-	requires ranges::CopyConstructible<T> && ranges::EqualityComparable<T>
+	requires ranges::copy_constructible<T> && ranges::equality_comparable<T>
 	void uninitialized_fill_test(const T& x) {
 		const auto independent = make_buffer<T>(test_size);
 		auto test = [&independent, &x](const auto& p){

--- a/test/memory/uninitialized_move.cpp
+++ b/test/memory/uninitialized_move.cpp
@@ -35,7 +35,7 @@ namespace {
 	requires requires {
 		typename ranges::iter_value_t<Rng>;
 		&ranges::iter_value_t<Rng>::empty;
-		requires ranges::Invocable<
+		requires ranges::invocable<
 			decltype(&ranges::iter_value_t<Rng>::empty),
 			ranges::iter_reference_t<ranges::iterator_t<const Rng>>>;
 	}
@@ -53,7 +53,7 @@ namespace {
 		return true;
 	}
 
-	template<ranges::Copyable T>
+	template<ranges::copyable T>
 	void uninitialized_move_test(const Array<T>& control) {
 		auto independent = make_buffer<T>(control.size());
 		auto test = [&control](const auto& to_move, const auto& independent, const auto& p) {

--- a/test/memory/uninitialized_value_construct.cpp
+++ b/test/memory/uninitialized_value_construct.cpp
@@ -30,8 +30,8 @@ namespace {
 
 	template<typename T>
 	requires
-		ranges::DefaultConstructible<T> &&
-		ranges::EqualityComparable<T>
+		ranges::default_initializable<T> &&
+		ranges::equality_comparable<T>
 	void uninitialized_value_construct_test()
 	{
 		auto independent = make_buffer<T>(N);

--- a/test/meta.cpp
+++ b/test/meta.cpp
@@ -9,7 +9,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Acknowledgements: Thanks for Paul Fultz for the suggestions that
-//                   concepts can be ordinary Boolean metafunctions.
+//                   concepts can be ordinary boolean metafunctions.
 //
 // Project home: https://github.com/ericniebler/range-v3
 //

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -106,14 +106,14 @@ namespace begin_testing {
 	void test() {
 		// Valid
 		static_assert(CanBegin<int(&)[2]>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<int(&)[2]>())), int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<int(&)[2]>())), int*>);
 		static_assert(CanBegin<const int(&)[2]>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const int(&)[2]>())), const int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const int(&)[2]>())), const int*>);
 
 		static_assert(CanCBegin<int(&)[2]>);
-		static_assert(ranges::Same<decltype(ranges::cbegin(std::declval<int(&)[2]>())), const int*>);
+		static_assert(ranges::same_as<decltype(ranges::cbegin(std::declval<int(&)[2]>())), const int*>);
 		static_assert(CanCBegin<const int(&)[2]>);
-		static_assert(ranges::Same<decltype(ranges::cbegin(std::declval<const int(&)[2]>())), const int*>);
+		static_assert(ranges::same_as<decltype(ranges::cbegin(std::declval<const int(&)[2]>())), const int*>);
 
 		// Ill-formed: array rvalue
 		static_assert(!CanBegin<int(&&)[2]>);
@@ -125,18 +125,18 @@ namespace begin_testing {
 		// Valid: only member begin
 		static_assert(CanBegin<A&>);
 		static_assert(!CanBegin<A>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<A&>())), int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<A&>())), int*>);
 		static_assert(CanBegin<const A&>);
 		static_assert(!CanBegin<const A>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const A&>())), const int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const A&>())), const int*>);
 
 		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
 		static_assert(CanBegin<B&>);
 		static_assert(!CanBegin<B>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<B&>())), int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<B&>())), int*>);
 		static_assert(CanBegin<const B&>);
 		static_assert(!CanBegin<const B>);
-		static_assert(ranges::Same<decltype(ranges::begin(std::declval<const B&>())), const int*>);
+		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const B&>())), const int*>);
 
 		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
 		static_assert(CanBegin<C&>);
@@ -147,16 +147,16 @@ namespace begin_testing {
 		// Valid: Prefer member begin
 		static_assert(CanBegin<D&>);
 		static_assert(!CanBegin<D>);
-		static_assert(ranges::Same<int*, decltype(ranges::begin(std::declval<D&>()))>);
+		static_assert(ranges::same_as<int*, decltype(ranges::begin(std::declval<D&>()))>);
 		static_assert(CanBegin<const D&>);
 		static_assert(!CanBegin<const D>);
-		static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<const D&>()))>);
+		static_assert(ranges::same_as<const int*, decltype(ranges::begin(std::declval<const D&>()))>);
 
 		{
 			using T = std::initializer_list<int>;
 			// Valid: begin accepts lvalue initializer_list
-			static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<T&>()))>);
-			static_assert(ranges::Same<const int*, decltype(ranges::begin(std::declval<const T&>()))>);
+			static_assert(ranges::same_as<const int*, decltype(ranges::begin(std::declval<T&>()))>);
+			static_assert(ranges::same_as<const int*, decltype(ranges::begin(std::declval<const T&>()))>);
 			static_assert(!CanBegin<std::initializer_list<int>>);
 			static_assert(!CanBegin<const std::initializer_list<int>>);
 		}
@@ -241,15 +241,15 @@ static_assert(ranges::Iterator<CI>);
 void test_string_view_p0970() {
 	// basic_string_views are non-dangling
 	using I = ranges::iterator_t<std::string_view>;
-	static_assert(ranges::Same<I, decltype(ranges::begin(std::declval<std::string_view>()))>);
-	static_assert(ranges::Same<I, decltype(ranges::end(std::declval<std::string_view>()))>);
-	static_assert(ranges::Same<I, decltype(ranges::begin(std::declval<const std::string_view>()))>);
-	static_assert(ranges::Same<I, decltype(ranges::end(std::declval<const std::string_view>()))>);
+	static_assert(ranges::same_as<I, decltype(ranges::begin(std::declval<std::string_view>()))>);
+	static_assert(ranges::same_as<I, decltype(ranges::end(std::declval<std::string_view>()))>);
+	static_assert(ranges::same_as<I, decltype(ranges::begin(std::declval<const std::string_view>()))>);
+	static_assert(ranges::same_as<I, decltype(ranges::end(std::declval<const std::string_view>()))>);
 
 	{
 		const char hw[] = "Hello, World!";
 		auto result = ranges::find(std::string_view{hw}, 'W');
-		static_assert(ranges::Same<I, decltype(result)>);
+		static_assert(ranges::same_as<I, decltype(result)>);
 		CHECK(result == std::string_view{hw}.begin() + 7);
 	}
 }
@@ -261,8 +261,8 @@ int main() {
 
 	constexpr auto first = begin(some_ints);
 	constexpr auto last = end(some_ints);
-	static_assert(ranges::Same<const CI, decltype(first)>);
-	static_assert(ranges::Same<const CI, decltype(last)>);
+	static_assert(ranges::same_as<const CI, decltype(first)>);
+	static_assert(ranges::same_as<const CI, decltype(last)>);
 	static_assert(first == cbegin(some_ints));
 	static_assert(last == cend(some_ints));
 

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -116,7 +116,7 @@ public:
 	constexpr output_iterator () {}
 	constexpr explicit output_iterator(It it) : it_(it) {}
 	template<class U>
-	  requires __stl2::ConvertibleTo<U, It>
+	  requires __stl2::convertible_to<U, It>
 	constexpr
 	output_iterator(const output_iterator<U>& u) :it_(u.it_) {}
 
@@ -145,7 +145,7 @@ public:
 	constexpr input_iterator() : it_() {}
 	constexpr explicit input_iterator(It it) : it_(it) {}
 	template<class U>
-	  requires __stl2::ConvertibleTo<U, It>
+	  requires __stl2::convertible_to<U, It>
 	constexpr input_iterator(const input_iterator<U>& u) :it_(u.it_) {}
 
 	constexpr reference operator*() const {return *it_;}
@@ -197,7 +197,7 @@ public:
 	constexpr forward_iterator() : it_() {}
 	constexpr explicit forward_iterator(It it) : it_(it) {}
 	template<class U>
-	  requires __stl2::ConvertibleTo<U, It>
+	  requires __stl2::convertible_to<U, It>
 	constexpr forward_iterator(const forward_iterator<U>& u) :it_(u.it_) {}
 
 	constexpr reference operator*() const {return *it_;}
@@ -249,7 +249,7 @@ public:
 	constexpr bidirectional_iterator() : it_() {}
 	constexpr explicit bidirectional_iterator(It it) : it_(it) {}
 	template<class U>
-	  requires __stl2::ConvertibleTo<U, It>
+	  requires __stl2::convertible_to<U, It>
 	constexpr bidirectional_iterator(const bidirectional_iterator<U>& u) :it_(u.it_) {}
 
 	constexpr reference operator*() const {return *it_;}
@@ -298,7 +298,7 @@ public:
 	constexpr random_access_iterator() : it_() {}
 	constexpr explicit random_access_iterator(It it) : it_(it) {}
 	template<class U>
-	  requires __stl2::ConvertibleTo<U, It>
+	  requires __stl2::convertible_to<U, It>
 	constexpr random_access_iterator(const random_access_iterator<U>& u) :it_(u.it_) {}
 
 	constexpr reference operator*() const {return *it_;}

--- a/test/view/common_view.cpp
+++ b/test/view/common_view.cpp
@@ -36,7 +36,7 @@ int main() {
 		static_assert(CommonRange<decltype(x)>);
 		static_assert(ForwardRange<decltype(x)>);
 		static_assert(!BidirectionalRange<decltype(x)>);
-		static_assert(Same<decltype(x), decltype(view::common(x))>);
+		static_assert(same_as<decltype(x), decltype(view::common(x))>);
 	}
 	return test_result();
 }

--- a/test/view/drop_view.cpp
+++ b/test/view/drop_view.cpp
@@ -134,7 +134,7 @@ int main()
 		using R = decltype(rng);
 		CONCEPT_ASSERT(InputView<R>());
 		CONCEPT_ASSERT(!ForwardRange<R>());
-		CONCEPT_ASSERT(Same<int const&, ranges::iter_reference_t<R>>());
+		CONCEPT_ASSERT(same_as<int const&, ranges::iter_reference_t<R>>());
 		CHECK_EQUAL(rng, {2,3});
 	}
 

--- a/test/view/drop_while_view.cpp
+++ b/test/view/drop_while_view.cpp
@@ -63,7 +63,7 @@ int main()
 	//      static_assert(InputView<R>());
 	//      static_assert(!ForwardRange<R>());
 	//      static_assert(!BoundedRange<R>());
-	//      static_assert(Same<int const&, range_reference_t<R>>());
+	//      static_assert(same_as<int const&, range_reference_t<R>>());
 	//      CHECK_EQUAL(rng, {4,5,6,7,8,9});
 	//  }
 

--- a/test/view/filter_view.cpp
+++ b/test/view/filter_view.cpp
@@ -48,8 +48,8 @@ int main() {
 	static_assert(size(view::all(rgi))==10);
 
 	auto rng = rgi | view::filter(is_odd());
-	static_assert(Same<int &, decltype(*begin(rgi))>);
-	static_assert(Same<int &, decltype(*begin(rng))>);
+	static_assert(same_as<int &, decltype(*begin(rgi))>);
+	static_assert(same_as<int &, decltype(*begin(rng))>);
 	static_assert(View<decltype(rng)>);
 	static_assert(InputRange<decltype(rng)>);
 	static_assert(CommonRange<decltype(rng)>);
@@ -63,7 +63,7 @@ int main() {
 	CHECK(&*begin(tmp) == &rgi[8]);
 
 	// auto rng2 = view::counted(rgi, 10) | view::remove_if(not_fn(is_odd()));
-	// static_assert(Same<int &, decltype(*begin(rng2))>);
+	// static_assert(same_as<int &, decltype(*begin(rng2))>);
 	// static_assert(BidirectionalView<__f<decltype(rng2)>>);
 	// static_assert(!RandomAccessView<__f<decltype(rng2)>>);
 	// static_assert(CommonView<__f<decltype(rng2)>>);
@@ -72,7 +72,7 @@ int main() {
 	// CHECK(&*begin(rng2) == &rgi[0]);
 
 	// auto rng3 = view::counted(bidirectional_iterator<int*>{rgi}, 10) | view::remove_if(is_even());
-	// static_assert(Same<int &, decltype(*begin(rng3))>);
+	// static_assert(same_as<int &, decltype(*begin(rng3))>);
 	// static_assert(BidirectionalView<__f<decltype(rng3)>>);
 	// static_assert(!RandomAccessView<__f<decltype(rng3)>>);
 	// static_assert(!CommonView<__f<decltype(rng3)>>);
@@ -90,7 +90,7 @@ int main() {
 	auto mutable_rng = view::filter(rgi, [flag](int) mutable { return flag = !flag;});
 	CHECK_EQUAL(mutable_rng, {1,3,5,7,9});
 	static_assert(Range<decltype(mutable_rng)>);
-	static_assert(Copyable<decltype(mutable_rng)>);
+	static_assert(copyable<decltype(mutable_rng)>);
 	static_assert(!View<decltype(mutable_rng) const>);
 
 	// {

--- a/test/view/move_view.cpp
+++ b/test/view/move_view.cpp
@@ -23,7 +23,7 @@
 namespace ranges = __stl2;
 
 namespace {
-	template<ranges::Integral I>
+	template<ranges::integral I>
 	auto make_interval(I from, I to) {
 		return ranges::view::iota(from, to);
 	}

--- a/test/view/ref_view.cpp
+++ b/test/view/ref_view.cpp
@@ -18,10 +18,10 @@
 
 namespace ranges = __stl2;
 
-static_assert(ranges::Constructible<ranges::ref_view<const int[42]>, const int(&)[42]>);
-static_assert(ranges::Constructible<ranges::ref_view<const int[42]>, int(&)[42]>);
-static_assert(!ranges::Constructible<ranges::ref_view<const int[42]>, int(&&)[42]>);
-static_assert(!ranges::Constructible<ranges::ref_view<const int[42]>, const int(&&)[42]>);
+static_assert(ranges::constructible_from<ranges::ref_view<const int[42]>, const int(&)[42]>);
+static_assert(ranges::constructible_from<ranges::ref_view<const int[42]>, int(&)[42]>);
+static_assert(!ranges::constructible_from<ranges::ref_view<const int[42]>, int(&&)[42]>);
+static_assert(!ranges::constructible_from<ranges::ref_view<const int[42]>, const int(&&)[42]>);
 
 int main() {
 	{

--- a/test/view/repeat_view.cpp
+++ b/test/view/repeat_view.cpp
@@ -29,8 +29,8 @@ int main() {
 		CHECK(v.value() == 42);
 
 		auto first = v.begin();
-		static_assert(ranges::Same<decltype(*first), int&>);
-		static_assert(ranges::Same<decltype(first.operator->()), int*>);
+		static_assert(ranges::same_as<decltype(*first), int&>);
+		static_assert(ranges::same_as<decltype(first.operator->()), int*>);
 		CHECK(*first == 42);
 		CHECK(std::addressof(*first) == std::addressof(v.value()));
 		CHECK(ranges::next(first) == first);
@@ -43,8 +43,8 @@ int main() {
 		CHECK(std::addressof(v.value()) == std::addressof(cv.value()));
 
 		auto cfirst = cv.begin();
-		static_assert(ranges::Same<decltype(*cfirst), const int&>);
-		static_assert(ranges::Same<decltype(cfirst.operator->()), const int*>);
+		static_assert(ranges::same_as<decltype(*cfirst), const int&>);
+		static_assert(ranges::same_as<decltype(cfirst.operator->()), const int*>);
 		CHECK(*cfirst == 42);
 		CHECK(std::addressof(*cfirst) == std::addressof(cv.value()));
 		CHECK(ranges::next(cfirst) == cfirst);

--- a/test/view/reverse_view.cpp
+++ b/test/view/reverse_view.cpp
@@ -57,7 +57,7 @@ int main() {
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
 #if 0
 		auto x = rg | view::reverse | view::reverse;
-		static_assert(Same<decltype(x), ref_view<decltype(rg)>>);
+		static_assert(same_as<decltype(x), ref_view<decltype(rg)>>);
 		CHECK(&x.base() == &rg);
 #else
 		auto x = view::reverse(rg);

--- a/test/view/single_view.cpp
+++ b/test/view/single_view.cpp
@@ -29,7 +29,7 @@ void test_one(V& v, const T& t) {
     static_assert(ranges::CommonRange<V>);
     using I = ranges::iterator_t<V>;
     static_assert(std::is_pointer_v<I>);
-    static_assert(ranges::Same<T, ranges::iter_value_t<I>>);
+    static_assert(ranges::same_as<T, ranges::iter_value_t<I>>);
     static_assert(V::size() == 1u);
     CHECK(v.size() == 1u);
     CHECK(v.data() != nullptr);
@@ -42,7 +42,7 @@ template<class T>
 void test(T&& t) {
     using D = remove_cvref_t<T>;
     auto v = ranges::view::single(std::forward<T>(t));
-    static_assert(ranges::Same<ranges::single_view<D>, decltype(v)>);
+    static_assert(ranges::same_as<ranges::single_view<D>, decltype(v)>);
     test_one(v, t);
     test_one(std::as_const(v), t);
 }

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -509,31 +509,31 @@ void test_case_class_template_argument_deduction()
 		int arr[] = {1, 2, 3, 4, 5};
 		{
 			span s{arr};
-			static_assert(ranges::Same<span<int, 5>, decltype(s)>);
+			static_assert(ranges::same_as<span<int, 5>, decltype(s)>);
 		}
 		{
 			span s{ranges::begin(arr), ranges::size(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 		{
 			span s{ranges::begin(arr), ranges::end(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 	}
 	{
 		std::array<int, 5> arr = {1, 2, 3, 4, 5};
 		{
 			span s{arr};
-			static_assert(ranges::Same<span<int, 5>, decltype(s)>);
+			static_assert(ranges::same_as<span<int, 5>, decltype(s)>);
 		}
 #if 0 // TODO: reactivate these cases on the span_updates branch
 		{
 			span s{ranges::begin(arr), ranges::size(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 		{
 			span s{ranges::begin(arr), ranges::end(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 #endif
 	}
@@ -541,7 +541,7 @@ void test_case_class_template_argument_deduction()
 		std::vector<int> vec = {1, 2, 3, 4, 5};
 		{
 			span s{vec};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 	}
 #endif
@@ -1038,7 +1038,7 @@ void test_case_interop_with_std_regex()
 	CHECK(match[0].second == (f_it + 1));
 }
 
-void test_case_default_constructible()
+void test_case_default_initializable()
 {
 	CHECK((std::is_default_constructible<span<int>>::value));
 	CHECK((std::is_default_constructible<span<int, 0>>::value));
@@ -1072,16 +1072,16 @@ int main() {
 	test_case_as_writeable_bytes();
 	test_case_fixed_size_conversions();
 	test_case_interop_with_std_regex();
-	test_case_default_constructible();
+	test_case_default_initializable();
 
 	static_assert(ranges::ContiguousRange<span<int>> && ranges::View<span<int>>);
 	static_assert(ranges::ContiguousRange<span<int, 42>> && ranges::View<span<int, 42>>);
 
 	// spans are non-dangling
-	static_assert(ranges::Same<decltype(ranges::begin(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::end(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::begin(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::end(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::begin(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::end(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::end(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
 	{
 		int some_ints[]{42};
 		CHECK(ranges::data(span{some_ints, 42}) == +some_ints);

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -34,50 +34,50 @@ int main() {
 	// safe_subrange_t tests:
 
 	// lvalues are ReferenceableRanges and do not dangle:
-	static_assert(Same<subrange<int*>,
+	static_assert(same_as<subrange<int*>,
 		decltype(::algorithm(std::declval<int(&)[42]>()))>);
-	static_assert(Same<subrange<std::vector<int>::iterator>,
+	static_assert(same_as<subrange<std::vector<int>::iterator>,
 		decltype(::algorithm(vi))>);
 
 	// subrange and ref_view are ReferenceableRanges and do not dangle:
-	static_assert(Same<subrange<int*>,
+	static_assert(same_as<subrange<int*>,
 		decltype(::algorithm(std::declval<subrange<int*>>()))>);
-	static_assert(Same<subrange<int*>,
+	static_assert(same_as<subrange<int*>,
 		decltype(::algorithm(std::declval<ref_view<int[42]>>()))>);
 
 	// non-ReferenceableRange rvalue ranges dangle:
-	static_assert(Same<dangling,
+	static_assert(same_as<dangling,
 		decltype(::algorithm(std::declval<std::vector<int>>()))>);
-	static_assert(Same<dangling,
+	static_assert(same_as<dangling,
 		decltype(::algorithm(std::move(vi)))>);
 
 	// Test that slicing conversions are not allowed.
-	static_assert(Constructible<subrange<Base*, Base*>, Base*, Base*>);
-	static_assert(!Constructible<subrange<Base*, Base*>, Derived*, Derived*>);
-	static_assert(Constructible<subrange<const Base*, const Base*>, Base*, Base*>);
-	static_assert(!Constructible<subrange<const Base*, const Base*>, Derived*, Derived*>);
-	static_assert(!Constructible<subrange<Base*, Base*>, subrange<Derived*, Derived*>>);
+	static_assert(constructible_from<subrange<Base*, Base*>, Base*, Base*>);
+	static_assert(!constructible_from<subrange<Base*, Base*>, Derived*, Derived*>);
+	static_assert(constructible_from<subrange<const Base*, const Base*>, Base*, Base*>);
+	static_assert(!constructible_from<subrange<const Base*, const Base*>, Derived*, Derived*>);
+	static_assert(!constructible_from<subrange<Base*, Base*>, subrange<Derived*, Derived*>>);
 
-	static_assert(Constructible<subrange<Base*, unreachable>, Base*, unreachable>);
-	static_assert(!Constructible<subrange<Base*, unreachable>, Derived*, unreachable>);
-	static_assert(Constructible<subrange<const Base*, unreachable>, Base*, unreachable>);
-	static_assert(!Constructible<subrange<const Base*, unreachable>, Derived*, unreachable>);
-	static_assert(!Constructible<subrange<Base*, unreachable>, subrange<Derived*, unreachable>>);
+	static_assert(constructible_from<subrange<Base*, unreachable>, Base*, unreachable>);
+	static_assert(!constructible_from<subrange<Base*, unreachable>, Derived*, unreachable>);
+	static_assert(constructible_from<subrange<const Base*, unreachable>, Base*, unreachable>);
+	static_assert(!constructible_from<subrange<const Base*, unreachable>, Derived*, unreachable>);
+	static_assert(!constructible_from<subrange<Base*, unreachable>, subrange<Derived*, unreachable>>);
 
-	static_assert(Constructible<subrange<Base*, unreachable, subrange_kind::sized>, Base*, unreachable, std::ptrdiff_t>);
-	static_assert(!Constructible<subrange<Base*, unreachable, subrange_kind::sized>, Derived*, unreachable, std::ptrdiff_t>);
-	static_assert(Constructible<subrange<const Base*, unreachable, subrange_kind::sized>, Base*, unreachable, std::ptrdiff_t>);
-	static_assert(!Constructible<subrange<const Base*, unreachable, subrange_kind::sized>, Derived*, unreachable, std::ptrdiff_t>);
-	static_assert(!Constructible<subrange<Base*, unreachable, subrange_kind::sized>, subrange<Derived*, unreachable>, std::ptrdiff_t>);
+	static_assert(constructible_from<subrange<Base*, unreachable, subrange_kind::sized>, Base*, unreachable, std::ptrdiff_t>);
+	static_assert(!constructible_from<subrange<Base*, unreachable, subrange_kind::sized>, Derived*, unreachable, std::ptrdiff_t>);
+	static_assert(constructible_from<subrange<const Base*, unreachable, subrange_kind::sized>, Base*, unreachable, std::ptrdiff_t>);
+	static_assert(!constructible_from<subrange<const Base*, unreachable, subrange_kind::sized>, Derived*, unreachable, std::ptrdiff_t>);
+	static_assert(!constructible_from<subrange<Base*, unreachable, subrange_kind::sized>, subrange<Derived*, unreachable>, std::ptrdiff_t>);
 
-	static_assert(ConvertibleTo<subrange<Base*, Base*>, std::pair<const Base*, const Base*>>);
-	static_assert(!ConvertibleTo<subrange<Derived*, Derived*>, std::pair<Base*, Base*>>);
+	static_assert(convertible_to<subrange<Base*, Base*>, std::pair<const Base*, const Base*>>);
+	static_assert(!convertible_to<subrange<Derived*, Derived*>, std::pair<Base*, Base*>>);
 
 	subrange<std::vector<int>::iterator> r0 {vi.begin(), vi.end()};
 	static_assert(std::tuple_size<decltype(r0)>::value == 2);
-	static_assert(Same<std::vector<int>::iterator,
+	static_assert(same_as<std::vector<int>::iterator,
 		std::tuple_element<0, decltype(r0)>::type>);
-	static_assert(Same<std::vector<int>::iterator,
+	static_assert(same_as<std::vector<int>::iterator,
 		std::tuple_element<1, decltype(r0)>::type>);
 	static_assert(SizedRange<decltype(r0)>);
 	CHECK(r0.size() == 4);
@@ -101,9 +101,9 @@ int main() {
 
 	subrange<std::vector<int>::iterator, unreachable> r1 { r0.begin(), {} };
 	static_assert(std::tuple_size<decltype(r1)>::value == 2);
-	static_assert(Same<std::vector<int>::iterator,
+	static_assert(same_as<std::vector<int>::iterator,
 		std::tuple_element<0, decltype(r1)>::type>);
-	static_assert(Same<unreachable,
+	static_assert(same_as<unreachable,
 		std::tuple_element<1, decltype(r1)>::type>);
 	static_assert(View<decltype(r1)>);
 	static_assert(!SizedRange<decltype(r1)>);
@@ -145,50 +145,50 @@ int main() {
 	{
 		subrange s0{vi.begin(), vi.end()};
 		subrange s1{li.begin(), li.end()};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l1), decltype(s1)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l1), decltype(s1)>);
 	}
 	{
 		subrange s0{vi.begin(), vi.end(), ranges::distance(vi)};
 		subrange s1{li.begin(), li.end(), ranges::distance(li)};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l0), decltype(s1)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l0), decltype(s1)>);
 	}
 	{
 		subrange s0{vi};
 		subrange s1{li};
 		subrange s2{view::all(vi)};
 		subrange s3{view::all(li)};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l0), decltype(s1)>);
-		static_assert(Same<decltype(r0), decltype(s2)>);
-		static_assert(Same<decltype(l0), decltype(s3)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l0), decltype(s1)>);
+		static_assert(same_as<decltype(r0), decltype(s2)>);
+		static_assert(same_as<decltype(l0), decltype(s3)>);
 	}
 	{
 		subrange s0{r0};
 		subrange s1{l0};
 		subrange s2{l1};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l0), decltype(s1)>);
-		static_assert(Same<decltype(l1), decltype(s2)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l0), decltype(s1)>);
+		static_assert(same_as<decltype(l1), decltype(s2)>);
 	}
 	{
 		subrange s0{vi, ranges::distance(vi)};
 		subrange s1{li, ranges::distance(li)};
 		subrange s2{view::all(vi), ranges::distance(vi)};
 		subrange s3{view::all(li), ranges::distance(li)};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l0), decltype(s1)>);
-		static_assert(Same<decltype(r0), decltype(s2)>);
-		static_assert(Same<decltype(l0), decltype(s3)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l0), decltype(s1)>);
+		static_assert(same_as<decltype(r0), decltype(s2)>);
+		static_assert(same_as<decltype(l0), decltype(s3)>);
 	}
 	{
 		subrange s0{r0, size(r0)};
 		subrange s1{l0, size(l0)};
 		subrange s2{l1, size(l0)};
-		static_assert(Same<decltype(r0), decltype(s0)>);
-		static_assert(Same<decltype(l0), decltype(s1)>);
-		static_assert(Same<decltype(l0), decltype(s2)>);
+		static_assert(same_as<decltype(r0), decltype(s0)>);
+		static_assert(same_as<decltype(l0), decltype(s1)>);
+		static_assert(same_as<decltype(l0), decltype(s2)>);
 	}
 
 	return ::test_result();

--- a/test/view/transform_view.cpp
+++ b/test/view/transform_view.cpp
@@ -38,8 +38,8 @@ int main() {
 	int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
 	auto rng = rgi | view::transform(is_odd());
-	static_assert(Same<int &, decltype(*begin(rgi))>);
-	static_assert(Same<bool, decltype(*begin(rng))>);
+	static_assert(same_as<int &, decltype(*begin(rgi))>);
+	static_assert(same_as<bool, decltype(*begin(rng))>);
 	static_assert(View<decltype(rng)>);
 	static_assert(SizedRange<decltype(rng)>);
 	static_assert(RandomAccessRange<decltype(rng)>);
@@ -47,9 +47,9 @@ int main() {
 
 	std::pair<int, int> rgp[] = {{1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}, {7,7}, {8,8}, {9,9}, {10,10}};
 	auto rng2 = rgp | view::transform(&std::pair<int,int>::first);
-	static_assert(Same<int &, decltype(*begin(rng2))>);
-	static_assert(Same<iter_value_t<iterator_t<decltype(rng2)>>, int>);
-	static_assert(Same<decltype(iter_move(begin(rng2))), int &&>);
+	static_assert(same_as<int &, decltype(*begin(rng2))>);
+	static_assert(same_as<iter_value_t<iterator_t<decltype(rng2)>>, int>);
+	static_assert(same_as<decltype(iter_move(begin(rng2))), int &&>);
 	static_assert(View<decltype(rng2)>);
 	static_assert(CommonRange<decltype(rng2)>);
 	static_assert(SizedRange<decltype(rng2)>);


### PR DESCRIPTION
P1754 renames the concepts from PascalCase to snake_case. This is a
partial commit to help make reviewing more bareable.

Everything in the range [same_as, readable) has been updated.

Since I used VS Code's non-discriminatory find/replace all tool, it's probably easiest to go through the list of concepts in P1754 and search for both the old names and the new ones.