### PR TITLE
renames all the concepts in P1754 in that weren't done by 8d54d1a

### DIFF
--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -11,7 +11,7 @@ namespace ranges = std::experimental::ranges;
 
 template<class...> class show_type;
 
-template<ranges::Readable T>
+template<ranges::readable T>
 void foo(T&) {}
 
 int main() {

--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -22,8 +22,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __adjacent_find_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectRelation<projected<I, Proj>> Pred = equal_to>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_relation<projected<I, Proj>> Pred = equal_to>
 		constexpr I
 		operator()(I first, S last, Pred pred = {}, Proj proj = {}) const {
 			if (first == last) {
@@ -41,8 +41,8 @@ STL2_OPEN_NAMESPACE {
 			return next;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> Pred = equal_to>
+		template<forward_range R, class Proj = identity,
+			indirect_relation<projected<iterator_t<R>, Proj>> Pred = equal_to>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/all_of.hpp
+++ b/include/stl2/detail/algorithm/all_of.hpp
@@ -23,8 +23,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __all_of_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr bool operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
 				if (!__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 			return true;
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr bool operator()(R&& rng, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), __stl2::ref(pred), __stl2::ref(proj));
 		}

--- a/include/stl2/detail/algorithm/any_of.hpp
+++ b/include/stl2/detail/algorithm/any_of.hpp
@@ -22,8 +22,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __any_of_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr bool operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
 				if (__stl2::invoke(pred, __stl2::invoke(proj, *first))) {
@@ -33,8 +33,8 @@ STL2_OPEN_NAMESPACE {
 			return false;
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr bool operator()(R&& rng, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), __stl2::ref(pred), __stl2::ref(proj));
 		}

--- a/include/stl2/detail/algorithm/binary_search.hpp
+++ b/include/stl2/detail/algorithm/binary_search.hpp
@@ -21,8 +21,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __binary_search_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-			IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
+			indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = less>
 		constexpr bool operator()(I first, S last, const T& value,
 			Comp comp = {}, Proj proj = {}) const
 		{
@@ -32,8 +32,8 @@ STL2_OPEN_NAMESPACE {
 				!__stl2::invoke(comp, value, __stl2::invoke(proj, *result));
 		}
 
-		template<ForwardRange R, class T, class Proj = identity,
-			IndirectStrictWeakOrder<const T*,
+		template<forward_range R, class T, class Proj = identity,
+			indirect_strict_weak_order<const T*,
 				projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr bool operator()(R&& r, const T& value, Comp comp = {},
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/copy.hpp
+++ b/include/stl2/detail/algorithm/copy.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	using copy_result = __in_out_result<I, O>;
 
 	struct __copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
-		requires IndirectlyCopyable<I, O>
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
+		requires indirectly_copyable<I, O>
 		constexpr copy_result<I, O>
 		operator()(I first, S last, O result) const {
 			for (; first != last; (void) ++first, (void) ++result) {
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+		template<input_range R, weakly_incrementable O>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result) const {
 			return (*this)(begin(r), end(r), std::move(result));
@@ -46,8 +46,8 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		struct __copy_fn : private __niebloid {
-			template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
-			requires IndirectlyCopyable<I, O>
+			template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
+			requires indirectly_copyable<I, O>
 			constexpr copy_result<I, O>
 			operator()(I first, S last, O result) const {
 				for (; first != last; (void) ++first, (void) ++result) {
@@ -56,9 +56,9 @@ STL2_OPEN_NAMESPACE {
 				return {std::move(first), std::move(result)};
 			}
 
-			template<InputRange R, class O>
-			requires (!Range<O> && WeaklyIncrementable<__f<O>>
-				&& IndirectlyCopyable<iterator_t<R>, __f<O>>)
+			template<input_range R, class O>
+			requires (!range<O> && weakly_incrementable<__f<O>>
+				&& indirectly_copyable<iterator_t<R>, __f<O>>)
 			constexpr copy_result<safe_iterator_t<R>, __f<O>>
 			operator()(R&& r, O&& result_) const {
 				auto result = std::forward<O>(result_);
@@ -66,8 +66,8 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Extension
-			template<InputIterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
-			requires IndirectlyCopyable<I1, I2>
+			template<input_iterator I1, sentinel_for<I1> S1, input_or_output_iterator I2, sentinel_for<I2> S2>
+			requires indirectly_copyable<I1, I2>
 			constexpr copy_result<I1, I2>
 			operator()(I1 first, S1 last, I2 rfirst, S2 rlast) const {
 				for (; first != last && rfirst != rlast; (void) ++first, (void)++rfirst) {
@@ -77,8 +77,8 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Extension
-			template<InputRange R1, Range R2>
-			requires IndirectlyCopyable<iterator_t<R1>, iterator_t<R2>>
+			template<input_range R1, range R2>
+			requires indirectly_copyable<iterator_t<R1>, iterator_t<R2>>
 			constexpr copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
 			operator()(R1&& r1, R2&& r2) const {
 				return (*this)(begin(r1), end(r1), begin(r2), end(r2));

--- a/include/stl2/detail/algorithm/copy_backward.hpp
+++ b/include/stl2/detail/algorithm/copy_backward.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	using copy_backward_result = __in_out_result<I, O>;
 
 	struct __copy_backward_fn : private __niebloid {
-		template<BidirectionalIterator I1, Sentinel<I1> S1, BidirectionalIterator I2>
-		requires IndirectlyCopyable<I1, I2>
+		template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator I2>
+		requires indirectly_copyable<I1, I2>
 		constexpr copy_backward_result<I1, I2>
 		operator()(I1 first, S1 sent, I2 out) const {
 			auto last = next(first, std::move(sent));
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(last), std::move(out)};
 		}
 
-		template<BidirectionalRange R, BidirectionalIterator I>
+		template<bidirectional_range R, bidirectional_iterator I>
 		constexpr copy_backward_result<safe_iterator_t<R>, I>
 		operator()(R&& r, I result) const {
 			return (*this)(begin(r), end(r), std::move(result));

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -26,9 +26,9 @@ STL2_OPEN_NAMESPACE {
 	using copy_if_result = __in_out_result<I, O>;
 
 	struct __copy_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-			class Proj = identity, IndirectUnaryPredicate<projected<I, Proj>> Pred>
-		requires IndirectlyCopyable<I, O>
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
+			class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
+		requires indirectly_copyable<I, O>
 		constexpr copy_if_result<I, O>
 		operator()(I first, S last, O result, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -42,9 +42,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+		template<input_range R, weakly_incrementable O, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr copy_if_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result),

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	using copy_n_result = __in_out_result<I, O>;
 
 	struct __copy_n_fn : private __niebloid {
-		template<InputIterator I, WeaklyIncrementable O>
-		requires IndirectlyCopyable<I, O>
+		template<input_iterator I, weakly_incrementable O>
+		requires indirectly_copyable<I, O>
 		constexpr copy_n_result<I, O>
 		operator()(I first_, iter_difference_t<I> n, O result) const {
 			if (n < 0) n = 0;

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __count_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
+		requires indirect_relation<equal_to, projected<I, Proj>, const T*>
 		constexpr iter_difference_t<I>
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			iter_difference_t<I> n = 0;
@@ -33,8 +33,8 @@ STL2_OPEN_NAMESPACE {
 			return n;
 		}
 
-		template<InputRange R, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+		template<input_range R, class T, class Proj = identity>
+		requires indirect_relation<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr iter_difference_t<iterator_t<R>>
 		operator()(R&& r, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __count_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr iter_difference_t<I>
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			auto n = iter_difference_t<I>{0};
@@ -33,8 +33,8 @@ STL2_OPEN_NAMESPACE {
 			return n;
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr iter_difference_t<iterator_t<R>>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/equal.hpp
+++ b/include/stl2/detail/algorithm/equal.hpp
@@ -21,9 +21,9 @@
 STL2_OPEN_NAMESPACE {
 	struct __equal_fn : private __niebloid {
 	private:
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
 			class Pred, class Proj1, class Proj2>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static constexpr bool __equal_3(I1 first1, S1 last1, I2 first2,
 			Pred& pred, Proj1& proj1, Proj2& proj2)
 		{
@@ -37,9 +37,9 @@ STL2_OPEN_NAMESPACE {
 			return true;
 		}
 
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, class Pred, class Proj1, class Proj2>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, class Pred, class Proj1, class Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static constexpr bool __equal_4(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred& pred, Proj1& proj1, Proj2& proj2)
 		{
@@ -55,13 +55,13 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 	public:
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
 			class Pred = equal_to, class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedSentinel<S1, I1> && SizedSentinel<S2, I2>) {
+			if constexpr (sized_sentinel_for<S1, I1> && sized_sentinel_for<S2, I2>) {
 				auto len1 = distance(first1, last1);
 				auto len2 = distance(first2, std::move(last2));
 				return len1 == len2 &&
@@ -75,13 +75,13 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<InputRange R1, InputRange R2, class Pred = equal_to,
+		template<input_range R1, input_range R2, class Pred = equal_to,
 			class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+		requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
 		constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedRange<R1> && SizedRange<R2>) {
+			if constexpr (sized_range<R1> && sized_range<R2>) {
 				return distance(r1) == distance(r2) &&
 					__equal_3(
 						begin(r1), end(r1),

--- a/include/stl2/detail/algorithm/equal_range.hpp
+++ b/include/stl2/detail/algorithm/equal_range.hpp
@@ -23,8 +23,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __equal_range_n_fn {
-			template<ForwardIterator I, class T, class Comp = less, class Proj = identity>
-			requires IndirectStrictWeakOrder<Comp, const T*, projected<I, Proj>>
+			template<forward_iterator I, class T, class Comp = less, class Proj = identity>
+			requires indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>
 			constexpr subrange<I>
 			operator()(I first, iter_difference_t<I> dist, const T& value,
 				Comp comp = {}, Proj proj = {}) const {
@@ -60,13 +60,13 @@ STL2_OPEN_NAMESPACE {
 	} // namespace ext
 
 	struct __equal_range_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class T, class Comp = less,
+		template<forward_iterator I, sentinel_for<I> S, class T, class Comp = less,
 			class Proj = identity>
-		requires IndirectStrictWeakOrder<Comp, const T*, projected<I, Proj>>
+		requires indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>
 		constexpr subrange<I> operator()(I first, S last, const T& value,
 			Comp comp = {}, Proj proj = {}) const
 		{
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				auto len = distance(first, std::move(last));
 				return ext::equal_range_n(std::move(first), len, value,
 					__stl2::ref(comp), __stl2::ref(proj));
@@ -110,11 +110,11 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange Rng, class T, class Comp = less, class Proj = identity>
-		requires IndirectStrictWeakOrder<Comp, const T*, projected<iterator_t<Rng>, Proj>>
+		template<forward_range Rng, class T, class Comp = less, class Proj = identity>
+		requires indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>
 		constexpr safe_subrange_t<Rng>
 		operator()(Rng&& rng, const T& value, Comp comp = {}, Proj proj = {}) const {
-			if constexpr (SizedRange<Rng>) {
+			if constexpr (sized_range<Rng>) {
 				return ext::equal_range_n(begin(rng), size(rng), value, __stl2::ref(comp),
 					__stl2::ref(proj));
 			} else {

--- a/include/stl2/detail/algorithm/fill.hpp
+++ b/include/stl2/detail/algorithm/fill.hpp
@@ -19,7 +19,7 @@
 // fill [alg.fill]
 STL2_OPEN_NAMESPACE {
 	struct __fill_fn : private __niebloid {
-		template<class T, OutputIterator<const T&> O, Sentinel<O> S>
+		template<class T, output_iterator<const T&> O, sentinel_for<O> S>
 		constexpr O operator()(O first, S last, const T& value) const {
 			for (; first != last; ++first) {
 				*first = value;
@@ -27,7 +27,7 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<class T, OutputRange<const T&> R>
+		template<class T, output_range<const T&> R>
 		constexpr safe_iterator_t<R> operator()(R&& r, const T& value) const {
 			return (*this)(begin(r), end(r), value);
 		}

--- a/include/stl2/detail/algorithm/fill_n.hpp
+++ b/include/stl2/detail/algorithm/fill_n.hpp
@@ -19,7 +19,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __fill_n_fn : private __niebloid {
-		template<class T, OutputIterator<const T&> O>
+		template<class T, output_iterator<const T&> O>
 		constexpr O
 		operator()(O first, iter_difference_t<O> n, const T& value) const {
 			for (; n > 0; --n, (void)++first) {

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __find_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
+		requires indirect_relation<equal_to, projected<I, Proj>, const T*>
 		constexpr I
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -32,8 +32,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<InputRange R, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+		template<input_range R, class T, class Proj = identity>
+		requires indirect_relation<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -23,10 +23,10 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __find_end_fn : private __niebloid {
-		template<ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
-			Sentinel<I2> S2, class Pred = equal_to, class Proj1 = identity,
+		template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
+			sentinel_for<I2> S2, class Pred = equal_to, class Proj1 = identity,
 			class Proj2 = identity>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		constexpr I1 operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
@@ -34,11 +34,11 @@ STL2_OPEN_NAMESPACE {
 				return next(first1, last1);
 			}
 
-			if constexpr (BidirectionalIterator<I1> && BidirectionalIterator<I2>) {
+			if constexpr (bidirectional_iterator<I1> && bidirectional_iterator<I2>) {
 				auto end1 = next(first1, last1);
 				auto end2 = next(first2, last2);
 
-				if constexpr (RandomAccessIterator<I1> && RandomAccessIterator<I2>) {
+				if constexpr (random_access_iterator<I1> && random_access_iterator<I2>) {
 					// Take advantage of knowing source and pattern lengths.
 					// Stop short when source is smaller than pattern
 					const auto len2 = end2 - first2;
@@ -111,9 +111,9 @@ STL2_OPEN_NAMESPACE {
 		}
 
 
-		template<ForwardRange R1, ForwardRange R2,
+		template<forward_range R1, forward_range R2,
 			class Pred = equal_to, class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+		requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
 		constexpr safe_iterator_t<R1> operator()(R1&& r1, R2&& r2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -21,9 +21,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __find_first_of_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, ForwardIterator I2, Sentinel<I2> S2,
+		template<input_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_for<I2> S2,
 			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<I1, Proj1>,	projected<I2, Proj2>> Pred = equal_to>
+			indirect_relation<projected<I1, Proj1>,	projected<I2, Proj2>> Pred = equal_to>
 		constexpr I1 operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
@@ -39,9 +39,9 @@ STL2_OPEN_NAMESPACE {
 			return first1;
 		}
 
-		template<InputRange R1, ForwardRange R2,
+		template<input_range R1, forward_range R2,
 			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<
+			indirect_relation<
 				projected<iterator_t<R1>, Proj1>,
 				projected<iterator_t<R2>, Proj2>> Pred = equal_to>
 		constexpr safe_iterator_t<R1>

--- a/include/stl2/detail/algorithm/find_if.hpp
+++ b/include/stl2/detail/algorithm/find_if.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __find_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr I
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -32,8 +32,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/find_if_not.hpp
+++ b/include/stl2/detail/algorithm/find_if_not.hpp
@@ -21,16 +21,16 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __find_if_not_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr I
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			return find_if(std::move(first), std::move(last),
 				__stl2::not_fn(__stl2::ref(pred)), __stl2::ref(proj));
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return find_if(begin(r), end(r),

--- a/include/stl2/detail/algorithm/for_each.hpp
+++ b/include/stl2/detail/algorithm/for_each.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	using for_each_result = __in_fun_result<I, F>;
 
 	struct __for_each_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryInvocable<projected<I, Proj>> F>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_invocable<projected<I, Proj>> F>
 		constexpr for_each_result<I, F>
 		operator()(I first, S last, F fun, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(fun)};
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryInvocable<projected<iterator_t<R>, Proj>> F>
+		template<input_range R, class Proj = identity,
+			indirect_unary_invocable<projected<iterator_t<R>, Proj>> F>
 		constexpr for_each_result<safe_iterator_t<R>, F>
 		operator()(R&& r, F fun, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(fun), std::move(proj));

--- a/include/stl2/detail/algorithm/forward_sort.hpp
+++ b/include/stl2/detail/algorithm/forward_sort.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct __fsort_n_fn {
 			template<class I, class Comp = less, class Proj = identity>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			I operator()(I first, const iter_difference_t<I> n,
 				Comp comp = {}, Proj proj = {}) const
 			{
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 			using buf_t = temporary_buffer<iter_value_t<I>>;
 
 			template<class I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			static I merge_n_with_buffer(I f0, iter_difference_t<I> n0,
 				I f1, iter_difference_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
@@ -85,7 +85,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			template<class I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			static constexpr void merge_n_step_0(I f0, iter_difference_t<I> n0,
 				I f1, iter_difference_t<I> n1,
 				Comp& comp, Proj& proj,
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			template<class I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			static constexpr void merge_n_step_1(I f0, iter_difference_t<I> n0,
 				I f1, iter_difference_t<I> n1,
 				Comp& comp, Proj& proj,
@@ -133,7 +133,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			template<class I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			static I merge_n_adaptive(I f0, iter_difference_t<I> n0,
 				I f1, iter_difference_t<I> n1,
 				buf_t<I>& buf, Comp& comp, Proj& proj)
@@ -163,7 +163,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			template<class I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			requires sortable<I, Comp, Proj>
 			static I sort_n_adaptive(I first, const iter_difference_t<I> n, buf_t<I>& buf,
 				Comp& comp, Proj& proj)
 			{

--- a/include/stl2/detail/algorithm/generate.hpp
+++ b/include/stl2/detail/algorithm/generate.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __generate_fn : private __niebloid {
-		template<Iterator O, Sentinel<O> S, copy_constructible F>
-		requires invocable<F&> && Writable<O, invoke_result_t<F&>>
+		template<input_or_output_iterator O, sentinel_for<O> S, copy_constructible F>
+		requires invocable<F&> && writable<O, invoke_result_t<F&>>
 		constexpr O operator()(O first, S last, F gen) const {
 			for (; first != last; ++first) {
 				*first = gen();
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<class R, copy_constructible F>
-		requires invocable<F&> && OutputRange<R, invoke_result_t<F&>>
+		requires invocable<F&> && output_range<R, invoke_result_t<F&>>
 		constexpr safe_iterator_t<R> operator()(R&& r, F gen) const {
 			return (*this)(begin(r), end(r), __stl2::ref(gen));
 		}

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __generate_n_fn : private __niebloid {
-		template<Iterator O, copy_constructible F>
-		requires invocable<F&> && Writable<O, invoke_result_t<F&>>
+		template<input_or_output_iterator O, copy_constructible F>
+		requires invocable<F&> && writable<O, invoke_result_t<F&>>
 		constexpr O operator()(O first, iter_difference_t<O> n, F gen) const {
 			for (; n > 0; (void) ++first, --n) {
 				*first = gen();

--- a/include/stl2/detail/algorithm/heap_sift.hpp
+++ b/include/stl2/detail/algorithm/heap_sift.hpp
@@ -31,8 +31,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct __sift_up_n_fn {
-			template<RandomAccessIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<random_access_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			constexpr void operator()(I first, iter_difference_t<I> n,
 				Comp comp, Proj proj) const
 			{
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 		inline constexpr __sift_up_n_fn sift_up_n {};
 
 		struct __sift_down_n_fn {
-			template<RandomAccessIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<random_access_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			constexpr void operator()(I first, iter_difference_t<I> n, I start,
 				Comp comp, Proj proj) const
 			{

--- a/include/stl2/detail/algorithm/includes.hpp
+++ b/include/stl2/detail/algorithm/includes.hpp
@@ -20,9 +20,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __includes_fn : private  __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, class Proj1 = identity, class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<I1, Proj1>,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
+			indirect_strict_weak_order<projected<I1, Proj1>,
 				projected<I2, Proj2>> Comp = less>
 		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -44,9 +44,9 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<InputRange R1, InputRange R2, class Proj1 = identity,
+		template<input_range R1, input_range R2, class Proj1 = identity,
 			class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R1>, Proj1>,
+			indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
 				projected<iterator_t<R2>, Proj2>> Comp = less>
 		constexpr bool operator()(R1&& r1, R2&& r2, Comp comp = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/inplace_merge.hpp
+++ b/include/stl2/detail/algorithm/inplace_merge.hpp
@@ -38,14 +38,14 @@
 // inplace_merge [alg.merge]
 //
 // TODO:
-// * SizedRange overload; downgrade the enumerate call to a distance?
+// * sized_range overload; downgrade the enumerate call to a distance?
 // * Forward ranges.
 //
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct merge_adaptive_fn {
-			template<BidirectionalIterator I, class C, class P>
-			requires Sortable<I, __f<C>, __f<P>>
+			template<bidirectional_iterator I, class C, class P>
+			requires sortable<I, __f<C>, __f<P>>
 			void operator()(I begin, I middle, I end, iter_difference_t<I> len1, iter_difference_t<I> len2,
 				detail::temporary_buffer<iter_value_t<I>>& buf, C pred, P proj) const
 			{
@@ -131,8 +131,8 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 		private:
-			template<BidirectionalIterator I, class C, class P>
-			requires Sortable<I, C, P>
+			template<bidirectional_iterator I, class C, class P>
+			requires sortable<I, C, P>
 			static void impl(I first, I middle, I last, iter_difference_t<I> len1,
 				iter_difference_t<I> len2, temporary_buffer<iter_value_t<I>>& buf,
 				C& pred, P& proj)
@@ -168,8 +168,8 @@ STL2_OPEN_NAMESPACE {
 
 		struct inplace_merge_no_buffer_fn
 		{
-			template<BidirectionalIterator I, class C = less, class P = identity>
-			requires Sortable<I, __f<C>, __f<P>>
+			template<bidirectional_iterator I, class C = less, class P = identity>
+			requires sortable<I, __f<C>, __f<P>>
 			void operator()(I begin, I middle, I end, iter_difference_t<I> len1,
 				iter_difference_t<I> len2, C pred = {}, P proj = {}) const
 			{
@@ -183,9 +183,9 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __inplace_merge_fn : private __niebloid {
-		template<BidirectionalIterator I, Sentinel<I> S, class Comp = less,
+		template<bidirectional_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		I operator()(I first, I middle, S last, Comp comp = {}, Proj proj = {}) const {
 			auto len1 = distance(first, middle);
 			auto len2_and_end = ext::enumerate(middle, std::move(last));
@@ -199,8 +199,8 @@ STL2_OPEN_NAMESPACE {
 			return len2_and_end.end;
 		}
 
-		template<BidirectionalRange Rng, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<Rng>, Comp, Proj>
+		template<bidirectional_range Rng, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<Rng>, Comp, Proj>
 		safe_iterator_t<Rng>
 		operator()(Rng&& rng, iterator_t<Rng> middle, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(rng), std::move(middle), end(rng), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/is_heap.hpp
+++ b/include/stl2/detail/algorithm/is_heap.hpp
@@ -30,16 +30,16 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __is_heap_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr bool
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			return last == is_heap_until(std::move(first), last,
 				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<RandomAccessRange Rng, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less>
+		template<random_access_range Rng, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<Rng>, Proj>> Comp = less>
 		constexpr bool
 		operator()(Rng&& rng, Comp comp = {}, Proj proj = {}) const {
 			return end(rng) ==

--- a/include/stl2/detail/algorithm/is_heap_until.hpp
+++ b/include/stl2/detail/algorithm/is_heap_until.hpp
@@ -31,8 +31,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct __is_heap_until_n_fn {
-			template<RandomAccessIterator I, class Proj = identity,
-				IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+			template<random_access_iterator I, class Proj = identity,
+				indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 			constexpr I operator()(I first, const iter_difference_t<I> n,
 				Comp comp = {}, Proj proj = {}) const
 			{
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __is_heap_until_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(first, std::move(last));
@@ -74,8 +74,8 @@ STL2_OPEN_NAMESPACE {
 				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<RandomAccessRange Rng, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<Rng>, Proj>> Comp = less>
+		template<random_access_range Rng, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<Rng>, Proj>> Comp = less>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, Comp comp = {}, Proj proj = {}) const {
 			return detail::is_heap_until_n(begin(rng), distance(rng),

--- a/include/stl2/detail/algorithm/is_partitioned.hpp
+++ b/include/stl2/detail/algorithm/is_partitioned.hpp
@@ -21,8 +21,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __is_partitioned_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr bool
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			first = find_if_not(std::move(first), last,
@@ -31,8 +31,8 @@ STL2_OPEN_NAMESPACE {
 				__stl2::ref(pred), __stl2::ref(proj));
 		}
 
-		template<InputRange Rng, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<Rng>, Proj>> Pred>
+		template<input_range Rng, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<Rng>, Proj>> Pred>
 		constexpr bool
 		operator()(Rng&& rng, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -130,7 +130,8 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Do the two ranges have the same length, and if so what is it?
-		template<input_or_output_iterator I1, sentinel_for<I1> S1, input_or_output_iterator I2, sentinel_for<I2> S2>
+		template<input_or_output_iterator I1, sentinel_for<I1> S1,
+			input_or_output_iterator I2, sentinel_for<I2> S2>
 		static constexpr std::pair<bool, iter_difference_t<I1>>
 		__common_range_length(I1 first1, S1 last1, I2 first2, S2 last2) {
 			using D = iter_difference_t<I1>;

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -27,16 +27,16 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __is_permutation_fn : private __niebloid {
-		template<ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
-			Sentinel<I2> S2, class Pred = equal_to, class Proj1 = identity,
+		template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
+			sentinel_for<I2> S2, class Pred = equal_to, class Proj1 = identity,
 			class Proj2 = identity>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedSentinel<S1, I1> || SizedSentinel<S2, I2>) {
+			if constexpr (sized_sentinel_for<S1, I1> || sized_sentinel_for<S2, I2>) {
 				iter_difference_t<I1> count1;
-				if constexpr (SizedSentinel<S1, I1>) {
+				if constexpr (sized_sentinel_for<S1, I1>) {
 					count1 = last1 - first1;
 					if (!__has_length(first2, last2, count1)) return false;
 				} else {
@@ -61,17 +61,17 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R1, ForwardRange R2, class Pred = equal_to,
+		template<forward_range R1, forward_range R2, class Pred = equal_to,
 			class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>, Pred,
+		requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred,
 			Proj1, Proj2>
 		constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedRange<R1> || SizedRange<R2>) {
+			if constexpr (sized_range<R1> || sized_range<R2>) {
 				using D = iter_difference_t<iterator_t<R1>>;
 				D count1;
-				if constexpr (SizedRange<R1>) {
+				if constexpr (sized_range<R1>) {
 					count1 = distance(r1);
 					if (!__has_length(r2, count1)) return false;
 				} else {
@@ -105,10 +105,10 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Does distance(first, last) == n?
-		template<Iterator I, Sentinel<I> S, signed_integral D>
+		template<input_or_output_iterator I, sentinel_for<I> S, signed_integral D>
 		static constexpr bool __has_length(const I first, const S last, const D n) {
 			STL2_EXPECT(n >= 0);
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				return n == last - first;
 			} else {
 				if (__can_represent<iter_difference_t<I>>(n)) {
@@ -119,10 +119,10 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 		// Does distance(rng) == n?
-		template<Range Rng, signed_integral D>
+		template<range Rng, signed_integral D>
 		static constexpr bool __has_length(Rng&& rng, const D n) {
 			STL2_EXPECT(n >= 0);
-			if constexpr (SizedRange<Rng>) {
+			if constexpr (sized_range<Rng>) {
 				return n == distance(rng);
 			} else {
 				return __has_length(begin(rng), end(rng), n);
@@ -130,15 +130,15 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Do the two ranges have the same length, and if so what is it?
-		template<Iterator I1, Sentinel<I1> S1, Iterator I2, Sentinel<I2> S2>
+		template<input_or_output_iterator I1, sentinel_for<I1> S1, input_or_output_iterator I2, sentinel_for<I2> S2>
 		static constexpr std::pair<bool, iter_difference_t<I1>>
 		__common_range_length(I1 first1, S1 last1, I2 first2, S2 last2) {
 			using D = iter_difference_t<I1>;
 
-			if constexpr (SizedSentinel<S1, I1>) {
+			if constexpr (sized_sentinel_for<S1, I1>) {
 				const auto count = last1 - first1;
 				return {__has_length(first2, last2, count), count};
-			} else if constexpr (SizedSentinel<S2, I2>) {
+			} else if constexpr (sized_sentinel_for<S2, I2>) {
 				const auto count = last2 - first2;
 				return {__has_length(first1, last1, count), static_cast<D>(count)};
 			} else {
@@ -149,15 +149,15 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 		}
-		template<Range Rng1, Range Rng2>
+		template<range Rng1, range Rng2>
 		static constexpr std::pair<bool, iter_difference_t<iterator_t<Rng1>>>
 		__common_range_length(Rng1&& rng1, Rng2&& rng2) {
 			using D = iter_difference_t<iterator_t<Rng1>>;
 
-			if constexpr (SizedRange<Rng1>) {
+			if constexpr (sized_range<Rng1>) {
 				auto count = distance(rng1);
 				return {__has_length(rng2, count), count};
-			} else if constexpr (SizedRange<Rng2>) {
+			} else if constexpr (sized_range<Rng2>) {
 				auto count = distance(rng2);
 				return {__has_length(rng1, count), static_cast<D>(count)};
 			} else {
@@ -167,9 +167,9 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardIterator I1, ForwardIterator I2,
+		template<forward_iterator I1, forward_iterator I2,
 			class Pred, class Proj1, class Proj2>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static bool __is_permutation_tail(const I1 first1, const I2 first2,
 			const iter_difference_t<I1> n, Pred& pred, Proj1& proj1, Proj2& proj2)
 		{
@@ -212,9 +212,9 @@ STL2_OPEN_NAMESPACE {
 			return true;
 		}
 
-		template<ForwardIterator I1, ForwardIterator I2,
+		template<forward_iterator I1, forward_iterator I2,
 			class Pred, class Proj1, class Proj2>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static bool __is_permutation_trim(I1 first1, I2 first2, iter_difference_t<I1> n,
 			Pred& pred, Proj1& proj1, Proj2& proj2)
 		{

--- a/include/stl2/detail/algorithm/is_sorted.hpp
+++ b/include/stl2/detail/algorithm/is_sorted.hpp
@@ -20,16 +20,16 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __is_sorted_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr bool
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			return last == is_sorted_until(std::move(first), last,
 				__stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<forward_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr bool operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return end(r) == is_sorted_until(begin(r), end(r),
 				__stl2::ref(comp), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/is_sorted_until.hpp
+++ b/include/stl2/detail/algorithm/is_sorted_until.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __is_sorted_until_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			if (first != last) {
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<forward_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/lexicographical_compare.hpp
+++ b/include/stl2/detail/algorithm/lexicographical_compare.hpp
@@ -20,9 +20,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __lexicographical_compare_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, class Proj1 = identity, class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<I1, Proj1>,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
+			indirect_strict_weak_order<projected<I1, Proj1>,
 				projected<I2, Proj2>> Comp = less>
 		constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -49,9 +49,9 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<InputRange Rng1, InputRange Rng2,
+		template<input_range Rng1, input_range Rng2,
 			class Proj1 = identity, class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<Rng1>, Proj1>,
+			indirect_strict_weak_order<projected<iterator_t<Rng1>, Proj1>,
 				projected<iterator_t<Rng2>, Proj2>> Comp = less>
 		constexpr bool operator()(Rng1&& rng1, Rng2&& rng2,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/lower_bound.hpp
+++ b/include/stl2/detail/algorithm/lower_bound.hpp
@@ -23,8 +23,8 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __lower_bound_n_fn {
 			template<class I, class T, class Comp = less, class Proj = identity>
-			requires ForwardIterator<__f<I>> &&
-				IndirectStrictWeakOrder<Comp, const T*, projected<__f<I>, Proj>>
+			requires forward_iterator<__f<I>> &&
+				indirect_strict_weak_order<Comp, const T*, projected<__f<I>, Proj>>
 			constexpr __f<I> operator()(I&& first, iter_difference_t<__f<I>> n,
 				const T& value, Comp comp = {}, Proj proj = {}) const
 			{
@@ -40,12 +40,12 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __lower_bound_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class T, class Proj = identity,
-			IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
+			indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = less>
 		constexpr I operator()(I first, S last, const T& value, Comp comp = {},
 			Proj proj = {}) const
 		{
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				auto n = distance(first, std::move(last));
 				return ext::lower_bound_n(std::move(first), n, value,
 					__stl2::ref(comp), __stl2::ref(proj));
@@ -58,13 +58,13 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange Rng, class T, class Proj = identity,
-			IndirectStrictWeakOrder<const T*,
+		template<forward_range Rng, class T, class Proj = identity,
+			indirect_strict_weak_order<const T*,
 				projected<iterator_t<Rng>, Proj>> Comp = less>
 		constexpr safe_iterator_t<Rng> operator()(Rng&& rng, const T& value,
 			Comp comp = {}, Proj proj = {}) const
 		{
-			if constexpr (SizedRange<Rng>) {
+			if constexpr (sized_range<Rng>) {
 				return ext::lower_bound_n(begin(rng), distance(rng), value,
 					__stl2::ref(comp), __stl2::ref(proj));
 			} else {

--- a/include/stl2/detail/algorithm/make_heap.hpp
+++ b/include/stl2/detail/algorithm/make_heap.hpp
@@ -31,9 +31,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __make_heap_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(first, std::move(last));
@@ -41,8 +41,8 @@ STL2_OPEN_NAMESPACE {
 			return first + n;
 		}
 
-		template<RandomAccessRange Rng, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<Rng>, Comp, Proj>
+		template<random_access_range Rng, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<Rng>, Comp, Proj>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(rng);
@@ -50,8 +50,8 @@ STL2_OPEN_NAMESPACE {
 			return begin(rng) + n;
 		}
 	private:
-		template<RandomAccessIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<random_access_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static void make_heap_n(I first, iter_difference_t<I> n, Comp comp, Proj proj) {
 			if (n > 1) {
 				// start from the first parent, there is no need to consider children

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __max_fn : private __niebloid {
 		template<class T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr const T&
 		operator()(const T& a, const T& b, Comp comp = {}, Proj proj = {}) const {
 			const bool test = __stl2::invoke(comp,
@@ -32,26 +32,26 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<copyable T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr T operator()(std::initializer_list<T> r, Comp comp = {},
 			Proj proj = {}) const
 		{
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<input_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		requires
-			IndirectlyCopyableStorable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
+			indirectly_copyable_storable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
 		constexpr iter_value_t<iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	private:
-		template<InputRange R, class Proj,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp>
+		template<input_range R, class Proj,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp>
 		requires
-			IndirectlyCopyableStorable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
+			indirectly_copyable_storable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
 		static constexpr iter_value_t<iterator_t<R>>
 		impl(R&& r, Comp comp, Proj proj) {
 			auto first = begin(r);

--- a/include/stl2/detail/algorithm/max_element.hpp
+++ b/include/stl2/detail/algorithm/max_element.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __max_element_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			if (first != last) {
@@ -36,8 +36,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<forward_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -25,10 +25,10 @@ STL2_OPEN_NAMESPACE {
 	using merge_result = __in_in_out_result<I1, I2, O>;
 
 	struct __merge_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2, Sentinel<I2> S2,
-			WeaklyIncrementable O, class Comp = less, class Proj1 = identity,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+			weakly_incrementable O, class Comp = less, class Proj1 = identity,
 			class Proj2 = identity>
-		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
 		constexpr merge_result<I1, I2, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -60,9 +60,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first1), std::move(first2), std::move(result)};
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O, class Comp = less,
+		template<input_range R1, input_range R2, weakly_incrementable O, class Comp = less,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
 		constexpr merge_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
 		operator()(R1&& r1, R2&& r2, O result, Comp comp = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -23,7 +23,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __min_fn : private __niebloid {
 		template<class T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr const T&
 		operator()(const T& a, const T& b, Comp comp = {}, Proj proj = {}) const {
 			const bool test = __stl2::invoke(comp,
@@ -32,24 +32,24 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<copyable T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr T
 		operator()(std::initializer_list<T> r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
-		requires IndirectlyCopyableStorable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
+		template<input_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
+		requires indirectly_copyable_storable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
 		constexpr iter_value_t<iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	private:
-		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<input_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		requires
-			IndirectlyCopyableStorable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
+			indirectly_copyable_storable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
 		static constexpr iter_value_t<iterator_t<R>>
 		impl(R&& r, Comp comp = {}, Proj proj = {}) {
 			auto first = begin(r);

--- a/include/stl2/detail/algorithm/min_element.hpp
+++ b/include/stl2/detail/algorithm/min_element.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __min_element_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			if (first != last) {
@@ -36,8 +36,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<forward_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -24,7 +24,7 @@
 STL2_OPEN_NAMESPACE {
 	struct __minmax_fn : private __niebloid {
 		template<class T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr minmax_result<const T&>
 		operator()(const T& a, const T& b, Comp comp = {}, Proj proj = {}) const {
 			const bool test = __stl2::invoke(comp,
@@ -36,23 +36,23 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		template<copyable T, class Proj = identity,
-			IndirectStrictWeakOrder<projected<const T*, Proj>> Comp = less>
+			indirect_strict_weak_order<projected<const T*, Proj>> Comp = less>
 		constexpr minmax_result<T>
 		operator()(std::initializer_list<T>&& r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<input_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		requires copyable<iter_value_t<iterator_t<R>>>
 		constexpr minmax_result<iter_value_t<iterator_t<R>>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return impl(r, __stl2::ref(comp), __stl2::ref(proj));
 		}
 	private:
-		template<InputRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
-		requires IndirectlyCopyableStorable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
+		template<input_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
+		requires indirectly_copyable_storable<iterator_t<R>, iter_value_t<iterator_t<R>>*>
 		static constexpr minmax_result<iter_value_t<iterator_t<R>>>
 		impl(R&& r, Comp comp = {}, Proj proj = {}) {
 			using V = iter_value_t<iterator_t<R>>;

--- a/include/stl2/detail/algorithm/minmax_element.hpp
+++ b/include/stl2/detail/algorithm/minmax_element.hpp
@@ -25,8 +25,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __minmax_element_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectStrictWeakOrder<projected<I, Proj>> Comp = less>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_strict_weak_order<projected<I, Proj>> Comp = less>
 		constexpr minmax_result<I>
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const
 		{
@@ -61,8 +61,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = less>
+		template<forward_range R, class Proj = identity,
+			indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr minmax_result<safe_iterator_t<R>>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp), __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -24,9 +24,9 @@ STL2_OPEN_NAMESPACE {
 	using mismatch_result = __in_in_result<I1, I2>;
 
 	struct __mismatch_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<I1, Proj1>,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
+			indirect_relation<projected<I1, Proj1>,
 				projected<I2, Proj2>> Pred = equal_to>
 		constexpr mismatch_result<I1, I2>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
@@ -46,9 +46,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first1), std::move(first2)};
 		}
 
-		template<InputRange R1, InputRange R2,
+		template<input_range R1, input_range R2,
 			class Proj1 = identity, class Proj2 = identity,
-			IndirectRelation<projected<iterator_t<R1>, Proj1>,
+			indirect_relation<projected<iterator_t<R1>, Proj1>,
 				projected<iterator_t<R2>, Proj2>> Pred = equal_to>
 		constexpr mismatch_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
 		operator()(R1&& r1, R2&& r2, Pred pred = {},

--- a/include/stl2/detail/algorithm/move.hpp
+++ b/include/stl2/detail/algorithm/move.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	using move_result = __in_out_result<I, O>;
 
 	struct __move_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
-		requires IndirectlyMovable<I, O>
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
+		requires indirectly_movable<I, O>
 		constexpr move_result<I, O>
 		operator()(I first, S last, O result) const {
 			for (; first != last; (void) ++first, (void) ++result) {
@@ -34,8 +34,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O>
-		requires IndirectlyMovable<iterator_t<R>, O>
+		template<input_range R, weakly_incrementable O>
+		requires indirectly_movable<iterator_t<R>, O>
 		constexpr move_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result) const {
 			return (*this)(begin(r), end(r), std::move(result));
@@ -46,8 +46,8 @@ STL2_OPEN_NAMESPACE {
 
 	namespace ext {
 		struct __move_fn : private __niebloid {
-			template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O>
-			requires IndirectlyMovable<I, O>
+			template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
+			requires indirectly_movable<I, O>
 			constexpr move_result<I, O>
 			operator()(I first, S last, O result) const {
 				for (; first != last; (void) ++first, (void) ++result) {
@@ -56,9 +56,9 @@ STL2_OPEN_NAMESPACE {
 				return {std::move(first), std::move(result)};
 			}
 
-			template<InputRange R, class O>
-			requires (!Range<O> && WeaklyIncrementable<__f<O>>
-				&& IndirectlyMovable<iterator_t<R>, __f<O>>)
+			template<input_range R, class O>
+			requires (!range<O> && weakly_incrementable<__f<O>>
+				&& indirectly_movable<iterator_t<R>, __f<O>>)
 			constexpr move_result<safe_iterator_t<R>, __f<O>>
 			operator()(R&& r, O&& result_) const {
 				auto result = std::forward<O>(result_);
@@ -66,9 +66,9 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Extension
-			template<InputIterator I1, Sentinel<I1> S1,
-				Iterator I2, Sentinel<I2> S2>
-			requires IndirectlyMovable<I1, I2>
+			template<input_iterator I1, sentinel_for<I1> S1,
+				input_or_output_iterator I2, sentinel_for<I2> S2>
+			requires indirectly_movable<I1, I2>
 			constexpr move_result<I1, I2>
 			operator()(I1 first1, S1 last1, I2 first2, S2 last2) const {
 				while (true) {
@@ -82,8 +82,8 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Extension
-			template<InputRange R1, Range R2>
-			requires IndirectlyMovable<iterator_t<R1>, iterator_t<R2>>
+			template<input_range R1, range R2>
+			requires indirectly_movable<iterator_t<R1>, iterator_t<R2>>
 			constexpr move_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
 			operator()(R1&& r1, R2&& r2) const {
 				return (*this)(begin(r1), end(r1), begin(r2), end(r2));

--- a/include/stl2/detail/algorithm/move_backward.hpp
+++ b/include/stl2/detail/algorithm/move_backward.hpp
@@ -23,9 +23,9 @@ STL2_OPEN_NAMESPACE {
 	using move_backward_result = __in_out_result<I1, I2>;
 
 	struct __move_backward_fn : private __niebloid {
-		template<BidirectionalIterator I1, Sentinel<I1> S1,
-			BidirectionalIterator I2>
-		requires IndirectlyMovable<I1, I2>
+		template<bidirectional_iterator I1, sentinel_for<I1> S1,
+			bidirectional_iterator I2>
+		requires indirectly_movable<I1, I2>
 		constexpr move_backward_result<I1, I2>
 		operator()(I1 first, S1 s, I2 result) const {
 			auto last = next(first, std::move(s));
@@ -36,8 +36,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(last), std::move(result)};
 		}
 
-		template<BidirectionalRange Rng, BidirectionalIterator I>
-		requires IndirectlyMovable<iterator_t<Rng>, I>
+		template<bidirectional_range Rng, bidirectional_iterator I>
+		requires indirectly_movable<iterator_t<Rng>, I>
 		constexpr move_backward_result<safe_iterator_t<Rng>, I>
 		operator()(Rng&& rng, I result) const {
 			return (*this)(begin(rng), end(rng), std::move(result));

--- a/include/stl2/detail/algorithm/next_permutation.hpp
+++ b/include/stl2/detail/algorithm/next_permutation.hpp
@@ -30,9 +30,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __next_permutation_fn : private __niebloid {
-		template<BidirectionalIterator I, Sentinel<I> S,
+		template<bidirectional_iterator I, sentinel_for<I> S,
 			class Comp = less, class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr bool
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			if (first == last) return false;
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<BidirectionalRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<bidirectional_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr bool
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/none_of.hpp
+++ b/include/stl2/detail/algorithm/none_of.hpp
@@ -20,8 +20,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __none_of_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<input_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr bool
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -32,8 +32,8 @@ STL2_OPEN_NAMESPACE {
 			return true;
 		}
 
-		template<InputRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<input_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr bool operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred),
 				__stl2::ref(proj));

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -32,9 +32,9 @@
 STL2_OPEN_NAMESPACE {
 	struct __nth_element_fn : private __niebloid {
 		// TODO: refactor this monstrosity.
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I operator()(I first, I nth, S last, Comp comp = {},
 			Proj proj = {}) const
 		{
@@ -214,8 +214,8 @@ STL2_OPEN_NAMESPACE {
 			return end_orig;
 		}
 
-		template<RandomAccessRange Rng, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<Rng>, Comp, Proj>
+		template<random_access_range Rng, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<Rng>, Comp, Proj>
 		constexpr safe_iterator_t<Rng> operator()(Rng&& rng, iterator_t<Rng> nth,
 			Comp comp = {}, Proj proj = {}) const
 		{
@@ -225,7 +225,7 @@ STL2_OPEN_NAMESPACE {
 	private:
 		// stable, 2-3 compares, 0-2 swaps
 		template<class I, class C, class P>
-		requires Sortable<I, C, P>
+		requires sortable<I, C, P>
 		static constexpr unsigned sort3(I x, I y, I z, C& comp, P& proj) {
 			auto pred = [&](auto&& lhs, auto&& rhs) -> bool {
 				return __stl2::invoke(comp,
@@ -258,8 +258,8 @@ STL2_OPEN_NAMESPACE {
 			return 1;
 		}
 
-		template<BidirectionalIterator I, class C, class P>
-		requires Sortable<I, C, P>
+		template<bidirectional_iterator I, class C, class P>
+		requires sortable<I, C, P>
 		static constexpr void selection_sort(I begin, I end, C &comp, P &proj) {
 			STL2_EXPECT(begin != end);
 			for (I lm1 = prev(end); begin != lm1; ++begin) {

--- a/include/stl2/detail/algorithm/partial_sort.hpp
+++ b/include/stl2/detail/algorithm/partial_sort.hpp
@@ -24,9 +24,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __partial_sort_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I operator()(I first, I middle, S last, Comp comp = {},
 			Proj proj = {}) const
 		{
@@ -47,8 +47,8 @@ STL2_OPEN_NAMESPACE {
 			return i;
 		}
 
-		template<RandomAccessRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<random_access_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr safe_iterator_t<R> operator()(R&& r, iterator_t<R> middle,
 			Comp comp = {}, Proj proj = {}) const
 		{

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -25,11 +25,11 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __partial_sort_copy_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2,
-			Sentinel<I2> S2, class Proj1 = identity, class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<I1, Proj1>,
+		template<input_iterator I1, sentinel_for<I1> S1, random_access_iterator I2,
+			sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
+			indirect_strict_weak_order<projected<I1, Proj1>,
 				projected<I2, Proj2>> Comp = less>
-		requires IndirectlyCopyable<I1, I2> && Sortable<I2, Comp, Proj2>
+		requires indirectly_copyable<I1, I2> && sortable<I2, Comp, Proj2>
 		constexpr I2
 		operator()(I1 first, S1 last, I2 result_first, S2 result_last,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -59,12 +59,12 @@ STL2_OPEN_NAMESPACE {
 			return r;
 		}
 
-		template<InputRange R1, RandomAccessRange R2, class Proj1 = identity,
+		template<input_range R1, random_access_range R2, class Proj1 = identity,
 			class Proj2 = identity,
-			IndirectStrictWeakOrder<projected<iterator_t<R1>, Proj1>,
+			indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
 				projected<iterator_t<R2>, Proj2>> Comp = less>
-		requires IndirectlyCopyable<iterator_t<R1>, iterator_t<R2>> &&
-			Sortable<iterator_t<R2>, Comp, Proj2>
+		requires indirectly_copyable<iterator_t<R1>, iterator_t<R2>> &&
+			sortable<iterator_t<R2>, Comp, Proj2>
 		constexpr safe_iterator_t<R2> operator()(R1&& r, R2&& result_r,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{

--- a/include/stl2/detail/algorithm/partition.hpp
+++ b/include/stl2/detail/algorithm/partition.hpp
@@ -31,10 +31,10 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __partition_fn : private __niebloid {
-		template<Permutable I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<permutable I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr I operator()(I first, S last_, Pred pred, Proj proj = {}) const {
-			if constexpr (BidirectionalIterator<I>) {
+			if constexpr (bidirectional_iterator<I>) {
 				auto last = next(first, std::move(last_));
 
 				for (; first != last; ++first) {
@@ -65,9 +65,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires Permutable<iterator_t<R>>
+		template<forward_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires permutable<iterator_t<R>>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/partition_copy.hpp
+++ b/include/stl2/detail/algorithm/partition_copy.hpp
@@ -24,10 +24,10 @@ STL2_OPEN_NAMESPACE {
 	using partition_copy_result = __in_out_out_result<I, O1, O2>;
 
 	struct __partition_copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O1,
-			WeaklyIncrementable O2, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
-		requires IndirectlyCopyable<I, O1> && IndirectlyCopyable<I, O2>
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O1,
+			weakly_incrementable O2, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
+		requires indirectly_copyable<I, O1> && indirectly_copyable<I, O2>
 		constexpr partition_copy_result<I, O1, O2>
 		operator()(I first, S last, O1 out_true, O2 out_false, Pred pred,
 			Proj proj = {}) const
@@ -45,11 +45,11 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(out_true), std::move(out_false)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O1, WeaklyIncrementable O2,
+		template<input_range R, weakly_incrementable O1, weakly_incrementable O2,
 			class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires IndirectlyCopyable<iterator_t<R>, O1> &&
-			IndirectlyCopyable<iterator_t<R>, O2>
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires indirectly_copyable<iterator_t<R>, O1> &&
+			indirectly_copyable<iterator_t<R>, O2>
 		constexpr partition_copy_result<safe_iterator_t<R>, O1, O2>
 		operator()(R&& r, O1 out_true, O2 out_false, Pred pred,
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/partition_point.hpp
+++ b/include/stl2/detail/algorithm/partition_point.hpp
@@ -32,8 +32,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __partition_point_n_fn {
-			template<ForwardIterator I, class Proj = identity,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<forward_iterator I, class Proj = identity,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			constexpr I operator()(I first, iter_difference_t<I> n, Pred pred,
 				Proj proj = {}) const
 			{
@@ -56,10 +56,10 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __partition_point_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr I operator()(I first, S last, Pred pred, Proj proj = {}) const {
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				auto n = distance(first, std::move(last));
 				return ext::partition_point_n(std::move(first), n,
 					__stl2::ref(pred), __stl2::ref(proj));
@@ -81,11 +81,11 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
+		template<forward_range R, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred, Proj proj = {}) const {
-			if constexpr (SizedRange<R>) {
+			if constexpr (sized_range<R>) {
 				return ext::partition_point_n(begin(r), distance(r),
 					__stl2::ref(pred), __stl2::ref(proj));
 			} else {

--- a/include/stl2/detail/algorithm/pop_heap.hpp
+++ b/include/stl2/detail/algorithm/pop_heap.hpp
@@ -32,8 +32,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct __pop_heap_n_fn {
-			template<RandomAccessIterator I, class Proj, class Comp>
-			requires Sortable<I, Comp, Proj>
+			template<random_access_iterator I, class Proj, class Comp>
+			requires sortable<I, Comp, Proj>
 			constexpr void
 			operator()(I first, iter_difference_t<I> n, Comp comp, Proj proj) const {
 				if (n > 1) {
@@ -48,9 +48,9 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __pop_heap_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(first, std::move(last));
@@ -58,8 +58,8 @@ STL2_OPEN_NAMESPACE {
 			return first + n;
 		}
 
-		template<RandomAccessRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<random_access_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(r);

--- a/include/stl2/detail/algorithm/prev_permutation.hpp
+++ b/include/stl2/detail/algorithm/prev_permutation.hpp
@@ -30,9 +30,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __prev_permutation_fn : private __niebloid {
-		template<BidirectionalIterator I, Sentinel<I> S, class Comp = less,
+		template<bidirectional_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr bool
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			if (first == last) return false;
@@ -65,8 +65,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<BidirectionalRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<bidirectional_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr bool
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/push_heap.hpp
+++ b/include/stl2/detail/algorithm/push_heap.hpp
@@ -31,9 +31,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __push_heap_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(first, std::move(last));
@@ -41,8 +41,8 @@ STL2_OPEN_NAMESPACE {
 			return first + n;
 		}
 
-		template<RandomAccessRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<random_access_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(r);

--- a/include/stl2/detail/algorithm/random_access_sort.hpp
+++ b/include/stl2/detail/algorithm/random_access_sort.hpp
@@ -24,8 +24,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace detail {
 		struct rsort {
-			template<BidirectionalIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<bidirectional_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			static constexpr void
 			unguarded_linear_insert(I last, iter_value_t<I> val, Comp& comp, Proj& proj)
 			{
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 				}
 				*last = std::move(val);
 			}
-			template<BidirectionalIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<bidirectional_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			static constexpr void insertion_sort(I first, I last, Comp& comp, Proj& proj)
 			{
 				if (first != last) {
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 		private:
-			template<BidirectionalIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<bidirectional_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			static constexpr void linear_insert(I first, I last, Comp& comp, Proj& proj)
 			{
 				iter_value_t<I> val = iter_move(last);

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -21,8 +21,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __remove_fn : private __niebloid {
-		template<Permutable I, Sentinel<I> S, class T, class Proj = identity>
-		requires IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		template<permutable I, sentinel_for<I> S, class T, class Proj = identity>
+		requires indirect_relation<equal_to, projected<I, Proj>, const T*>
 		constexpr I
 		operator()(I first, S last, const T& value, Proj proj = {}) const {
 			first = find(std::move(first), last, value, __stl2::ref(proj));
@@ -37,9 +37,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange Rng, class T, class Proj = identity>
-		requires Permutable<iterator_t<Rng>> &&
-			IndirectRelation<equal_to, projected<iterator_t<Rng>, Proj>, const T*>
+		template<forward_range Rng, class T, class Proj = identity>
+		requires permutable<iterator_t<Rng>> &&
+			indirect_relation<equal_to, projected<iterator_t<Rng>, Proj>, const T*>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, const T& value, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -24,10 +24,10 @@ STL2_OPEN_NAMESPACE {
 	using remove_copy_result = __in_out_result<I, O>;
 
 	struct __remove_copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O, class T,
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class T,
 			class Proj = identity>
-		requires IndirectlyCopyable<I, O> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T*>
+		requires indirectly_copyable<I, O> &&
+			indirect_relation<equal_to, projected<I, Proj>, const T*>
 		constexpr remove_copy_result<I, O>
 		operator()(I first, S last, O result, const T& value, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -40,9 +40,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, class T, class Proj = identity>
-		requires IndirectlyCopyable<iterator_t<R>, O> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T*>
+		template<input_range R, weakly_incrementable O, class T, class Proj = identity>
+		requires indirectly_copyable<iterator_t<R>, O> &&
+			indirect_relation<equal_to, projected<iterator_t<R>, Proj>, const T*>
 		constexpr remove_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, const T& value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result), value, __stl2::ref(proj));

--- a/include/stl2/detail/algorithm/remove_copy_if.hpp
+++ b/include/stl2/detail/algorithm/remove_copy_if.hpp
@@ -24,9 +24,9 @@ STL2_OPEN_NAMESPACE {
 	using remove_copy_if_result = __in_out_result<I, O>;
 
 	struct __remove_copy_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
-			class Proj = identity, IndirectUnaryPredicate<projected<I, Proj>> Pred>
-		requires IndirectlyCopyable<I, O>
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
+			class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
+		requires indirectly_copyable<I, O>
 		constexpr remove_copy_if_result<I, O>
 		operator()(I first, S last, O result, Pred pred, Proj proj = {}) const {
 			for (; first != last; ++first) {
@@ -39,9 +39,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+		template<input_range R, weakly_incrementable O, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr remove_copy_if_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result),

--- a/include/stl2/detail/algorithm/remove_if.hpp
+++ b/include/stl2/detail/algorithm/remove_if.hpp
@@ -21,8 +21,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __remove_if_fn : private __niebloid {
-		template<Permutable I, Sentinel<I> S, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
+		template<permutable I, sentinel_for<I> S, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
 		constexpr I
 		operator()(I first, S last, Pred pred, Proj proj = {}) const {
 			first = find_if(std::move(first), last, __stl2::ref(pred),
@@ -38,9 +38,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange Rng, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<Rng>, Proj>> Pred>
-		requires Permutable<iterator_t<Rng>>
+		template<forward_range Rng, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<Rng>, Proj>> Pred>
+		requires permutable<iterator_t<Rng>>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, Pred pred, Proj proj = {}) const {
 			return (*this)(begin(rng), end(rng), __stl2::ref(pred),

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -20,10 +20,10 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __replace_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T1, class T2,
+		template<input_iterator I, sentinel_for<I> S, class T1, class T2,
 			class Proj = identity>
-		requires Writable<I, const T2&> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T1*>
+		requires writable<I, const T2&> &&
+			indirect_relation<equal_to, projected<I, Proj>, const T1*>
 		constexpr I operator()(I first, S last, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
 		{
@@ -35,9 +35,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<InputRange R, class T1, class T2, class Proj = identity>
-		requires Writable<iterator_t<R>, const T2&> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
+		template<input_range R, class T1, class T2, class Proj = identity>
+		requires writable<iterator_t<R>, const T2&> &&
+			indirect_relation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
 		constexpr safe_iterator_t<R> operator()(R&& r, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
 		{

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -24,10 +24,10 @@ STL2_OPEN_NAMESPACE {
 	using replace_copy_result = __in_out_result<I, O>;
 
 	struct __replace_copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T1, class T2,
-			OutputIterator<const T2&> O, class Proj = identity>
-		requires IndirectlyCopyable<I, O> &&
-			IndirectRelation<equal_to, projected<I, Proj>, const T1*>
+		template<input_iterator I, sentinel_for<I> S, class T1, class T2,
+			output_iterator<const T2&> O, class Proj = identity>
+		requires indirectly_copyable<I, O> &&
+			indirect_relation<equal_to, projected<I, Proj>, const T1*>
 		constexpr replace_copy_result<I, O>
 		operator()(I first, S last, O result, const T1& old_value,
 			const T2& new_value, Proj proj = {}) const
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, class T1, class T2, OutputIterator<const T2&> O,
+		template<input_range R, class T1, class T2, output_iterator<const T2&> O,
 			class Proj = identity>
-		requires IndirectlyCopyable<iterator_t<R>, O> &&
-			IndirectRelation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
+		requires indirectly_copyable<iterator_t<R>, O> &&
+			indirect_relation<equal_to, projected<iterator_t<R>, Proj>, const T1*>
 		constexpr replace_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, const T1& old_value, const T2& new_value,
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/replace_copy_if.hpp
+++ b/include/stl2/detail/algorithm/replace_copy_if.hpp
@@ -24,10 +24,10 @@ STL2_OPEN_NAMESPACE {
 	using replace_copy_if_result = __in_out_result<I, O>;
 
 	struct __replace_copy_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T,
-			OutputIterator<const T&> O, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
-		requires IndirectlyCopyable<I, O>
+		template<input_iterator I, sentinel_for<I> S, class T,
+			output_iterator<const T&> O, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
+		requires indirectly_copyable<I, O>
 		constexpr replace_copy_if_result<I, O>
 		operator()(I first, S last, O result, Pred pred,
 			const T& new_value, Proj proj = {}) const
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, class T, OutputIterator<const T&> O,
+		template<input_range R, class T, output_iterator<const T&> O,
 			class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr replace_copy_if_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, Pred pred, const T& new_value,
 			Proj proj = {}) const

--- a/include/stl2/detail/algorithm/replace_if.hpp
+++ b/include/stl2/detail/algorithm/replace_if.hpp
@@ -20,9 +20,9 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __replace_if_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, class T, class Proj = identity,
-			IndirectUnaryPredicate<projected<I, Proj>> Pred>
-		requires Writable<I, const T&>
+		template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
+			indirect_unary_predicate<projected<I, Proj>> Pred>
+		requires writable<I, const T&>
 		constexpr I operator()(I first, S last, Pred pred, const T& new_value,
 			Proj proj = {}) const
 		{
@@ -34,9 +34,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<InputRange R, class T, class Proj = identity,
-			IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
-		requires Writable<iterator_t<R>, const T&>
+		template<input_range R, class T, class Proj = identity,
+			indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+		requires writable<iterator_t<R>, const T&>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Pred pred, const T& new_value, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(pred), new_value,

--- a/include/stl2/detail/algorithm/reverse.hpp
+++ b/include/stl2/detail/algorithm/reverse.hpp
@@ -42,7 +42,7 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __reverse_n_fn {
-			template<Permutable I>
+			template<permutable I>
 			constexpr I operator()(I first, iter_difference_t<I> n) const {
 				auto ufirst = ext::uncounted(first);
 				// TODO: tune this threshold.
@@ -52,12 +52,12 @@ STL2_OPEN_NAMESPACE {
 				return ext::recounted(first, std::move(last), n);
 			}
 		private:
-			template<Readable I>
+			template<readable I>
 			using buf_t = detail::temporary_buffer<iter_value_t<I>>;
 
 			// An adaptation of the EoP algorithm reverse_n_with_buffer
 			// Complexity: n moves + n / 2 swaps
-			template<Permutable I>
+			template<permutable I>
 			static I reverse_n_with_half_buffer(I first, const iter_difference_t<I> n, buf_t<I>& buf) {
 				// Precondition: $\property{mutable\_counted\_range}(first, n)$
 				STL2_EXPECT(n / 2 <= buf.size());
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// From EoP
-			template<Permutable I>
+			template<permutable I>
 			static I reverse_n_adaptive(I first, const iter_difference_t<I> n, buf_t<I>& buf)
 			{
 				// Precondition: $\property{mutable\_counted\_range}(first, n)$
@@ -109,11 +109,11 @@ STL2_OPEN_NAMESPACE {
 
 	struct __reverse_fn : private __niebloid {
 		// Extension: supports forward iterators
-		template<Permutable I, Sentinel<I> S>
+		template<permutable I, sentinel_for<I> S>
 		constexpr I operator()(I first, S last) const {
-			if constexpr (BidirectionalIterator<I>) {
+			if constexpr (bidirectional_iterator<I>) {
 				auto bound = next(first, std::move(last));
-				if constexpr (RandomAccessIterator<I>) {
+				if constexpr (random_access_iterator<I>) {
 					if (first != bound) {
 						for (auto m = bound; first < --m; ++first) {
 							iter_swap(first, m);
@@ -135,8 +135,8 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Extension: supports forward ranges
-		template<ForwardRange R>
-		requires Permutable<iterator_t<R>>
+		template<forward_range R>
+		requires permutable<iterator_t<R>>
 		constexpr safe_iterator_t<R> operator()(R&& r) const {
 			return (*this)(begin(r), end(r));
 		}

--- a/include/stl2/detail/algorithm/reverse_copy.hpp
+++ b/include/stl2/detail/algorithm/reverse_copy.hpp
@@ -24,8 +24,8 @@ STL2_OPEN_NAMESPACE {
 	using reverse_copy_result = __in_out_result<I, O>;
 
 	struct __reverse_copy_fn : private __niebloid {
-		template<BidirectionalIterator I, Sentinel<I> S, WeaklyIncrementable O>
-		requires IndirectlyCopyable<I, O>
+		template<bidirectional_iterator I, sentinel_for<I> S, weakly_incrementable O>
+		requires indirectly_copyable<I, O>
 		constexpr reverse_copy_result<I, O>
 		operator()(I first, S last, O result) const {
 			auto bound = next(first, std::move(last));
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(bound), std::move(result)};
 		}
 
-		template<BidirectionalRange R, WeaklyIncrementable O>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+		template<bidirectional_range R, weakly_incrementable O>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr reverse_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result) const {
 			return (*this)(begin(r), end(r), std::move(result));

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -33,7 +33,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __sean_parent_fn : private __niebloid {
-		template<Permutable I, Sentinel<I> S>
+		template<permutable I, sentinel_for<I> S>
 		constexpr subrange<I> operator()(I first, I middle, S last) const {
 			if (first == middle) {
 				first = next(std::move(first), std::move(last));
@@ -47,13 +47,13 @@ STL2_OPEN_NAMESPACE {
 					return __rotate_left(std::move(first), std::move(last));
 				}
 				if constexpr (same_as<I, S>) {
-					if constexpr (BidirectionalIterator<I>) {
+					if constexpr (bidirectional_iterator<I>) {
 						if (next(middle) == last) {
 							return __rotate_right(std::move(first), std
 								::move(last));
 						}
 					}
-					if constexpr (RandomAccessIterator<I>) {
+					if constexpr (random_access_iterator<I>) {
 						return __rotate_gcd(std::move(first), std::move(middle),
 							std::move(last));
 					}
@@ -63,14 +63,14 @@ STL2_OPEN_NAMESPACE {
 				std::move(last));
 		}
 
-		template<ForwardRange R>
-		requires Permutable<iterator_t<R>>
+		template<forward_range R>
+		requires permutable<iterator_t<R>>
 		constexpr safe_subrange_t<R>
 		operator()(R&& r, iterator_t<R> middle) const {
 			return (*this)(begin(r), std::move(middle), end(r));
 		}
 	private:
-		template<Permutable I, Sentinel<I> S>
+		template<permutable I, sentinel_for<I> S>
 		static constexpr subrange<I> __rotate_left(I first, S sent) {
 			STL2_EXPECT(first != sent);
 			iter_value_t<I> tmp = iter_move(first);
@@ -79,8 +79,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(last_but_one), std::move(last)};
 		}
 
-		template<Permutable I>
-		requires BidirectionalIterator<I>
+		template<permutable I>
+		requires bidirectional_iterator<I>
 		static constexpr subrange<I> __rotate_right(I first, I last) {
 			STL2_EXPECT(first != last);
 			I last_but_one = prev(last);
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(fp1), std::move(last)};
 		}
 
-		template<Permutable I, Sentinel<I> S>
+		template<permutable I, sentinel_for<I> S>
 		static constexpr subrange<I> __rotate_forward(I first, I middle, S last) {
 			STL2_EXPECT(first != middle);
 			STL2_EXPECT(middle != last);
@@ -134,8 +134,8 @@ STL2_OPEN_NAMESPACE {
 			return x;
 		}
 
-		template<Permutable I>
-		requires RandomAccessIterator<I>
+		template<permutable I>
+		requires random_access_iterator<I>
 		static constexpr subrange<I> __rotate_gcd(I first, I middle, I last) {
 			using D = iter_difference_t<I>;
 			D const m1 = middle - first;

--- a/include/stl2/detail/algorithm/rotate_copy.hpp
+++ b/include/stl2/detail/algorithm/rotate_copy.hpp
@@ -25,8 +25,8 @@ STL2_OPEN_NAMESPACE {
 	using rotate_copy_result = __in_out_result<I, O>;
 
 	struct __rotate_copy_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, WeaklyIncrementable O>
-		requires IndirectlyCopyable<I, O>
+		template<forward_iterator I, sentinel_for<I> S, weakly_incrementable O>
+		requires indirectly_copyable<I, O>
 		constexpr rotate_copy_result<I, O>
 		operator()(I first, I middle, S last, O result) const {
 			auto res = copy(middle, std::move(last), std::move(result));
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 			return res;
 		}
 
-		template<ForwardRange R, WeaklyIncrementable O>
-		requires IndirectlyCopyable<iterator_t<R>, O>
+		template<forward_range R, weakly_incrementable O>
+		requires indirectly_copyable<iterator_t<R>, O>
 		constexpr rotate_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, iterator_t<R> middle, O result) const {
 			return (*this)(begin(r), std::move(middle), end(r),

--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -29,21 +29,21 @@ STL2_OPEN_NAMESPACE {
 
 		template<class I, class S, class O, class Gen>
 		META_CONCEPT __sample_constraint =
-			InputIterator<I> && Sentinel<S, I> && WeaklyIncrementable<O> &&
-			IndirectlyCopyable<I, O> &&
-			UniformRandomBitGenerator<std::remove_reference_t<Gen>>;
+			input_iterator<I> && sentinel_for<S, I> && weakly_incrementable<O> &&
+			indirectly_copyable<I, O> &&
+			uniform_random_bit_generator<std::remove_reference_t<Gen>>;
 
 		struct __sample_fn : private __niebloid {
 			template<class I, class S, class O,
 				class Gen = detail::default_random_engine&>
 			requires __sample_constraint<I, S, O, Gen> &&
-				(ForwardIterator<I> || SizedSentinel<S, I> ||
-				 RandomAccessIterator<O>)
+				(forward_iterator<I> || sized_sentinel_for<S, I> ||
+				 random_access_iterator<O>)
 			constexpr sample_result<I, O>
 			operator()(I first, S last, O o, iter_difference_t<I> n,
 				Gen&& gen = detail::get_random_engine()) const
 			{
-				if constexpr (ForwardIterator<I> || SizedSentinel<S, I>) {
+				if constexpr (forward_iterator<I> || sized_sentinel_for<S, I>) {
 					const auto k = distance(first, last);
 					return sized_impl(std::move(first), std::move(last),
 						k, std::move(o), n, gen);
@@ -74,54 +74,54 @@ STL2_OPEN_NAMESPACE {
 			template<class I, class S, class OR,
 				class Gen = detail::default_random_engine&>
 			requires __sample_constraint<I, S, iterator_t<OR>, Gen> &&
-				(ForwardIterator<I> || SizedSentinel<S, I> ||
-				 RandomAccessRange<OR>) &&
-				(ForwardRange<OR> || SizedRange<OR>)
+				(forward_iterator<I> || sized_sentinel_for<S, I> ||
+				 random_access_range<OR>) &&
+				(forward_range<OR> || sized_range<OR>)
 			constexpr sample_result<I, safe_iterator_t<OR>>
 			operator()(I first, S last, OR&& o,
 				Gen&& gen = detail::get_random_engine()) const
 			{
-				if constexpr (ForwardIterator<I> || SizedSentinel<S, I>) {
+				if constexpr (forward_iterator<I> || sized_sentinel_for<S, I>) {
 					auto k = distance(first, last);
 					return sized_impl(std::move(first), std::move(last),
 						k, begin(o), distance(o), gen);
-				} else { // RandomAccessRange<OR>
+				} else { // random_access_range<OR>
 					return (*this)(std::move(first), std::move(last),
 						begin(o), distance(o), std::forward<Gen>(gen));
 				}
 			}
 
-			template<Range R, class O, class Gen = detail::default_random_engine&>
+			template<range R, class O, class Gen = detail::default_random_engine&>
 			requires __sample_constraint<iterator_t<R>, sentinel_t<R>, O, Gen> &&
-				(ForwardRange<R> || SizedRange<R> || RandomAccessIterator<O>)
+				(forward_range<R> || sized_range<R> || random_access_iterator<O>)
 			constexpr sample_result<safe_iterator_t<R>, O>
 			operator()(R&& r, O o, iter_difference_t<iterator_t<R>> n,
 				Gen&& gen = detail::get_random_engine()) const
 			{
-				if constexpr (ForwardRange<R> || SizedRange<R>) {
+				if constexpr (forward_range<R> || sized_range<R>) {
 					return sized_impl(begin(r), end(r), distance(r), std::move(o),
 						n, std::forward<Gen>(gen));
-				} else { // RandomAccessIterator<O>
+				} else { // random_access_iterator<O>
 					return (*this)(begin(r), end(r), std::move(o), n,
 						std::forward<Gen>(gen));
 				}
 			}
 
-			template<Range IR, Range OR,
+			template<range IR, range OR,
 				class Gen = detail::default_random_engine&>
 			requires
 				__sample_constraint<iterator_t<IR>, sentinel_t<IR>,
 					iterator_t<OR>, Gen> &&
-				(ForwardRange<IR> || SizedRange<IR> || RandomAccessRange<OR>) &&
-				(ForwardRange<OR> || SizedRange<OR>)
+				(forward_range<IR> || sized_range<IR> || random_access_range<OR>) &&
+				(forward_range<OR> || sized_range<OR>)
 			constexpr sample_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
 			operator()(IR&& r, OR&& o,
 				Gen&& gen = detail::get_random_engine()) const
 			{
-				if constexpr (ForwardRange<IR> || SizedRange<IR>) {
+				if constexpr (forward_range<IR> || sized_range<IR>) {
 					return sized_impl(begin(r), end(r), distance(r), begin(o),
 						distance(o), std::forward<Gen>(gen));
-				} else { // RandomAccessRange<OR>
+				} else { // random_access_range<OR>
 					return (*this)(begin(r), end(r),
 						begin(o), distance(o), std::forward<Gen>(gen));
 				}

--- a/include/stl2/detail/algorithm/search.hpp
+++ b/include/stl2/detail/algorithm/search.hpp
@@ -32,14 +32,14 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __search_fn : private __niebloid {
-		template<ForwardIterator I1, Sentinel<I1> S1,
-			ForwardIterator I2, Sentinel<I2> S2, class Pred = equal_to,
+		template<forward_iterator I1, sentinel_for<I1> S1,
+			forward_iterator I2, sentinel_for<I2> S2, class Pred = equal_to,
 			class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable< I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable< I1, I2, Pred, Proj1, Proj2>
 		constexpr subrange<I1> operator()(I1 first1, S1 last1, I2 first2,
 			S2 last2, Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedSentinel<S1, I1> && SizedSentinel<S2, I2>) {
+			if constexpr (sized_sentinel_for<S1, I1> && sized_sentinel_for<S2, I2>) {
 				return sized(first1, last1, last1 - first1,
 					first2, last2, last2 - first2,
 					__stl2::ref(pred), __stl2::ref(proj1), __stl2::ref(proj2));
@@ -49,14 +49,14 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R1, ForwardRange R2, class Pred = equal_to,
+		template<forward_range R1, forward_range R2, class Pred = equal_to,
 			class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<iterator_t<R1>, iterator_t<R2>,
+		requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>,
 			Pred, Proj1, Proj2>
 		constexpr safe_subrange_t<R1> operator()(R1&& r1, R2&& r2,
 			Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
 		{
-			if constexpr (SizedRange<R1> && SizedRange<R2>) {
+			if constexpr (sized_range<R1> && sized_range<R2>) {
 				return sized(begin(r1), end(r1), distance(r1),
 					begin(r2), end(r2), distance(r2), __stl2::ref(pred),
 					__stl2::ref(proj1), __stl2::ref(proj2));
@@ -66,10 +66,10 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 	private:
-		template<ForwardIterator I1, Sentinel<I1> S1,
-			ForwardIterator I2, Sentinel<I2> S2, class Pred = equal_to,
+		template<forward_iterator I1, sentinel_for<I1> S1,
+			forward_iterator I2, sentinel_for<I2> S2, class Pred = equal_to,
 			class Proj1 = identity, class Proj2 = identity>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static constexpr subrange<I1> unsized(I1 first1, S1 last1, I2 first2,
 			S2 last2, Pred pred, Proj1 proj1, Proj2 proj2)
 		{
@@ -101,10 +101,10 @@ STL2_OPEN_NAMESPACE {
 			return {first1, first1};
 		}
 
-		template<ForwardIterator I1, Sentinel<I1> S1,
-			ForwardIterator I2, Sentinel<I2> S2,
+		template<forward_iterator I1, sentinel_for<I1> S1,
+			forward_iterator I2, sentinel_for<I2> S2,
 			class Pred, class Proj1, class Proj2>
-		requires IndirectlyComparable<I1, I2, Pred, Proj1, Proj2>
+		requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
 		static constexpr subrange<I1> sized(const I1 first1_, S1 last1,
 			const iter_difference_t<I1> d1_, I2 first2, S2 last2,
 			const iter_difference_t<I2> d2, Pred pred, Proj1 proj1, Proj2 proj2)

--- a/include/stl2/detail/algorithm/search_n.hpp
+++ b/include/stl2/detail/algorithm/search_n.hpp
@@ -32,13 +32,13 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __search_n_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class T,
+		template<forward_iterator I, sentinel_for<I> S, class T,
 			class Pred = equal_to, class Proj = identity>
-		requires IndirectlyComparable<I, const T*, Pred, Proj>
+		requires indirectly_comparable<I, const T*, Pred, Proj>
 		constexpr I operator()(I first, S last, iter_difference_t<I> count,
 			const T& value, Pred pred = {}, Proj proj = {}) const
 		{
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				auto n = static_cast<iter_difference_t<I>>(last - first);
 				return sized(std::move(first), std::move(last),
 					n, count, value, __stl2::ref(pred), __stl2::ref(proj));
@@ -48,14 +48,14 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R, class T, class Pred = equal_to,
+		template<forward_range R, class T, class Pred = equal_to,
 			class Proj = identity>
-		requires IndirectlyComparable<iterator_t<R>, const T*, Pred, Proj>
+		requires indirectly_comparable<iterator_t<R>, const T*, Pred, Proj>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, iter_difference_t<iterator_t<R>> count,
 			const T& value, Pred pred = {}, Proj proj = {}) const
 		{
-			if constexpr (SizedRange<R>) {
+			if constexpr (sized_range<R>) {
 				return sized(begin(r), end(r), distance(r), count, value,
 					__stl2::ref(pred), __stl2::ref(proj));
 			} else {
@@ -64,9 +64,9 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 	private:
-		template<ForwardIterator I, Sentinel<I> S, class T, class Pred,
+		template<forward_iterator I, sentinel_for<I> S, class T, class Pred,
 			class Proj>
-		requires IndirectlyComparable<I, const T*, Pred, Proj>
+		requires indirectly_comparable<I, const T*, Pred, Proj>
 		static constexpr I unsized(I first, S last, iter_difference_t<I> count,
 			const T& value, Pred pred, Proj proj)
 		{
@@ -92,8 +92,8 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardIterator I, Sentinel<I> S, class T, class Pred, class Proj>
-		requires IndirectlyComparable<I, const T*, Pred, Proj>
+		template<forward_iterator I, sentinel_for<I> S, class T, class Pred, class Proj>
+		requires indirectly_comparable<I, const T*, Pred, Proj>
 		static constexpr I sized(I first_, S last, iter_difference_t<I> d_,
 			iter_difference_t<I> count, const T& value, Pred pred, Proj proj)
 		{

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -25,10 +25,10 @@ STL2_OPEN_NAMESPACE {
 	using set_difference_result = __in_out_result<I, O>;
 
 	struct __set_difference_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, WeaklyIncrementable O, class Comp = less,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, weakly_incrementable O, class Comp = less,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
 		constexpr set_difference_result<I1, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -52,9 +52,9 @@ STL2_OPEN_NAMESPACE {
 			return copy(std::move(first1), std::move(last1), std::move(result));
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+		template<input_range R1, input_range R2, weakly_incrementable O,
 			class Comp = less, class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
 		constexpr set_difference_result<safe_iterator_t<R1>, O>
 		operator()(R1&& r1, R2&& r2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/set_intersection.hpp
+++ b/include/stl2/detail/algorithm/set_intersection.hpp
@@ -24,10 +24,10 @@ STL2_OPEN_NAMESPACE {
 	using set_intersection_result = __in_in_out_result<I1, I2, O>;
 
 	struct __set_intersection_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, WeaklyIncrementable O, class Comp = less,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, weakly_incrementable O, class Comp = less,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
 		constexpr set_intersection_result<I1, I2, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -51,9 +51,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first1), std::move(first2), std::move(result)};
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+		template<input_range R1, input_range R2, weakly_incrementable O,
 			class Comp = less, class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
 		constexpr set_intersection_result<
 			safe_iterator_t<R1>, safe_iterator_t<R2>, O>
 		operator()(R1&& r1, R2&& r2, O result, Comp comp = {}, Proj1 proj1 = {},

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -25,10 +25,10 @@ STL2_OPEN_NAMESPACE {
 	using set_symmetric_difference_result = __in_in_out_result<I1, I2, O>;
 
 	struct __set_symmetric_difference_fn : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, WeaklyIncrementable O, class Comp = less,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, weakly_incrementable O, class Comp = less,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
 		constexpr set_symmetric_difference_result<I1, I2, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -71,9 +71,9 @@ STL2_OPEN_NAMESPACE {
 			};
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+		template<input_range R1, input_range R2, weakly_incrementable O,
 			class Comp = less, class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
 		constexpr set_symmetric_difference_result<
 			safe_iterator_t<R1>, safe_iterator_t<R2>, O>
 		operator()(R1&& r1, R2&& r2, O result, Comp comp = {},

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -25,10 +25,10 @@ STL2_OPEN_NAMESPACE {
 	using set_union_result = __in_in_out_result<I1, I2, O>;
 
 	struct __set_union : private __niebloid {
-		template<InputIterator I1, Sentinel<I1> S1, InputIterator I2,
-			Sentinel<I2> S2, WeaklyIncrementable O, class Comp = less,
+		template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2,
+			sentinel_for<I2> S2, weakly_incrementable O, class Comp = less,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<I1, I2, O, Comp, Proj1, Proj2>
+		requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
 		constexpr set_union_result<I1, I2, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 			Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const
@@ -64,9 +64,9 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+		template<input_range R1, input_range R2, weakly_incrementable O,
 			class Comp = less, class Proj1 = identity, class Proj2 = identity>
-		requires Mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+		requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
 		constexpr set_union_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
 		operator()(R1&& r1, R2&& r2, O result, Comp comp = {},
 			Proj1 proj1 = {}, Proj2 proj2 = {}) const

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -22,10 +22,10 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __shuffle_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S,
+		template<random_access_iterator I, sentinel_for<I> S,
 			class Gen = detail::default_random_engine&>
-		requires Permutable<I> &&
-			UniformRandomBitGenerator<std::remove_reference_t<Gen>>
+		requires permutable<I> &&
+			uniform_random_bit_generator<std::remove_reference_t<Gen>>
 		constexpr I operator()(I const first, S const last,
 			Gen&& g = detail::get_random_engine()) const
 		{
@@ -43,10 +43,10 @@ STL2_OPEN_NAMESPACE {
 			return mid;
 		}
 
-		template<RandomAccessRange Rng,
+		template<random_access_range Rng,
 			class Gen = detail::default_random_engine&>
-		requires Permutable<iterator_t<Rng>> &&
-			UniformRandomBitGenerator<std::remove_reference_t<Gen>>
+		requires permutable<iterator_t<Rng>> &&
+			uniform_random_bit_generator<std::remove_reference_t<Gen>>
 		constexpr safe_iterator_t<Rng>
 		operator()(Rng&& rng, Gen&& g = detail::get_random_engine()) const {
 			return (*this)(begin(rng), end(rng), std::forward<Gen>(g));

--- a/include/stl2/detail/algorithm/sort.hpp
+++ b/include/stl2/detail/algorithm/sort.hpp
@@ -25,12 +25,12 @@ STL2_OPEN_NAMESPACE {
 	struct __sort_fn : private __niebloid {
 		/// Extension: sort using forward iterators
 		///
-		template<ForwardIterator I, Sentinel<I> S, class Comp = less,
+		template<forward_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I
 		operator()(I first, S sent, Comp comp = {}, Proj proj = {}) const {
-			if constexpr (RandomAccessIterator<I>) {
+			if constexpr (random_access_iterator<I>) {
 				if (first == sent) return first;
 				auto last = next(first, std::move(sent));
 				auto n = distance(first, last);
@@ -45,8 +45,8 @@ STL2_OPEN_NAMESPACE {
 
 		/// Extension: sort using forward ranges
 		///
-		template<ForwardRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<forward_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(comp), std::move(proj));
@@ -54,8 +54,8 @@ STL2_OPEN_NAMESPACE {
 	private:
 		static constexpr std::ptrdiff_t introsort_threshold = 16;
 
-		template<RandomAccessIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<random_access_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static constexpr I
 		choose_pivot(I first, I last, Comp& comp, Proj& proj) {
 			STL2_EXPECT(first != last);
@@ -69,8 +69,8 @@ STL2_OPEN_NAMESPACE {
 			}(__stl2::invoke(proj, *first), __stl2::invoke(proj, *mid), __stl2::invoke(proj, *last));
 		}
 
-		template<RandomAccessIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<random_access_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static constexpr I
 		unguarded_partition(I first, I last, Comp& comp, Proj& proj) {
 			I pivot_pnt = choose_pivot(first, last, comp, proj);
@@ -94,8 +94,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<RandomAccessIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<random_access_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static constexpr void
 		introsort_loop(I first, I last, iter_difference_t<I> depth_limit, Comp& comp, Proj& proj)
 		{
@@ -110,8 +110,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<BidirectionalIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<bidirectional_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static constexpr void
 		unguarded_insertion_sort(I first, I last, Comp& comp, Proj& proj) {
 			for (I i = first; i != last; ++i) {
@@ -119,8 +119,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<RandomAccessIterator I, class Comp, class Proj>
-		requires Sortable<I, Comp, Proj>
+		template<random_access_iterator I, class Comp, class Proj>
+		requires sortable<I, Comp, Proj>
 		static constexpr void
 		final_insertion_sort(I first, I last, Comp &comp, Proj &proj) {
 			if (distance(first, last) > introsort_threshold) {

--- a/include/stl2/detail/algorithm/sort_heap.hpp
+++ b/include/stl2/detail/algorithm/sort_heap.hpp
@@ -32,8 +32,8 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __sort_heap_n_fn {
-			template<RandomAccessIterator I, class Comp, class Proj>
-			requires Sortable<I, Comp, Proj>
+			template<random_access_iterator I, class Comp, class Proj>
+			requires sortable<I, Comp, Proj>
 			constexpr void operator()(I first, iter_difference_t<I> n,
 				Comp comp, Proj proj) const
 			{
@@ -48,9 +48,9 @@ STL2_OPEN_NAMESPACE {
 	} // namespace ext
 
 	struct __sort_heap_fn : private __niebloid {
-		template<RandomAccessIterator I, Sentinel<I> S, class Comp = less,
+		template<random_access_iterator I, sentinel_for<I> S, class Comp = less,
 			class Proj = identity>
-		requires Sortable<I, Comp, Proj>
+		requires sortable<I, Comp, Proj>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(first, std::move(last));
@@ -58,8 +58,8 @@ STL2_OPEN_NAMESPACE {
 			return first + n;
 		}
 
-		template<RandomAccessRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<random_access_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			auto n = distance(r);

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -28,13 +28,13 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __stable_partition_n_fn : private __niebloid {
-			template<ForwardIterator I, class Pred, class Proj = identity>
-			requires Permutable<I> &&
-				IndirectUnaryPredicate<Pred, projected<I, Proj>>
+			template<forward_iterator I, class Pred, class Proj = identity>
+			requires permutable<I> &&
+				indirect_unary_predicate<Pred, projected<I, Proj>>
 			I operator()(I first, iter_difference_t<I> n, Pred pred,
 				Proj proj = {}) const
 			{
-				if constexpr (BidirectionalIterator<I>) {
+				if constexpr (bidirectional_iterator<I>) {
 					auto bound = next(first, n);
 					return (*this)(std::move(first), std::move(bound), n,
 						__stl2::ref(pred), __stl2::ref(proj));
@@ -53,9 +53,9 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 
-			template<BidirectionalIterator I, class Pred, class Proj = identity>
-			requires Permutable<I> &&
-				IndirectUnaryPredicate<Pred, projected<I, Proj>>
+			template<bidirectional_iterator I, class Pred, class Proj = identity>
+			requires permutable<I> &&
+				indirect_unary_predicate<Pred, projected<I, Proj>>
 			I operator()(I first, I last, iter_difference_t<I> n, Pred pred,
 				Proj proj = {}) const
 			{
@@ -79,11 +79,11 @@ STL2_OPEN_NAMESPACE {
 				return bidirectional(first, last, n, buf, pred, proj);
 			}
 		private:
-			template<Readable I>
+			template<readable I>
 			using buf_t = detail::temporary_buffer<iter_value_t<I>>;
 
-			template<ForwardIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<forward_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			static constexpr void
 			skip_true(I& first, iter_difference_t<I>& n, Pred& pred, Proj& proj) {
 				// advance "first" past values that satisfy the predicate.
@@ -95,8 +95,8 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 
-			template<Permutable I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<permutable I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			static subrange<I> forward_buffer(I first, I next,
 				iter_difference_t<I> n, buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -117,8 +117,8 @@ STL2_OPEN_NAMESPACE {
 				return {std::move(pp), std::move(last)};
 			}
 
-			template<Permutable I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<permutable I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			static subrange<I> forward(I first, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -145,8 +145,8 @@ STL2_OPEN_NAMESPACE {
 				return {std::move(pp), std::move(res2.end())};
 			}
 
-			template<Permutable I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<permutable I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			static subrange<I> forward_reduce(I first, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -160,8 +160,8 @@ STL2_OPEN_NAMESPACE {
 				return forward(std::move(first), n, buf, pred, proj);
 			}
 
-			template<BidirectionalIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
+			template<bidirectional_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
 			static constexpr void
 			skip_false(I& last, iter_difference_t<I>& n, Pred& pred, Proj& proj) {
 				// Move last backward past values that do not satisfy pred.
@@ -174,9 +174,9 @@ STL2_OPEN_NAMESPACE {
 				} while (--n != 0 && !__stl2::invoke(pred, __stl2::invoke(proj, *last)));
 			}
 
-			template<BidirectionalIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			requires Permutable<I>
+			template<bidirectional_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
+			requires permutable<I>
 			static I bidirectional_buffer(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -204,9 +204,9 @@ STL2_OPEN_NAMESPACE {
 				return middle;
 			}
 
-			template<BidirectionalIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			requires Permutable<I>
+			template<bidirectional_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
+			requires permutable<I>
 			static I bidirectional(I first, I last, iter_difference_t<I> n,
 				buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -237,9 +237,9 @@ STL2_OPEN_NAMESPACE {
 					std::move(pp2)).begin();
 			}
 
-			template<BidirectionalIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			requires Permutable<I>
+			template<bidirectional_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
+			requires permutable<I>
 			static I bidirectional_reduce_front(I first, I last,
 				iter_difference_t<I> n, buf_t<I>& buf, Pred& pred, Proj& proj)
 			{
@@ -254,9 +254,9 @@ STL2_OPEN_NAMESPACE {
 				return bidirectional(first, last, n, buf, pred, proj);
 			}
 
-			template<BidirectionalIterator I, class Proj,
-				IndirectUnaryPredicate<projected<I, Proj>> Pred>
-			requires Permutable<I>
+			template<bidirectional_iterator I, class Proj,
+				indirect_unary_predicate<projected<I, Proj>> Pred>
+			requires permutable<I>
 			static I bidirectional_reduce_back(I first, I last,
 				iter_difference_t<I> n, buf_t<I>& buf, Pred& pred, Proj& proj) {
 				// Pre: !__stl2::invoke(pred, __stl2::invoke(proj, *first))
@@ -275,10 +275,10 @@ STL2_OPEN_NAMESPACE {
 	} // namespace ext
 
 	struct __stable_partition_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class Pred, class Proj = identity>
-		requires Permutable<I> && IndirectUnaryPredicate<Pred, projected<I, Proj>>
+		template<forward_iterator I, sentinel_for<I> S, class Pred, class Proj = identity>
+		requires permutable<I> && indirect_unary_predicate<Pred, projected<I, Proj>>
 		I operator()(I first, S last, Pred pred, Proj proj = {}) const {
-			if constexpr (BidirectionalIterator<I>) {
+			if constexpr (bidirectional_iterator<I>) {
 				auto [bound, n] = ext::enumerate(first, std::move(last));
 				return ext::stable_partition_n(
 					std::move(first), std::move(bound), n,
@@ -291,12 +291,12 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange Rng, class Pred, class Proj = identity>
-		requires Permutable<iterator_t<Rng>> &&
-			IndirectUnaryPredicate<Pred, projected<iterator_t<Rng>, Proj>>
+		template<forward_range Rng, class Pred, class Proj = identity>
+		requires permutable<iterator_t<Rng>> &&
+			indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>
 		safe_iterator_t<Rng>
 		operator()(Rng&& rng, Pred pred, Proj proj = {}) const {
-			if constexpr (BidirectionalRange<Rng>) {
+			if constexpr (bidirectional_range<Rng>) {
 				auto [bound, n] = ext::enumerate(rng);
 				return ext::stable_partition_n(
 					begin(rng), std::move(bound), n,

--- a/include/stl2/detail/algorithm/stable_sort.hpp
+++ b/include/stl2/detail/algorithm/stable_sort.hpp
@@ -52,9 +52,9 @@ STL2_OPEN_NAMESPACE {
 	struct __stable_sort_fn : private __niebloid {
 		// Extension: Supports forward iterators.
 		template<class I, class S, class Comp = less, class Proj = identity>
-		requires Sentinel<__f<S>, I> && Sortable<I, Comp, Proj>
+		requires sentinel_for<__f<S>, I> && sortable<I, Comp, Proj>
 		I operator()(I first, S&& last_, Comp comp = {}, Proj proj = {}) const {
-			if constexpr (RandomAccessIterator<I>) {
+			if constexpr (random_access_iterator<I>) {
 				auto last = next(first, std::forward<S>(last_));
 				auto len = iter_difference_t<I>(last - first);
 				auto buf = len > 256 ? buf_t<I>{len} : buf_t<I>{};
@@ -72,10 +72,10 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		// Extension: supports forward ranges.
-		template<ForwardRange R, class Comp = less, class Proj = identity>
-		requires Sortable<iterator_t<R>, Comp, Proj>
+		template<forward_range R, class Comp = less, class Proj = identity>
+		requires sortable<iterator_t<R>, Comp, Proj>
 		safe_iterator_t<R> operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
-			if constexpr (RandomAccessRange<R>) {
+			if constexpr (random_access_range<R>) {
 				return (*this)(begin(r), end(r), __stl2::ref(comp),
 					__stl2::ref(proj));
 			} else {
@@ -89,8 +89,8 @@ STL2_OPEN_NAMESPACE {
 
 		static constexpr int merge_sort_chunk_size = 7;
 
-		template<RandomAccessIterator I, class C, class P>
-		requires Sortable<I, C, P>
+		template<random_access_iterator I, class C, class P>
+		requires sortable<I, C, P>
 		static void inplace_stable_sort(I first, I last, C &pred, P &proj) {
 			if (last - first < 15) {
 				detail::rsort::insertion_sort(first, last, pred, proj);
@@ -104,8 +104,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<RandomAccessIterator I, WeaklyIncrementable O, class C, class P>
-		requires Sortable<I, C, P>
+		template<random_access_iterator I, weakly_incrementable O, class C, class P>
+		requires sortable<I, C, P>
 		static void merge_sort_loop(I first, I last, O result,
 			iter_difference_t<I> step_size, C &pred, P &proj) {
 			auto two_step = iter_difference_t<I>(2 * step_size);
@@ -129,8 +129,8 @@ STL2_OPEN_NAMESPACE {
 				__stl2::ref(proj), __stl2::ref(proj));
 		}
 
-		template<RandomAccessIterator I, class C, class P>
-		requires Sortable<I, C, P>
+		template<random_access_iterator I, class C, class P>
+		requires sortable<I, C, P>
 		static void chunk_insertion_sort(I first, I last,
 			iter_difference_t<I> chunk_size, C &comp, P &proj) {
 			while (last - first >= chunk_size) {
@@ -140,8 +140,8 @@ STL2_OPEN_NAMESPACE {
 			detail::rsort::insertion_sort(first, last, comp, proj);
 		}
 
-		template<RandomAccessIterator I, class C, class P>
-		requires Sortable<I, C, P>
+		template<random_access_iterator I, class C, class P>
+		requires sortable<I, C, P>
 		static void merge_sort_with_buffer(I first, I last, buf_t<I>& buf, C &comp, P &proj) {
 			auto len = iter_difference_t<I>(last - first);
 			auto step_size = iter_difference_t<I>(merge_sort_chunk_size);
@@ -163,8 +163,8 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<RandomAccessIterator I, class C, class P>
-		requires Sortable<I, C, P>
+		template<random_access_iterator I, class C, class P>
+		requires sortable<I, C, P>
 		static void stable_sort_adaptive(I first, I last, buf_t<I>& buf, C &comp, P &proj) {
 			auto len = iter_difference_t<I>((last - first + 1) / 2);
 			auto middle = first + len;

--- a/include/stl2/detail/algorithm/swap_ranges.hpp
+++ b/include/stl2/detail/algorithm/swap_ranges.hpp
@@ -26,8 +26,8 @@ STL2_OPEN_NAMESPACE {
 	using swap_ranges_result = __in_in_result<I1, I2>;
 
 	struct __swap_ranges3_fn {
-		template<ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2>
-		requires IndirectlySwappable<I1, I2>
+		template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2>
+		requires indirectly_swappable<I1, I2>
 		constexpr swap_ranges_result<I1, I2>
 		operator()(I1 first1, S1 last1, I2 first2) const {
 			for (; first1 != last1; (void) ++first1, (void) ++first2) {
@@ -40,9 +40,9 @@ STL2_OPEN_NAMESPACE {
 	inline constexpr __swap_ranges3_fn __swap_ranges3 {};
 
 	struct __swap_ranges_fn : private __niebloid {
-		template<ForwardIterator I1, Sentinel<I1> S1, ForwardIterator I2,
-			Sentinel<I2> S2>
-		requires IndirectlySwappable<I1, I2>
+		template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
+			sentinel_for<I2> S2>
+		requires indirectly_swappable<I1, I2>
 		constexpr swap_ranges_result<I1, I2>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2) const {
 			for (; bool(first1 != last1) && bool(first2 != last2);
@@ -53,8 +53,8 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first1), std::move(first2)};
 		}
 
-		template<ForwardRange R1, ForwardRange R2>
-		requires IndirectlySwappable<iterator_t<R1>, iterator_t<R2>>
+		template<forward_range R1, forward_range R2>
+		requires indirectly_swappable<iterator_t<R1>, iterator_t<R2>>
 		constexpr swap_ranges_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
 		operator()(R1&& r1, R2&& r2) const {
 			return (*this)(begin(r1), end(r1), begin(r2), end(r2));

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -28,9 +28,9 @@ STL2_OPEN_NAMESPACE {
 	using binary_transform_result = __in_in_out_result<I1, I2, O>;
 
 	struct __transform_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
 			copy_constructible F, class Proj = identity>
-		requires Writable<O, indirect_result_t<F&, projected<I, Proj>>>
+		requires writable<O, indirect_result_t<F&, projected<I, Proj>>>
 		constexpr unary_transform_result<I, O>
 		operator()(I first, S last, O result, F op, Proj proj = {}) const {
 			for (; first != last; (void) ++first, (void) ++result) {
@@ -39,20 +39,20 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, copy_constructible F,
+		template<input_range R, weakly_incrementable O, copy_constructible F,
 			class Proj = identity>
-		requires Writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
+		requires writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
 		constexpr unary_transform_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, F op, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result), __stl2::ref(op),
 				__stl2::ref(proj));
 		}
 
-		template<InputIterator I1, Sentinel<I1> S1,
-			InputIterator I2, Sentinel<I2> S2,
-			WeaklyIncrementable O, copy_constructible F,
+		template<input_iterator I1, sentinel_for<I1> S1,
+			input_iterator I2, sentinel_for<I2> S2,
+			weakly_incrementable O, copy_constructible F,
 			class Proj1 = identity, class Proj2 = identity>
-		requires Writable<O, indirect_result_t<F&,
+		requires writable<O, indirect_result_t<F&,
 			projected<I1, Proj1>, projected<I2, Proj2>>>
 		constexpr binary_transform_result<I1, I2, O>
 		operator()(I1 first1, S1 last1, I2 first2, S2 last2, O result,
@@ -67,9 +67,9 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first1), std::move(first2), std::move(result)};
 		}
 
-		template<InputRange R1, InputRange R2, WeaklyIncrementable O,
+		template<input_range R1, input_range R2, weakly_incrementable O,
 			copy_constructible F, class Proj1 = identity, class Proj2 = identity>
-		requires Writable<O, indirect_result_t<F&,
+		requires writable<O, indirect_result_t<F&,
 			projected<iterator_t<R1>, Proj1>, projected<iterator_t<R2>, Proj2>>>
 		constexpr binary_transform_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
 		operator()(R1&& r1, R2&& r2, O result, F op, Proj1 proj1 = {},

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -21,8 +21,8 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct __unique_fn : private __niebloid {
-		template<Permutable I, Sentinel<I> S, class Proj = identity,
-			IndirectRelation<projected<I, Proj>> Comp = equal_to>
+		template<permutable I, sentinel_for<I> S, class Proj = identity,
+			indirect_relation<projected<I, Proj>> Comp = equal_to>
 		constexpr I
 		operator()(I first, S last, Comp comp = {}, Proj proj = {}) const {
 			first = adjacent_find(std::move(first), last, __stl2::ref(comp),
@@ -40,9 +40,9 @@ STL2_OPEN_NAMESPACE {
 			return first;
 		}
 
-		template<ForwardRange R, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> Comp = equal_to>
-		requires Permutable<iterator_t<R>>
+		template<forward_range R, class Proj = identity,
+			indirect_relation<projected<iterator_t<R>, Proj>> Comp = equal_to>
+		requires permutable<iterator_t<R>>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, Comp comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), __stl2::ref(comp),

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -24,16 +24,16 @@ STL2_OPEN_NAMESPACE {
 	using unique_copy_result = __in_out_result<I, O>;
 
 	template<class I, class O>
-	META_CONCEPT __unique_copy_helper = InputIterator<I> &&  InputIterator<O> &&
+	META_CONCEPT __unique_copy_helper = input_iterator<I> &&  input_iterator<O> &&
 		same_as<iter_value_t<I>, iter_value_t<O>>;
 
 	struct __unique_copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S, WeaklyIncrementable O,
+		template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
 			class Proj = identity,
-			IndirectRelation<projected<I, Proj>> C = equal_to>
-		requires IndirectlyCopyable<I, O> &&
-			(ForwardIterator<I> || __unique_copy_helper<I, O> ||
-			 IndirectlyCopyableStorable<I, O>)
+			indirect_relation<projected<I, Proj>> C = equal_to>
+		requires indirectly_copyable<I, O> &&
+			(forward_iterator<I> || __unique_copy_helper<I, O> ||
+			 indirectly_copyable_storable<I, O>)
 		constexpr unique_copy_result<I, O> operator()(I first, const S last,
 			O result, C comp = {}, Proj proj = {}) const
 		{
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 						__stl2::invoke(proj, std::forward<decltype(lhs)>(lhs)),
 						__stl2::invoke(proj, std::forward<decltype(rhs)>(rhs))));
 				};
-				if constexpr (ForwardIterator<I>) {
+				if constexpr (forward_iterator<I>) {
 					*result = *first;
 					++result;
 					auto m = first;
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 						}
 					}
 					++result;
-				} else { // IndirectlyCopyableStorable<I, O>
+				} else { // indirectly_copyable_storable<I, O>
 					iter_value_t<I> saved = *first;
 					*result = saved;
 					++result;
@@ -81,11 +81,11 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(first), std::move(result)};
 		}
 
-		template<InputRange R, WeaklyIncrementable O, class Proj = identity,
-			IndirectRelation<projected<iterator_t<R>, Proj>> C = equal_to>
-		requires IndirectlyCopyable<iterator_t<R>, O> &&
-			(ForwardRange<R> || __unique_copy_helper<iterator_t<R>, O> ||
-			 IndirectlyCopyableStorable<iterator_t<R>, O>)
+		template<input_range R, weakly_incrementable O, class Proj = identity,
+			indirect_relation<projected<iterator_t<R>, Proj>> C = equal_to>
+		requires indirectly_copyable<iterator_t<R>, O> &&
+			(forward_range<R> || __unique_copy_helper<iterator_t<R>, O> ||
+			 indirectly_copyable_storable<iterator_t<R>, O>)
 		constexpr unique_copy_result<safe_iterator_t<R>, O>
 		operator()(R&& r, O result, C comp = {}, Proj proj = {}) const {
 			return (*this)(begin(r), end(r), std::move(result),

--- a/include/stl2/detail/algorithm/upper_bound.hpp
+++ b/include/stl2/detail/algorithm/upper_bound.hpp
@@ -23,8 +23,8 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __upper_bound_n_fn {
 			template<class I, class T, class Comp = less, class Proj = identity>
-			requires ForwardIterator<__f<I>> &&
-				IndirectStrictWeakOrder<Comp, const T*, projected<__f<I>, Proj>>
+			requires forward_iterator<__f<I>> &&
+				indirect_strict_weak_order<Comp, const T*, projected<__f<I>, Proj>>
 			constexpr __f<I> operator()(I&& first_, iter_difference_t<__f<I>> n,
 				const T& value, Comp comp = {}, Proj proj = {}) const
 			{
@@ -40,13 +40,13 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __upper_bound_fn : private __niebloid {
-		template<ForwardIterator I, Sentinel<I> S, class T,
+		template<forward_iterator I, sentinel_for<I> S, class T,
 			class Proj = identity,
-			IndirectStrictWeakOrder<const T*, projected<I, Proj>> Comp = less>
+			indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = less>
 		constexpr I operator()(I first, S last, const T& value,
 			Comp comp = {}, Proj proj = {}) const
 		{
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				auto n = distance(first, std::move(last));
 				return ext::upper_bound_n(std::move(first), n, value,
 					__stl2::ref(comp), __stl2::ref(proj));
@@ -59,12 +59,12 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<ForwardRange R, class T, class Proj = identity,
-			IndirectStrictWeakOrder<const T*,
+		template<forward_range R, class T, class Proj = identity,
+			indirect_strict_weak_order<const T*,
 				projected<iterator_t<R>, Proj>> Comp = less>
 		constexpr safe_iterator_t<R>
 		operator()(R&& r, const T& value, Comp comp = {}, Proj proj = {}) const {
-			if constexpr (SizedRange<R>) {
+			if constexpr (sized_range<R>) {
 				return ext::upper_bound_n(begin(r), distance(r), value,
 					__stl2::ref(comp), __stl2::ref(proj));
 			} else {

--- a/include/stl2/detail/cached_position.hpp
+++ b/include/stl2/detail/cached_position.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 		/// @{
 
 		/// \brief Caches a position in a range.
-		template<Range R, class Tag = void, bool Enable = true>
+		template<range R, class Tag = void, bool Enable = true>
 		struct cached_position {
 			/// \brief Returns `true` if and only if a position is cached.
 			constexpr explicit operator bool() const noexcept {
@@ -33,14 +33,14 @@ STL2_OPEN_NAMESPACE {
 			}
 			/// \brief Retrieves an `iterator_t<R>` denoting the cached position.
 			///
-			/// \pre `*this` caches a position within the \c Range `r`.
+			/// \pre `*this` caches a position within the \c range `r`.
 			[[noreturn]] iterator_t<R> get(R& r) const {
 				(void) r;
 				STL2_EXPECT(false);
 			}
 			/// \brief Caches the position of the `iterator_t<R>` argument.
 			///
-			/// \pre The \c Iterator `it` denotes a position in \c Range r.
+			/// \pre The \c input_or_output_iterator `it` denotes a position in \c range r.
 			constexpr void set(R& r, const iterator_t<R>& it) {
 				(void) r;
 				(void) it;
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 		/// @}
 
 		/// \cond
-		template<Range R, class Tag>
+		template<range R, class Tag>
 		struct cached_position<R, Tag, true> {
 			constexpr explicit operator bool() const noexcept {
 				return static_cast<bool>(cache_);
@@ -66,7 +66,7 @@ STL2_OPEN_NAMESPACE {
 				std::optional<iterator_t<R>>,
 				non_propagating_cache<iterator_t<R>>> cache_;
 		};
-		template<RandomAccessRange R, class Tag>
+		template<random_access_range R, class Tag>
 		struct cached_position<R, Tag, true> {
 			cached_position() = default;
 			cached_position(const cached_position&) = default;

--- a/include/stl2/detail/concepts/callable.hpp
+++ b/include/stl2/detail/concepts/callable.hpp
@@ -33,7 +33,7 @@ STL2_OPEN_NAMESPACE {
 	struct __common_reference<T, U, Rest...>
 	: __common_reference<common_reference_t<T, U>, Rest...> {};
 
-	template<Readable... Is>
+	template<readable... Is>
 	using __iter_args_lists_ =
 		meta::push_back<
 			meta::cartesian_product<
@@ -55,7 +55,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class F, class... Is>
 		META_CONCEPT IndirectInvocable =
-			(Readable<Is> && ... && true) &&
+			(readable<Is> && ... && true) &&
 			copy_constructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
@@ -71,14 +71,14 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class F, class I>
-	META_CONCEPT IndirectUnaryInvocable =
+	META_CONCEPT indirect_unary_invocable =
 		ext::IndirectInvocable<F, I>;
 
 	////////////////////////////////////////////////////////////////////////////
 	// indirect_result_t
 	//
 	template<class F, class... Is>
-	requires (Readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
+	requires (readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
 	using indirect_result_t = invoke_result_t<F, iter_reference_t<Is>&&...>;
 
 	namespace ext {
@@ -88,7 +88,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class F, class I>
-	META_CONCEPT IndirectRegularUnaryInvocable =
+	META_CONCEPT indirect_regular_unary_invocable =
 		ext::IndirectRegularInvocable<F, I>;
 
 	template<class, class...> struct __predicate : std::false_type {};
@@ -99,7 +99,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class F, class... Is>
 		META_CONCEPT IndirectPredicate =
-			(Readable<Is> && ... && true) &&
+			(readable<Is> && ... && true) &&
 			copy_constructible<F> &&
 			// The following 3 are checked redundantly, but are called out
 			// specifically for better error messages on concept check failure.
@@ -115,13 +115,13 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	template<class F, class I>
-	META_CONCEPT IndirectUnaryPredicate =
+	META_CONCEPT indirect_unary_predicate =
 		ext::IndirectPredicate<F, I>;
 
 	template<class F, class I1, class I2 = I1>
-	META_CONCEPT IndirectRelation =
-		Readable<I1> &&
-		Readable<I2> &&
+	META_CONCEPT indirect_relation =
+		readable<I1> &&
+		readable<I2> &&
 		copy_constructible<F> &&
 		relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
 		relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
@@ -130,9 +130,9 @@ STL2_OPEN_NAMESPACE {
 		relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
 	template<class F, class I1, class I2 = I1>
-	META_CONCEPT IndirectStrictWeakOrder =
-		Readable<I1> &&
-		Readable<I2> &&
+	META_CONCEPT indirect_strict_weak_order =
+		readable<I1> &&
+		readable<I2> &&
 		copy_constructible<F> &&
 		strict_weak_order<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
 		strict_weak_order<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
@@ -143,48 +143,48 @@ STL2_OPEN_NAMESPACE {
 	////////////////////////////////////////////////////////////////////////////
 	// projected [projected.indirectcallables]
 	//
-	template<Readable I, IndirectRegularUnaryInvocable<I> Proj>
+	template<readable I, indirect_regular_unary_invocable<I> Proj>
 	struct projected {
 		using value_type = __uncvref<indirect_result_t<Proj&, I>>;
 		indirect_result_t<Proj&, I> operator*() const;
 	};
 
-	template<WeaklyIncrementable I, class Proj>
+	template<weakly_incrementable I, class Proj>
 	struct incrementable_traits<projected<I, Proj>> {
 		using type = iter_difference_t<I>;
 	};
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlyComparable [alg.req.ind.cmp]
+	// indirectly_comparable [alg.req.ind.cmp]
 	//
 	template<class I1, class I2, class R = equal_to, class P1 = identity,
 		class P2 = identity>
-	META_CONCEPT IndirectlyComparable =
-		IndirectRelation<R, projected<I1, P1>, projected<I2, P2>>;
+	META_CONCEPT indirectly_comparable =
+		indirect_relation<R, projected<I1, P1>, projected<I2, P2>>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Permutable [alg.req.permutable]
+	// permutable [alg.req.permutable]
 	//
 	template<class I>
-	META_CONCEPT Permutable = ForwardIterator<I> &&
-		IndirectlyMovableStorable<I, I> && IndirectlySwappable<I, I>;
+	META_CONCEPT permutable = forward_iterator<I> &&
+		indirectly_movable_storable<I, I> && indirectly_swappable<I, I>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Mergeable [alg.req.mergeable]
+	// mergeable [alg.req.mergeable]
 	//
 	template<class I1, class I2, class Out, class R = less,
 		class P1 = identity, class P2 = identity>
-	META_CONCEPT Mergeable = InputIterator<I1> && InputIterator<I2> &&
-		WeaklyIncrementable<Out> &&
-		IndirectlyCopyable<I1, Out> && IndirectlyCopyable<I2, Out> &&
-		IndirectStrictWeakOrder<R, projected<I1, P1>, projected<I2, P2>>;
+	META_CONCEPT mergeable = input_iterator<I1> && input_iterator<I2> &&
+		weakly_incrementable<Out> &&
+		indirectly_copyable<I1, Out> && indirectly_copyable<I2, Out> &&
+		indirect_strict_weak_order<R, projected<I1, P1>, projected<I2, P2>>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Sortable [alg.req.sortable]
+	// sortable [alg.req.sortable]
 	//
 	template<class I, class R = less, class P = identity>
-	META_CONCEPT Sortable = Permutable<I> &&
-		IndirectStrictWeakOrder<R, projected<I, P>>;
+	META_CONCEPT sortable = permutable<I> &&
+		indirect_strict_weak_order<R, projected<I, P>>;
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/concepts/compare.hpp
+++ b/include/stl2/detail/concepts/compare.hpp
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 	// Relaxation of equality_comparable<T, U> that doesn't require
 	// equality_comparable<T>, equality_comparable<U>, common_with<T, U>, or
 	// equality_comparable<common_type_t<T, U>>. I.e., provides exactly the
-	// requirements for Sentinel's operator ==.
+	// requirements for sentinel_for's operator ==.
 	//
 	template<class T, class U>
 	META_CONCEPT WeaklyEqualityComparable =

--- a/include/stl2/detail/concepts/object.hpp
+++ b/include/stl2/detail/concepts/object.hpp
@@ -27,16 +27,16 @@ STL2_OPEN_NAMESPACE {
 	// whose target will eventually accept a parameter by value. E.g., the
 	// range overload of find:
 	//
-	//   template<InputRange Rng, class T, class Proj = identity>
-	//     requires IndirectRelation<equal_to,
+	//   template<input_range Rng, class T, class Proj = identity>
+	//     requires indirect_relation<equal_to,
 	//                projected<iterator_t<Rng>, Proj>, const T*>()
 	//   safe_iterator_t<Rng>
 	//   find(Rng&& rng, const T& value, Proj proj = {});
 	//
 	// can be implemented to perfect-forward to the iterator overload as:
 	//
-	//   template<InputRange Rng, class T, class Proj = identity>
-	//     requires IndirectRelation<equal_to,
+	//   template<input_range Rng, class T, class Proj = identity>
+	//     requires indirect_relation<equal_to,
 	//                projected<iterator_t<Rng>, __f<Proj>>, // NW: __f<Proj>
 	//                const T*>()
 	//   safe_iterator_t<Rng>

--- a/include/stl2/detail/concepts/urng.hpp
+++ b/include/stl2/detail/concepts/urng.hpp
@@ -19,7 +19,7 @@ STL2_OPEN_NAMESPACE {
 	template<auto> struct __require_constant; // not defined
 
 	template<class G>
-	META_CONCEPT UniformRandomBitGenerator =
+	META_CONCEPT uniform_random_bit_generator =
 		invocable<G&> && unsigned_integral<invoke_result_t<G&>> &&
 		requires {
 #ifdef META_HAS_P1084

--- a/include/stl2/detail/iterator/any_iterator.hpp
+++ b/include/stl2/detail/iterator/any_iterator.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 		struct counted {
 			std::atomic<long> cnt{ 1 };
 		};
-		template<InputIterator I> struct shared_iterator : counted {
+		template<input_iterator I> struct shared_iterator : counted {
 			shared_iterator(I i) : it(std::move(i)) {}
 			I it;
 		};
@@ -58,12 +58,12 @@ STL2_OPEN_NAMESPACE {
 			std::terminate();
 		}
 
-		template<class Reference, InputIterator I>
+		template<class Reference, input_iterator I>
 		Reference deref_small(blob const &src) {
 			return **static_cast<I const *>(static_cast<void const *>(&src.tiny));
 		}
 
-		template<class Reference, InputIterator I>
+		template<class Reference, input_iterator I>
 		Reference deref_big(blob const &src) {
 			return *static_cast<shared_iterator<I> const *>(src.big)->it;
 		}
@@ -73,12 +73,12 @@ STL2_OPEN_NAMESPACE {
 			return true;
 		}
 
-		template<class I, Sentinel<I> J>
+		template<class I, sentinel_for<I> J>
 		constexpr bool iter_equal(I const &i, J const &j) {
 			return i == j;
 		}
 
-		template<class RValueReference, InputIterator I>
+		template<class RValueReference, input_iterator I>
 		iter_move_fn<RValueReference> exec_small(op o, blob *src, blob *dst) {
 			switch (o) {
 			case op::copy:
@@ -110,7 +110,7 @@ STL2_OPEN_NAMESPACE {
 			return nullptr;
 		}
 
-		template<class RValueReference, InputIterator I>
+		template<class RValueReference, input_iterator I>
 		iter_move_fn<RValueReference> exec_big(op o, blob *src, blob *dst) {
 			switch (o) {
 			case op::copy:
@@ -150,12 +150,12 @@ STL2_OPEN_NAMESPACE {
 			iter_move_fn<RValueReference> (*exec_)(op, blob *, blob *) =
 				&uninit_noop<RValueReference>;
 
-			template<InputIterator I> cursor(I i, small_tag) {
+			template<input_iterator I> cursor(I i, small_tag) {
 				::new (static_cast<void *>(&data_.tiny)) I(std::move(i));
 				deref_ = &deref_small<Reference, I>;
 				exec_ = &exec_small<RValueReference, I>;
 			}
-			template<InputIterator I> cursor(I i, big_tag) {
+			template<input_iterator I> cursor(I i, big_tag) {
 				data_.big = new shared_iterator<I>(std::move(i));
 				deref_ = &deref_big<Reference, I>;
 				exec_ = &exec_big<RValueReference, I>;
@@ -186,7 +186,7 @@ STL2_OPEN_NAMESPACE {
 				using base_t = basic_mixin<cursor>;
 			public:
 				mixin() = default;
-				template<InputIterator I> explicit mixin(I i)
+				template<input_iterator I> explicit mixin(I i)
 				: base_t(cursor{std::move(i)})
 				{}
 				using base_t::base_t;
@@ -204,7 +204,7 @@ STL2_OPEN_NAMESPACE {
 			cursor(cursor const &that) {
 				copy_from(that);
 			}
-			template<InputIterator I> cursor(I i)
+			template<input_iterator I> cursor(I i)
 			: cursor{std::move(i), is_small<I>{}}
 			{}
 			cursor &operator=(cursor &&that) {

--- a/include/stl2/detail/iterator/common_iterator.hpp
+++ b/include/stl2/detail/iterator/common_iterator.hpp
@@ -24,7 +24,7 @@
 // common_iterator [common.iterators]
 //
 STL2_OPEN_NAMESPACE {
-	template<Iterator I, Sentinel<I> S>
+	template<input_or_output_iterator I, sentinel_for<I> S>
 	requires (!same_as<I, S>)
 	class common_iterator;
 
@@ -51,13 +51,13 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Not to spec: Here to avoid LLVM 37556
-			template<InputIterator I, class S>
+			template<input_iterator I, class S>
 			friend iter_rvalue_reference_t<I>
 			iter_move(const common_iterator<I, S>& i)
 			noexcept(noexcept(__stl2::iter_move(std::declval<const I&>()))) {
 				return __stl2::iter_move(__stl2::__unchecked_get<I>(v(i)));
 			}
-			template<class I1, class S1, IndirectlySwappable<I1> I2, class S2>
+			template<class I1, class S1, indirectly_swappable<I1> I2, class S2>
 			friend void iter_swap(
 				const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y)
 			noexcept(noexcept(__stl2::iter_swap(std::declval<const I1&>(),
@@ -69,8 +69,8 @@ STL2_OPEN_NAMESPACE {
 			}
 
 			// Not to spec: here avoid GCC hidden friend constraint bugs
-			template<class I1, class S1, SizedSentinel<I1> I2, SizedSentinel<I1> S2>
-			requires SizedSentinel<S1, I2>
+			template<class I1, class S1, sized_sentinel_for<I1> I2, sized_sentinel_for<I1> S2>
+			requires sized_sentinel_for<S1, I2>
 			friend iter_difference_t<I2> operator-(
 				const common_iterator<I1, S1>& x, const common_iterator<I2, S2>& y)
 			{
@@ -79,9 +79,9 @@ STL2_OPEN_NAMESPACE {
 			}
 
 		private:
-			template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
-			requires SizedSentinel<I2, I1> && SizedSentinel<S2, I1> &&
-				SizedSentinel<S1, I2>
+			template<class I1, sentinel_for<I1> S1, class I2, sentinel_for<I2> S2>
+			requires sized_sentinel_for<I2, I1> && sized_sentinel_for<S2, I1> &&
+				sized_sentinel_for<S1, I2>
 			struct difference_visitor {
 				template<class T, class U>
 				constexpr iter_difference_t<I2>
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 			};
 		};
 
-		template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
+		template<class I1, sentinel_for<I1> S1, class I2, sentinel_for<I2> S2>
 		requires convertible_to<const I2&, I1> && convertible_to<const S2&, S1>
 		struct convert_visitor {
 			constexpr auto operator()(const I2& i) const
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
+		template<class I1, sentinel_for<I1> S1, class I2, sentinel_for<I2> S2>
 		requires convertible_to<const I2&, I1> && convertible_to<const S2&, S1> &&
 			assignable_from<I1&, const I2&> && assignable_from<S1&, const S2&>
 		struct assign_visitor {
@@ -133,8 +133,8 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		template<class I1, Sentinel<I1> S1, class I2, Sentinel<I2> S2>
-		requires Sentinel<S1, I2>
+		template<class I1, sentinel_for<I1> S1, class I2, sentinel_for<I2> S2>
+		requires sentinel_for<S1, I2>
 		struct equal_visitor {
 			constexpr bool operator()(const I1&, const I2&) const noexcept {
 				return true;
@@ -159,7 +159,7 @@ STL2_OPEN_NAMESPACE {
 	META_CONCEPT _HasArrow = requires(I& i) { i.operator->(); };
 
 	// common_iterator [common.iterator]
-	template<Iterator I, Sentinel<I> S>
+	template<input_or_output_iterator I, sentinel_for<I> S>
 	requires (!same_as<I, S>)
 	class common_iterator
 	: __common_iterator::access
@@ -214,7 +214,7 @@ STL2_OPEN_NAMESPACE {
 			return *__stl2::__unchecked_get<I>(v_);
 		}
 		decltype(auto) operator->() const
-		requires Readable<const I> &&
+		requires readable<const I> &&
 			(_HasArrow<const I> ||
 			 std::is_reference_v<iter_reference_t<I>> ||
 			 constructible_from<iter_value_t<I>, iter_reference_t<I>>)
@@ -239,7 +239,7 @@ STL2_OPEN_NAMESPACE {
 		decltype(auto) operator++(int)
 		{
 			auto& i = __stl2::__unchecked_get<I>(v_);
-			if constexpr (ForwardIterator<I>) {
+			if constexpr (forward_iterator<I>) {
 				auto tmp = *this;
 				++i;
 				return tmp;
@@ -247,16 +247,16 @@ STL2_OPEN_NAMESPACE {
 				return i++;
 		}
 
-		template<class I2, Sentinel<I> S2>
-		requires Sentinel<S, I2>
+		template<class I2, sentinel_for<I> S2>
+		requires sentinel_for<S, I2>
 		friend bool
 		operator==(const common_iterator& x, const common_iterator<I2, S2>& y) {
 			return __stl2::__unchecked_visit(
 				__common_iterator::equal_visitor<I, S, I2, S2>{}, x.v_,
 				__common_iterator::access::v(y));
 		}
-		template<class I2, Sentinel<I> S2>
-		requires Sentinel<S, I2>
+		template<class I2, sentinel_for<I> S2>
+		requires sentinel_for<S, I2>
 		friend bool
 		operator!=(const common_iterator& x, const common_iterator<I2, S2>& y) {
 			return !(x == y);
@@ -268,16 +268,16 @@ STL2_OPEN_NAMESPACE {
 		using difference_type = iter_difference_t<I>;
 	};
 
-	template<Readable I, class S>
+	template<readable I, class S>
 	struct readable_traits<common_iterator<I, S>> {
 		using value_type = iter_value_t<I>;
 	};
 
-	template<InputIterator I, class S>
+	template<input_iterator I, class S>
 	struct iterator_category<common_iterator<I, S>> {
 		using type = input_iterator_tag;
 	};
-	template<ForwardIterator I, class S>
+	template<forward_iterator I, class S>
 	struct iterator_category<common_iterator<I, S>> {
 		using type = forward_iterator_tag;
 	};

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -27,7 +27,7 @@
 #include <stl2/detail/iterator/increment.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
-// input_or_output_iterator concepts [iterator.requirements]
+// Iterator concepts [iterator.requirements]
 //
 STL2_OPEN_NAMESPACE {
 	template<class T>

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -304,7 +304,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	////////////////////////////////////////////////////////////////////////////
-	// input_or_output_iterator tags [std.iterator.tags]
+	// Iterator tags [std.iterator.tags]
 	// Extension: contiguous_iterator_tag for denoting contiguous iterators.
 	//
 	struct output_iterator_tag {};

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -27,7 +27,7 @@
 #include <stl2/detail/iterator/increment.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
-// Iterator concepts [iterator.requirements]
+// input_or_output_iterator concepts [iterator.requirements]
 //
 STL2_OPEN_NAMESPACE {
 	template<class T>
@@ -143,10 +143,10 @@ STL2_OPEN_NAMESPACE {
 	using iter_value_t = typename readable_traits<I>::value_type;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Readable [readable.iterators]
+	// readable [readable.iterators]
 	//
 	template<class I>
-	META_CONCEPT Readable =
+	META_CONCEPT readable =
 		requires {
 			// Associated types
 			typename iter_value_t<I>;
@@ -159,15 +159,15 @@ STL2_OPEN_NAMESPACE {
 		common_reference_with<iter_rvalue_reference_t<I>&&, const iter_value_t<I>&>;
 
 	// A generally useful dependent type
-	template<Readable I>
+	template<readable I>
 	using iter_common_reference_t =
 		common_reference_t<iter_reference_t<I>, iter_value_t<I>&>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Writable [iterators.writable]
+	// writable [iterators.writable]
 	//
 	template<class Out, class R>
-	META_CONCEPT Writable =
+	META_CONCEPT writable =
 		__dereferenceable<Out> &&
 		requires(Out&& o, R&& r) {
 			*o = static_cast<R&&>(r);
@@ -177,27 +177,27 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlyMovable [alg.req.ind.move]
+	// indirectly_movable [alg.req.ind.move]
 	//
 	template<class In, class Out>
-	META_CONCEPT IndirectlyMovable =
-		Readable<In> && Writable<Out, iter_rvalue_reference_t<In>>;
+	META_CONCEPT indirectly_movable =
+		readable<In> && writable<Out, iter_rvalue_reference_t<In>>;
 
 	template<class In, class Out>
 	constexpr bool is_nothrow_indirectly_movable_v = false;
 
-	template<class Out, IndirectlyMovable<Out> In>
+	template<class Out, indirectly_movable<Out> In>
 	constexpr bool is_nothrow_indirectly_movable_v<In, Out> =
 		noexcept(noexcept(std::declval<iter_reference_t<Out>>()
 			= iter_move(std::declval<In>())));
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlyMovableStorable [alg.req.ind.move]
+	// indirectly_movable_storable [alg.req.ind.move]
 	//
 	template<class In, class Out>
-	META_CONCEPT IndirectlyMovableStorable =
-		IndirectlyMovable<In, Out> &&
-		Writable<Out, iter_value_t<In>&&> &&
+	META_CONCEPT indirectly_movable_storable =
+		indirectly_movable<In, Out> &&
+		writable<Out, iter_value_t<In>&&> &&
 		movable<iter_value_t<In>> &&
 		constructible_from<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
 		assignable_from<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
@@ -205,7 +205,7 @@ STL2_OPEN_NAMESPACE {
 	template<class In, class Out>
 	constexpr bool is_nothrow_indirectly_movable_storable_v = false;
 
-	template<class Out, IndirectlyMovableStorable<Out> In>
+	template<class Out, indirectly_movable_storable<Out> In>
 	constexpr bool is_nothrow_indirectly_movable_storable_v<In, Out> =
 		is_nothrow_indirectly_movable_v<In, Out> &&
 		std::is_nothrow_assignable<iter_reference_t<Out>, iter_value_t<In>>::value &&
@@ -213,19 +213,19 @@ STL2_OPEN_NAMESPACE {
 		std::is_nothrow_assignable<iter_value_t<In>&, iter_rvalue_reference_t<In>>::value;
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlyCopyable [alg.req.ind.copy]
+	// indirectly_copyable [alg.req.ind.copy]
 	//
 	template<class In, class Out>
-	META_CONCEPT IndirectlyCopyable =
-		Readable<In> && Writable<Out, iter_reference_t<In>>;
+	META_CONCEPT indirectly_copyable =
+		readable<In> && writable<Out, iter_reference_t<In>>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlyCopyableStorable [alg.req.ind.copy]
+	// indirectly_copyable_storable [alg.req.ind.copy]
 	//
 	template<class In, class Out>
-	META_CONCEPT IndirectlyCopyableStorable =
-		IndirectlyCopyable<In, Out> &&
-		Writable<Out, const iter_value_t<In>&> &&
+	META_CONCEPT indirectly_copyable_storable =
+		indirectly_copyable<In, Out> &&
+		writable<Out, const iter_value_t<In>&> &&
 		copyable<iter_value_t<In>> &&
 		constructible_from<iter_value_t<In>, iter_reference_t<In>> &&
 		assignable_from<iter_value_t<In>&, iter_reference_t<In>>;
@@ -253,8 +253,8 @@ STL2_OPEN_NAMESPACE {
 
 		template<class R1, class R2>
 		requires (!swappable_with<iter_reference_t<R1>, iter_reference_t<R2>> &&
-			IndirectlyMovableStorable<R1, R2> &&
-			IndirectlyMovableStorable<R2, R1>)
+			indirectly_movable_storable<R1, R2> &&
+			indirectly_movable_storable<R2, R1>)
 		constexpr void impl(R1& r1, R2& r2)
 			noexcept(
 				is_nothrow_indirectly_movable_storable_v<R1, R2> &&
@@ -275,8 +275,8 @@ STL2_OPEN_NAMESPACE {
 
 			template<class R1, class R2>
 			requires
-				Readable<std::remove_reference_t<R1>> &&
-				Readable<std::remove_reference_t<R2>> &&
+				readable<std::remove_reference_t<R1>> &&
+				readable<std::remove_reference_t<R2>> &&
 				(!has_customization<R1&, R2&>) &&
 				requires(R1& r1, R2& r2) {
 					__iter_swap::impl(r1, r2);
@@ -292,10 +292,10 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	////////////////////////////////////////////////////////////////////////////
-	// IndirectlySwappable [commonalgoreq.indirectlyswappable]
+	// indirectly_swappable [commonalgoreq.indirectlyswappable]
 	//
 	template<class I1, class I2 = I1>
-	META_CONCEPT IndirectlySwappable =
+	META_CONCEPT indirectly_swappable =
 		requires(I1&& i1, I2&& i2) {
 			iter_swap((I1&&)i1, (I2&&)i2);
 			iter_swap((I2&&)i2, (I1&&)i1);
@@ -304,7 +304,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	////////////////////////////////////////////////////////////////////////////
-	// Iterator tags [std.iterator.tags]
+	// input_or_output_iterator tags [std.iterator.tags]
 	// Extension: contiguous_iterator_tag for denoting contiguous iterators.
 	//
 	struct output_iterator_tag {};
@@ -367,13 +367,13 @@ STL2_OPEN_NAMESPACE {
 	using iterator_category_t = meta::_t<iterator_category<T>>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// Iterator [iterators.iterator]
+	// input_or_output_iterator [iterators.iterator]
 	//
 	// Denotes an element of a range, i.e., is a position.
 	//
 	template<class I>
-	META_CONCEPT Iterator =
-		__dereferenceable<I&> && WeaklyIncrementable<I>;
+	META_CONCEPT input_or_output_iterator =
+		__dereferenceable<I&> && weakly_incrementable<I>;
 		// Axiom?: i is non-singular iff it denotes an element
 		// Axiom?: if i equals j then i and j denote equal elements
 		// Axiom?: I{} is in the domain of copy/move construction/assignment
@@ -381,14 +381,14 @@ STL2_OPEN_NAMESPACE {
 		//         or at least semiregular.)
 
 	////////////////////////////////////////////////////////////////////////////
-	// Sentinel [sentinel.iterators]
+	// sentinel_for [sentinel.iterators]
 	//
-	// A relationship between an Iterator and a semiregular ("sentinel")
+	// A relationship between an input_or_output_iterator and a semiregular ("sentinel")
 	// that denote a range.
 	//
 	template<class S, class I>
-	META_CONCEPT Sentinel =
-		Iterator<I> &&
+	META_CONCEPT sentinel_for =
+		input_or_output_iterator<I> &&
 		semiregular<S> &&
 		WeaklyEqualityComparable<S, I>;
 		// Axiom: if [i,s) denotes a range then:
@@ -400,18 +400,18 @@ STL2_OPEN_NAMESPACE {
 		//          * [++i,s) denotes a range
 
 	////////////////////////////////////////////////////////////////////////////
-	// SizedSentinel [iterators.sizedsentinel]
+	// sized_sentinel_for [iterators.sizedsentinel]
 	//
-	// Refinement of Sentinel that provides the capability to compute the
-	// distance between a Iterator and Sentinel that denote a range in
+	// Refinement of sentinel_for that provides the capability to compute the
+	// distance between a input_or_output_iterator and sentinel_for that denote a range in
 	// constant time.
 	//
 	template<class S, class I>
 	constexpr bool disable_sized_sentinel = false;
 
 	template<class S, class I>
-	META_CONCEPT SizedSentinel =
-		Sentinel<S, I> &&
+	META_CONCEPT sized_sentinel_for =
+		sentinel_for<S, I> &&
 		!disable_sized_sentinel<std::remove_cv_t<S>, std::remove_cv_t<I>> &&
 		requires(const I i, const S s) {
 			{ s - i } -> STL2_RVALUE_REQ(same_as<iter_difference_t<I>>);
@@ -426,23 +426,23 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	////////////////////////////////////////////////////////////////////////////
-	// OutputIterator [iterators.output]
+	// output_iterator [iterators.output]
 	//
 	template<class I, class T>
-	META_CONCEPT OutputIterator =
-		Iterator<I> &&
-		Writable<I, T> &&
+	META_CONCEPT output_iterator =
+		input_or_output_iterator<I> &&
+		writable<I, T> &&
 		requires(I& i, T&& t) {
 			*i++ = std::forward<T>(t);
 		};
 
 	////////////////////////////////////////////////////////////////////////////
-	// InputIterator [iterators.input]
+	// input_iterator [iterators.input]
 	//
 	template<class I>
-	META_CONCEPT InputIterator =
-		Iterator<I> &&
-		Readable<I> &&
+	META_CONCEPT input_iterator =
+		input_or_output_iterator<I> &&
+		readable<I> &&
 		requires(I& i, const I& ci) {
 			typename iterator_category_t<I>;
 			derived_from<iterator_category_t<I>, input_iterator_tag>;
@@ -452,18 +452,18 @@ STL2_OPEN_NAMESPACE {
 	////////////////////////////////////////////////////////////////////////////
 	// Exposition-only has-arrow [range.utility.helpers]
 	template<class I>
-	META_CONCEPT __has_arrow = InputIterator<I> &&
+	META_CONCEPT __has_arrow = input_iterator<I> &&
 		(std::is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 	////////////////////////////////////////////////////////////////////////////
-	// ForwardIterator [iterators.forward]
+	// forward_iterator [iterators.forward]
 	//
 	template<class I>
-	META_CONCEPT ForwardIterator =
-		InputIterator<I> &&
+	META_CONCEPT forward_iterator =
+		input_iterator<I> &&
 		derived_from<iterator_category_t<I>, forward_iterator_tag> &&
-		Incrementable<I> &&
-		Sentinel<I, I>;
+		incrementable<I> &&
+		sentinel_for<I, I>;
 		// Axiom: I{} is equality-preserving and non-singular
 		// Axiom: if i equals j then i and j denote the same element.
 		// Axiom: if [i,s) denotes a range && bool(i != s) then [i,i+1) denotes
@@ -473,23 +473,23 @@ STL2_OPEN_NAMESPACE {
 		//        all iterator values that participate in a range.
 
 	////////////////////////////////////////////////////////////////////////////
-	// BidirectionalIterator [iterators.bidirectional]
+	// bidirectional_iterator [iterators.bidirectional]
 	//
 	template<class I>
-	META_CONCEPT BidirectionalIterator =
-		ForwardIterator<I> &&
+	META_CONCEPT bidirectional_iterator =
+		forward_iterator<I> &&
 		derived_from<iterator_category_t<I>, bidirectional_iterator_tag> &&
 		ext::Decrementable<I>;
 
 	////////////////////////////////////////////////////////////////////////////
-	// RandomAccessIterator [iterators.random.access]
+	// random_access_iterator [iterators.random.access]
 	//
 	template<class I>
-	META_CONCEPT RandomAccessIterator =
-		BidirectionalIterator<I> &&
+	META_CONCEPT random_access_iterator =
+		bidirectional_iterator<I> &&
 		derived_from<iterator_category_t<I>, random_access_iterator_tag> &&
-		SizedSentinel<I, I> &&
-		// Should ordering be in SizedSentinel and/or RandomAccessIncrementable?
+		sized_sentinel_for<I, I> &&
+		// Should ordering be in sized_sentinel_for and/or RandomAccessIncrementable?
 		totally_ordered<I> &&
 		ext::RandomAccessIncrementable<I> &&
 		requires(const I& ci, const iter_difference_t<I> n) {
@@ -503,15 +503,15 @@ STL2_OPEN_NAMESPACE {
 		// FIXME: Axioms for definition space of ordering operations. Don't
 		// require them to be the same space as ==, since pointers can't meet
 		// that requirement. Formulation should be similar to that for == in
-		// ForwardIterator, e.g., "if [i,j) denotes a range, i < j et al are
+		// forward_iterator, e.g., "if [i,j) denotes a range, i < j et al are
 		// well-defined."
 
 	////////////////////////////////////////////////////////////////////////////
-	// ContiguousIterator
+	// contiguous_iterator
 	//
 	template<class I>
-	META_CONCEPT ContiguousIterator =
-		RandomAccessIterator<I> &&
+	META_CONCEPT contiguous_iterator =
+		random_access_iterator<I> &&
 		derived_from<iterator_category_t<I>, contiguous_iterator_tag> &&
 		std::is_lvalue_reference<iter_reference_t<I>>::value &&
 		same_as<iter_value_t<I>, __uncvref<iter_reference_t<I>>>;
@@ -519,12 +519,12 @@ STL2_OPEN_NAMESPACE {
 	////////////////////////////////////////////////////////////////////////////
 	// iterator_traits [iterator.assoc]
 	//
-	template<InputIterator I>
+	template<input_iterator I>
 	struct __pointer_type {
 		using type = std::add_pointer_t<iter_reference_t<I>>;
 	};
 
-	template<InputIterator I>
+	template<input_iterator I>
 	requires
 		requires(I i) {
 #ifdef META_HAS_P1084
@@ -540,7 +540,7 @@ STL2_OPEN_NAMESPACE {
 	template<class>
 	struct __iterator_traits {};
 
-	template<Iterator I>
+	template<input_or_output_iterator I>
 	struct __iterator_traits<I> {
 		using difference_type = iter_difference_t<I>;
 		using value_type = void;
@@ -549,7 +549,7 @@ STL2_OPEN_NAMESPACE {
 		using iterator_category = output_iterator_tag;
 	};
 
-	template<InputIterator I>
+	template<input_iterator I>
 	struct __iterator_traits<I> {
 		using difference_type = iter_difference_t<I>;
 		using value_type = iter_value_t<I>;
@@ -605,7 +605,7 @@ STL2_OPEN_NAMESPACE {
 						 derived_from<typename I::iterator_category, std::output_iterator_tag>;
 			};
 		template<class I>
-		META_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && Iterator<I>;
+		META_CONCEPT ProbablySTL2Iterator = !LooksLikeSTL1Iterator<I> && input_or_output_iterator<I>;
 	} // namespace detail
 } STL2_CLOSE_NAMESPACE
 
@@ -624,11 +624,11 @@ namespace std {
 	};
 
 	template<::__stl2::detail::ProbablySTL2Iterator In>
-	requires ::__stl2::InputIterator<In>
+	requires ::__stl2::input_iterator<In>
 	struct iterator_traits<In> { };
 
 	template<::__stl2::detail::ProbablySTL2Iterator In>
-	requires ::__stl2::InputIterator<In> && ::__stl2::Sentinel<In, In>
+	requires ::__stl2::input_iterator<In> && ::__stl2::sentinel_for<In, In>
 	struct iterator_traits<In> {
 		using difference_type   = ::__stl2::iter_difference_t<In>;
 		using value_type        = ::__stl2::iter_value_t<In>;

--- a/include/stl2/detail/iterator/counted_iterator.hpp
+++ b/include/stl2/detail/iterator/counted_iterator.hpp
@@ -22,7 +22,7 @@
 #include <stl2/detail/iterator/operations.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<Iterator> class counted_iterator;
+	template<input_or_output_iterator> class counted_iterator;
 
 	namespace __counted_iterator {
 		struct access {
@@ -41,10 +41,10 @@ STL2_OPEN_NAMESPACE {
 		constexpr iter_rvalue_reference_t<I>
 		iter_move(const counted_iterator<I>& i)
 			noexcept(noexcept(__stl2::iter_move(access::current(i))))
-			requires InputIterator<I> {
+			requires input_iterator<I> {
 			return __stl2::iter_move(access::current(i));
 		}
-		template<class I, IndirectlySwappable<I> I2>
+		template<class I, indirectly_swappable<I> I2>
 		constexpr void iter_swap(
 			const counted_iterator<I>& x, const counted_iterator<I2>& y)
 			noexcept(noexcept(__stl2::iter_swap(
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	// counted_iterator [counted.iterator]
-	template<Iterator I>
+	template<input_or_output_iterator I>
 	class counted_iterator
 #if STL2_WORKAROUND_CLANG_37556
 	: __counted_iterator::access
@@ -122,42 +122,42 @@ STL2_OPEN_NAMESPACE {
 				throw;
 			}
 		}
-		constexpr counted_iterator operator++(int) requires ForwardIterator<I> {
+		constexpr counted_iterator operator++(int) requires forward_iterator<I> {
 			auto tmp = *this;
 			++*this;
 			return tmp;
 		}
 		constexpr counted_iterator& operator--()
-		requires BidirectionalIterator<I> {
+		requires bidirectional_iterator<I> {
 			--current_;
 			++length_;
 			return *this;
 		}
 		constexpr counted_iterator operator--(int)
-		requires BidirectionalIterator<I> {
+		requires bidirectional_iterator<I> {
 			auto tmp = *this;
 			--*this;
 			return tmp;
 		}
 		constexpr counted_iterator operator+(iter_difference_t<I> n) const
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			STL2_EXPECT(n <= length_);
 			return counted_iterator(current_ + n, length_ - n);
 		}
 		friend constexpr counted_iterator
 		operator+(iter_difference_t<I> n, const counted_iterator& x)
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			return x + n;
 		}
 		constexpr counted_iterator& operator+=(iter_difference_t<I> n)
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			STL2_EXPECT(n <= length_);
 			current_ += n;
 			length_ -= n;
 			return *this;
 		}
 		constexpr counted_iterator operator-(iter_difference_t<I> n) const
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			STL2_EXPECT(-n <= length_);
 			return counted_iterator(current_ - n, length_ + n);
 		}
@@ -178,7 +178,7 @@ STL2_OPEN_NAMESPACE {
 			return y.length_;
 		}
 		constexpr counted_iterator& operator-=(iter_difference_t<I> n)
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			STL2_EXPECT(-n <= length_);
 			current_ -= n;
 			length_ += n;
@@ -186,7 +186,7 @@ STL2_OPEN_NAMESPACE {
 		}
 		constexpr decltype(auto) operator[](iter_difference_t<I> n) const
 		noexcept(noexcept(std::declval<const I&>()[n])) // strengthened
-		requires RandomAccessIterator<I> {
+		requires random_access_iterator<I> {
 			STL2_EXPECT(n <= length_);
 			return current_[n];
 		}
@@ -253,10 +253,10 @@ STL2_OPEN_NAMESPACE {
 		friend constexpr iter_rvalue_reference_t<I>
 		iter_move(const counted_iterator& i)
 		noexcept(noexcept(__stl2::iter_move(i.current_)))
-		requires InputIterator<I> {
+		requires input_iterator<I> {
 			return __stl2::iter_move(i.current_);
 		}
-		template<IndirectlySwappable<I> I2>
+		template<indirectly_swappable<I> I2>
 		friend constexpr void
 		iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
 		STL2_NOEXCEPT_RETURN(
@@ -271,20 +271,20 @@ STL2_OPEN_NAMESPACE {
 		using difference_type = iter_difference_t<I>;
 	};
 
-	template<Readable I>
+	template<readable I>
 	struct readable_traits<counted_iterator<I>> {
 		using value_type = iter_value_t<I>;
 	};
-	template<InputIterator I>
+	template<input_iterator I>
 	struct iterator_category<counted_iterator<I>> {
 		using type = iterator_category_t<I>;
 	};
 
-	template<Iterator I>
+	template<input_or_output_iterator I>
 	constexpr void __advance_fn::operator()(
 		counted_iterator<I>& i, iter_difference_t<I> n) const
 	{
-		if constexpr (RandomAccessIterator<I>) {
+		if constexpr (random_access_iterator<I>) {
 			i += n;
 		} else {
 			auto& length = __counted_iterator::access::count(i);
@@ -295,7 +295,7 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	namespace ext {
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr auto uncounted(const I& i)
 		noexcept(std::is_nothrow_copy_constructible<I>::value) {
 			return i;
@@ -307,7 +307,7 @@ STL2_OPEN_NAMESPACE {
 			i.base()
 		)
 
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr auto recounted(const I&, const I& i, iter_difference_t<I> = 0)
 		noexcept(std::is_nothrow_copy_constructible<I>::value)
 		{
@@ -325,7 +325,7 @@ STL2_OPEN_NAMESPACE {
 			const counted_iterator<I>& o, I i, iter_difference_t<I> n)
 		noexcept(noexcept(counted_iterator<I>{std::move(i), o.count() - n}))
 		{
-			STL2_EXPENSIVE_ASSERT(!ForwardIterator<I> ||
+			STL2_EXPENSIVE_ASSERT(!forward_iterator<I> ||
 				i == next(o.base(), n));
 			return counted_iterator<I>{std::move(i), o.count() - n};
 		}

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -64,10 +64,10 @@ STL2_OPEN_NAMESPACE {
 	using iter_difference_t = typename incrementable_traits<T>::difference_type;
 
 	///////////////////////////////////////////////////////////////////////////
-	// WeaklyIncrementable [weaklyincrementable.iterators]
+	// weakly_incrementable [weaklyincrementable.iterators]
 	//
 	template<class I>
-	META_CONCEPT WeaklyIncrementable =
+	META_CONCEPT weakly_incrementable =
 		semiregular<I> &&
 		requires(I i) {
 			typename iter_difference_t<I>;
@@ -81,12 +81,12 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	///////////////////////////////////////////////////////////////////////////
-	// Incrementable [incrementable.iterators]
+	// incrementable [incrementable.iterators]
 	//
 	template<class I>
-	META_CONCEPT Incrementable =
+	META_CONCEPT incrementable =
 		regular<I> &&
-		WeaklyIncrementable<I> &&
+		weakly_incrementable<I> &&
 		requires(I i) {
 #ifdef META_HAS_P1084
 			{ i++ } -> same_as<I>;
@@ -101,7 +101,7 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class I>
 		META_CONCEPT Decrementable =
-			Incrementable<I> &&
+			incrementable<I> &&
 			requires(I i) {
 #ifdef META_HAS_P1084
 				{ --i } -> same_as<I&>;

--- a/include/stl2/detail/iterator/move_iterator.hpp
+++ b/include/stl2/detail/iterator/move_iterator.hpp
@@ -25,7 +25,7 @@ STL2_OPEN_NAMESPACE {
 	template<semiregular> class move_sentinel;
 
 	namespace __move_iterator {
-		template<InputIterator> class cursor;
+		template<input_iterator> class cursor;
 
 		struct access {
 			template<_SpecializationOf<cursor> C>
@@ -38,14 +38,14 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		template<InputIterator I>
+		template<input_iterator I>
 		class cursor {
 			friend access;
 			I current_{};
 		public:
 			using difference_type = iter_difference_t<I>;
 			using value_type = iter_value_t<I>;
-			using single_pass = meta::bool_<!ForwardIterator<I>>;
+			using single_pass = meta::bool_<!forward_iterator<I>>;
 
 			class mixin : protected basic_mixin<cursor> {
 				using base_t = basic_mixin<cursor>;
@@ -104,7 +104,7 @@ STL2_OPEN_NAMESPACE {
 			// BUGBUG doesn't correctly handle when decltype(current_++)
 			// is a reference.
 			using __postinc_t = std::decay_t<decltype(current_++)>;
-			template<Readable R>
+			template<readable R>
 			struct __proxy {
 				using value_type = __stl2::iter_value_t<R>;
 				R __tmp;
@@ -123,20 +123,20 @@ STL2_OPEN_NAMESPACE {
 #endif // STL2_WORKAROUND_GCC_69096
 			constexpr auto post_increment()
 			noexcept(noexcept(__proxy<__postinc_t>{current_++}))
-			requires (!ForwardIterator<I> && Readable<__postinc_t>) {
+			requires (!forward_iterator<I> && readable<__postinc_t>) {
 				return __proxy<__postinc_t>{current_++};
 			}
 
 			constexpr void prev()
 			noexcept(noexcept(--current_))
-			requires BidirectionalIterator<I>
+			requires bidirectional_iterator<I>
 			{
 				--current_;
 			}
 
 			constexpr void advance(iter_difference_t<I> n)
 			noexcept(noexcept(current_ += n))
-			requires RandomAccessIterator<I>
+			requires random_access_iterator<I>
 			{
 				current_ += n;
 			}
@@ -147,20 +147,20 @@ STL2_OPEN_NAMESPACE {
 				current_ == access::current(that)
 			)
 
-			template<Sentinel<I> S>
+			template<sentinel_for<I> S>
 			constexpr bool equal(const move_sentinel<S>& that) const
 			STL2_NOEXCEPT_RETURN(
 				current_ == access::sentinel(that)
 			)
 
-			template<SizedSentinel<I> S>
+			template<sized_sentinel_for<I> S>
 			constexpr iter_difference_t<I>
 			distance_to(const cursor<S>& that) const
 			STL2_NOEXCEPT_RETURN(
 				access::current(that) - current_
 			)
 
-			template<SizedSentinel<I> S>
+			template<sized_sentinel_for<I> S>
 			constexpr iter_difference_t<I>
 			distance_to(const move_sentinel<S>& that) const
 			STL2_NOEXCEPT_RETURN(
@@ -172,7 +172,7 @@ STL2_OPEN_NAMESPACE {
 				iter_move(current_)
 			)
 
-			template<IndirectlySwappable<I> I2>
+			template<indirectly_swappable<I> I2>
 			constexpr void indirect_swap(const cursor<I2>& that) const
 			STL2_NOEXCEPT_RETURN(
 				iter_swap(current_, access::current(that))
@@ -180,7 +180,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 
-	template<InputIterator I>
+	template<input_iterator I>
 	using move_iterator = basic_iterator<__move_iterator::cursor<I>>;
 
 	template<class I>
@@ -219,7 +219,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<class I>
 	requires
-		InputIterator<__f<I>>
+		input_iterator<__f<I>>
 	constexpr auto make_move_iterator(I&& i)
 	STL2_NOEXCEPT_RETURN(
 		move_iterator<__f<I>>{std::forward<I>(i)}

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -16,7 +16,7 @@
 #include <stl2/detail/iterator/concepts.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
-// input_or_output_iterator operations [range.iter.ops]
+// Iterator operations [range.iter.ops]
 STL2_OPEN_NAMESPACE {
 	template<input_or_output_iterator> class counted_iterator;
 

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -16,19 +16,19 @@
 #include <stl2/detail/iterator/concepts.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
-// Iterator operations [range.iter.ops]
+// input_or_output_iterator operations [range.iter.ops]
 STL2_OPEN_NAMESPACE {
-	template<Iterator> class counted_iterator;
+	template<input_or_output_iterator> class counted_iterator;
 
 	struct __advance_fn : private __niebloid {
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr void operator()(I& i, iter_difference_t<I> n) const
-		// [[expects: n >= 0 || BidirectionalIterator<I>]]
+		// [[expects: n >= 0 || bidirectional_iterator<I>]]
 		{
-			if constexpr (RandomAccessIterator<I>) {
+			if constexpr (random_access_iterator<I>) {
 				i += n;
 			} else {
-				if constexpr (BidirectionalIterator<I>) {
+				if constexpr (bidirectional_iterator<I>) {
 					for (; n < 0; ++n) {
 						--i;
 					}
@@ -40,13 +40,13 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<Iterator I, Sentinel<I> S>
+		template<input_or_output_iterator I, sentinel_for<I> S>
 		constexpr void operator()(I& i, S bound) const
 		// [[expects axiom: reachable(i, bound)]]
 		{
 			if constexpr (assignable_from<I&, S>) {
 				i = std::move(bound);
-			} else if constexpr (SizedSentinel<S, I>) {
+			} else if constexpr (sized_sentinel_for<S, I>) {
 				iter_difference_t<I> d = bound - i;
 				STL2_EXPECT(d >= 0);
 				(*this)(i, d);
@@ -55,16 +55,16 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<Iterator I, Sentinel<I> S>
+		template<input_or_output_iterator I, sentinel_for<I> S>
 		constexpr iter_difference_t<I>
 		operator()(I& i, iter_difference_t<I> n, S bound) const
 		// [[expects axiom: 0 == n ||
 		//     (n > 0 && reachable(i, bound)) ||
-		//     (n < 0 && same_as<I, S> && BidirectionalIterator<I> && reachable(bound, i))]]
+		//     (n < 0 && same_as<I, S> && bidirectional_iterator<I> && reachable(bound, i))]]
 		{
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				const auto d = bound - i;
-				if constexpr (BidirectionalIterator<I> && same_as<I, S>) {
+				if constexpr (bidirectional_iterator<I> && same_as<I, S>) {
 					STL2_EXPECT(n >= 0 ? d >= 0 : d <= 0);
 					if (n >= 0 ? n >= d : n <= d) {
 						i = std::move(bound);
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 				(*this)(i, n);
 				return 0;
 			} else {
-				if constexpr (BidirectionalIterator<I> && same_as<I, S>) {
+				if constexpr (bidirectional_iterator<I> && same_as<I, S>) {
 					if (n < 0) {
 						while (n != 0 && i != bound) {
 							--i;
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr void
 		operator()(counted_iterator<I>& i, iter_difference_t<I> n) const;
 	};
@@ -107,24 +107,24 @@ STL2_OPEN_NAMESPACE {
 
 	// next
 	struct __next_fn : private __niebloid {
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr I operator()(I i) const {
 			return ++i;
 		}
 
-		template<Iterator I>
+		template<input_or_output_iterator I>
 		constexpr I operator()(I i, iter_difference_t<I> n) const {
 			advance(i, n);
 			return i;
 		}
 
-		template<Iterator I, Sentinel<I> S>
+		template<input_or_output_iterator I, sentinel_for<I> S>
 		constexpr I operator()(I i, S bound) const {
 			advance(i, std::move(bound));
 			return i;
 		}
 
-		template<Iterator I, Sentinel<I> S>
+		template<input_or_output_iterator I, sentinel_for<I> S>
 		constexpr I operator()(I i, iter_difference_t<I> n, S bound) const {
 			advance(i, n, std::move(bound));
 			return i;
@@ -135,18 +135,18 @@ STL2_OPEN_NAMESPACE {
 
 	// prev
 	struct __prev_fn : private __niebloid {
-		template<BidirectionalIterator I>
+		template<bidirectional_iterator I>
 		constexpr I operator()(I i) const {
 			return --i;
 		}
 
-		template<BidirectionalIterator I>
+		template<bidirectional_iterator I>
 		constexpr I operator()(I i, iter_difference_t<I> n) const {
 			advance(i, -n);
 			return i;
 		}
 
-		template<BidirectionalIterator I>
+		template<bidirectional_iterator I>
 		constexpr I operator()(I i, iter_difference_t<I> n, I bound) const {
 			advance(i, -n, std::move(bound));
 			return i;

--- a/include/stl2/detail/iterator/ostreambuf_iterator.hpp
+++ b/include/stl2/detail/iterator/ostreambuf_iterator.hpp
@@ -24,7 +24,7 @@
 
 STL2_OPEN_NAMESPACE {
 	// Not to spec:
-	// * Extension: satisfies equality_comparable and Sentinel<default_sentinel>
+	// * Extension: satisfies equality_comparable and sentinel_for<default_sentinel>
 	template<class charT, class traits = std::char_traits<charT>>
 	class ostreambuf_iterator {
 	public:

--- a/include/stl2/detail/iterator/reverse_iterator.hpp
+++ b/include/stl2/detail/iterator/reverse_iterator.hpp
@@ -25,7 +25,7 @@
 //
 STL2_OPEN_NAMESPACE {
 	namespace __reverse_iterator {
-		template<BidirectionalIterator> class cursor;
+		template<bidirectional_iterator> class cursor;
 
 		struct access {
 			template<_SpecializationOf<cursor> C>
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		template<BidirectionalIterator I>
+		template<bidirectional_iterator I>
 		class cursor {
 			friend access;
 			I current_{};
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr void advance(iter_difference_t<I> n)
 			noexcept(noexcept(current_ -= n))
-			requires RandomAccessIterator<I>
+			requires random_access_iterator<I>
 			{
 				current_ -= n;
 			}
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 				current_ == access::current(that)
 			)
 
-			template<SizedSentinel<I> J>
+			template<sized_sentinel_for<I> J>
 			constexpr iter_difference_t<I> distance_to(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				-(access::current(that) - current_)
@@ -120,7 +120,7 @@ STL2_OPEN_NAMESPACE {
 				iter_move(__stl2::prev(current_))
 			)
 
-			template<IndirectlySwappable<I> J>
+			template<indirectly_swappable<I> J>
 			constexpr void indirect_swap(const cursor<J>& that) const
 			STL2_NOEXCEPT_RETURN(
 				iter_swap(
@@ -162,7 +162,7 @@ STL2_OPEN_NAMESPACE {
 	)
 
 	template<class I>
-	requires BidirectionalIterator<__f<I>>
+	requires bidirectional_iterator<__f<I>>
 	constexpr auto make_reverse_iterator(I&& i)
 	STL2_NOEXCEPT_RETURN(
 		reverse_iterator<__f<I>>{std::forward<I>(i)}

--- a/include/stl2/detail/iterator/unreachable.hpp
+++ b/include/stl2/detail/iterator/unreachable.hpp
@@ -21,20 +21,20 @@
 //
 STL2_OPEN_NAMESPACE {
 	struct unreachable {
-		template<WeaklyIncrementable WI>
+		template<weakly_incrementable WI>
 		friend constexpr bool operator==(unreachable, const WI&) noexcept {
 			return false;
 		}
-		template<WeaklyIncrementable WI>
+		template<weakly_incrementable WI>
 		friend constexpr bool operator==(const WI&, unreachable) noexcept {
 			return false;
 		}
 
-		template<WeaklyIncrementable WI>
+		template<weakly_incrementable WI>
 		friend constexpr bool operator!=(unreachable, const WI&) noexcept {
 			return true;
 		}
-		template<WeaklyIncrementable WI>
+		template<weakly_incrementable WI>
 		friend constexpr bool operator!=(const WI&, unreachable) noexcept {
 			return true;
 		}

--- a/include/stl2/detail/memory/concepts.hpp
+++ b/include/stl2/detail/memory/concepts.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class I>
 	META_CONCEPT _NoThrowInputIterator =
-		InputIterator<I> &&
+		input_iterator<I> &&
 		std::is_lvalue_reference_v<iter_reference_t<I>> &&
 		same_as<__uncvref<iter_reference_t<I>>, iter_value_t<I>>;
 		// Axiom: no exceptions are thrown from increment, copy, move, assignment,
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class S, class I>
 	META_CONCEPT _NoThrowSentinel =
-		Sentinel<S, I>;
+		sentinel_for<S, I>;
 		// Axiom: no exceptions are thrown from comparisons between objects of types
 		//        I and S.
 
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 	//
 	template<class Rng>
 	META_CONCEPT _NoThrowInputRange =
-		Range<Rng> &&
+		range<Rng> &&
 		_NoThrowInputIterator<iterator_t<Rng>> &&
 		_NoThrowSentinel<sentinel_t<Rng>, iterator_t<Rng>>;
 		// Axiom: no exceptions are thrown from calls to begin and end on a Rng.
@@ -54,7 +54,7 @@ STL2_OPEN_NAMESPACE {
 	template<class I>
 	META_CONCEPT _NoThrowForwardIterator =
 		_NoThrowInputIterator<I> &&
-		ForwardIterator<I> &&
+		forward_iterator<I> &&
 		_NoThrowSentinel<I, I>;
 
 	///////////////////////////////////////////////////////////////////////////

--- a/include/stl2/detail/memory/uninitialized_copy.hpp
+++ b/include/stl2/detail/memory/uninitialized_copy.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 	using uninitialized_copy_result = __in_out_result<I, O>;
 
 	struct __uninitialized_copy_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S1, _NoThrowForwardIterator O, _NoThrowSentinel<O> S2>
+		template<input_iterator I, sentinel_for<I> S1, _NoThrowForwardIterator O, _NoThrowSentinel<O> S2>
 		requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
 		uninitialized_copy_result<I, O> operator()(I ifirst, S1 ilast, O ofirst, S2 olast) const {
 			auto guard = detail::destroy_guard{ofirst};
@@ -39,7 +39,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(ifirst), std::move(ofirst)};
 		}
 
-		template<InputRange IR, _NoThrowForwardRange OR>
+		template<input_range IR, _NoThrowForwardRange OR>
 		requires constructible_from<iter_value_t<iterator_t<OR>>, iter_reference_t<iterator_t<IR>>>
 		uninitialized_copy_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
 		operator()(IR&& in, OR&& out) const {
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 	using uninitialized_copy_n_result = __in_out_result<I, O>;
 
 	struct __uninitialized_copy_n_fn : private __niebloid {
-		template<InputIterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
+		template<input_iterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
 		requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
 		uninitialized_copy_n_result<I, O>
 		operator()(I first, iter_difference_t<I> n, O ofirst, S olast) const {

--- a/include/stl2/detail/memory/uninitialized_move.hpp
+++ b/include/stl2/detail/memory/uninitialized_move.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 	using uninitialized_move_result = __in_out_result<I, O>;
 
 	struct __uninitialized_move_fn : private __niebloid {
-		template<InputIterator I, Sentinel<I> S1,
+		template<input_iterator I, sentinel_for<I> S1,
 			_NoThrowForwardIterator O, _NoThrowSentinel<O> S2>
 		requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
 		uninitialized_move_result<I, O>
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 			return {std::move(ifirst), std::move(ofirst)};
 		}
 
-		template<InputRange IR, _NoThrowForwardRange OR>
+		template<input_range IR, _NoThrowForwardRange OR>
 		requires constructible_from<iter_value_t<iterator_t<OR>>,
 		                       iter_rvalue_reference_t<iterator_t<IR>>>
 		uninitialized_move_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
@@ -59,7 +59,7 @@ STL2_OPEN_NAMESPACE {
 	using uninitialized_move_n_result = __in_out_result<I, O>;
 
 	struct __uninitialized_move_n_fn : private __niebloid {
-		template<InputIterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
+		template<input_iterator I, _NoThrowForwardIterator O, _NoThrowSentinel<O> S>
 		requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
 		uninitialized_move_n_result<I, O>
 		operator()(I ifirst, iter_difference_t<I> n, O ofirst, S olast) const {

--- a/include/stl2/detail/randutils.hpp
+++ b/include/stl2/detail/randutils.hpp
@@ -30,10 +30,10 @@ STL2_OPEN_NAMESPACE {
 
 				seeder() = default;
 				seeder(std::initializer_list<result_type>) {}
-				template<InputIterator I, Sentinel<I> S>
+				template<input_iterator I, sentinel_for<I> S>
 				seeder(I, S) {}
 
-				template<RandomAccessIterator I, SizedSentinel<I> S>
+				template<random_access_iterator I, sized_sentinel_for<I> S>
 				void generate(I first, S last) const {
 					std::random_device rd{};
 					__stl2::generate(first, last, __stl2::ref(rd));
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 
 				static constexpr std::size_t size() noexcept { return ~std::size_t{0}; }
 
-				template<OutputIterator<result_type> I>
+				template<output_iterator<result_type> I>
 				void param(I) noexcept {}
 			};
 		}

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -23,7 +23,7 @@
 #include <stl2/detail/iterator/reverse_iterator.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
-// Range access [range.access]
+// range access [range.access]
 //
 STL2_OPEN_NAMESPACE {
 	inline constexpr struct __as_const_fn {
@@ -50,13 +50,13 @@ STL2_OPEN_NAMESPACE {
 		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				r.begin();
-				{ __decay_copy(r.begin()) } -> Iterator;
+				{ __decay_copy(r.begin()) } -> input_or_output_iterator;
 			};
 
 		template<class R>
 		META_CONCEPT has_non_member = requires(R&& r) {
 			begin(static_cast<R&&>(r));
-			{ __decay_copy(begin(static_cast<R&&>(r))) } -> Iterator;
+			{ __decay_copy(begin(static_cast<R&&>(r))) } -> input_or_output_iterator;
 		};
 
 		template<class>
@@ -116,14 +116,14 @@ STL2_OPEN_NAMESPACE {
 			requires(R& r) {
 				r.end();
 				begin(r);
-				{ __decay_copy(r.end()) } -> Sentinel<__begin_t<R>>;
+				{ __decay_copy(r.end()) } -> sentinel_for<__begin_t<R>>;
 			};
 
 		template<class R>
 		META_CONCEPT has_non_member = requires(R&& r) {
 			end(static_cast<R&&>(r));
 			begin(static_cast<R&&>(r));
-			{ __decay_copy(end(static_cast<R&&>(r))) } -> Sentinel<__begin_t<R>>;
+			{ __decay_copy(end(static_cast<R&&>(r))) } -> sentinel_for<__begin_t<R>>;
 		};
 
 		template<class>
@@ -211,25 +211,25 @@ STL2_OPEN_NAMESPACE {
 		// Poison pill
 		template<class T> void rbegin(T&&) = delete;
 
-		// Prefer member if it returns Iterator
+		// Prefer member if it returns input_or_output_iterator
 		template<class R>
 		META_CONCEPT has_member = std::is_lvalue_reference_v<R> &&
 			requires(R& r) {
 				r.rbegin();
-				{ __decay_copy(r.rbegin()) } -> Iterator;
+				{ __decay_copy(r.rbegin()) } -> input_or_output_iterator;
 			};
 
 		template<class R>
 		META_CONCEPT has_non_member = requires(R&& r) {
 			rbegin(static_cast<R&&>(r));
-			{ __decay_copy(rbegin(static_cast<R&&>(r))) } -> Iterator;
+			{ __decay_copy(rbegin(static_cast<R&&>(r))) } -> input_or_output_iterator;
 		};
 
 		// Default to make_reverse_iterator(end(r)) for common_with ranges of
 		// Bidirectional iterators.
 		template<class R>
 		META_CONCEPT can_make_reverse = requires(R&& r) {
-			{ begin(static_cast<R&&>(r)) } -> BidirectionalIterator;
+			{ begin(static_cast<R&&>(r)) } -> bidirectional_iterator;
 			{ end(static_cast<R&&>(r)) } -> same_as<__begin_t<R>>;
 		};
 
@@ -280,7 +280,7 @@ STL2_OPEN_NAMESPACE {
 			requires(R& r) {
 				rbegin(r);
 				r.rend();
-				{ __decay_copy(r.rend()) } -> Sentinel<__rbegin_t<R>>;
+				{ __decay_copy(r.rend()) } -> sentinel_for<__rbegin_t<R>>;
 			};
 
 		template<class R>
@@ -288,7 +288,7 @@ STL2_OPEN_NAMESPACE {
 			rbegin(static_cast<R&&>(r));
 			rend(static_cast<R&&>(r));
 			{ __decay_copy(rend(static_cast<R&&>(r))) } ->
-				Sentinel<__rbegin_t<R>>;
+				sentinel_for<__rbegin_t<R>>;
 		};
 
 		using __stl2::__rbegin::can_make_reverse;
@@ -389,8 +389,8 @@ STL2_OPEN_NAMESPACE {
 
 		template<class R>
 		META_CONCEPT has_difference = requires(R& r) {
-			{ begin(r) } -> ForwardIterator;
-			{ end(r) } -> SizedSentinel<__begin_t<R&>>;
+			{ begin(r) } -> forward_iterator;
+			{ end(r) } -> sized_sentinel_for<__begin_t<R&>>;
 		};
 
 		template<class T>
@@ -448,7 +448,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<class R>
 		META_CONCEPT has_begin_end = requires(R& r) {
-			{ begin(r) } -> ForwardIterator;
+			{ begin(r) } -> forward_iterator;
 			end(r);
 		};
 
@@ -511,7 +511,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<class R>
 		META_CONCEPT has_contiguous_iterator = requires(R&& r) {
-			{ begin(static_cast<R&&>(r)) } -> ContiguousIterator;
+			{ begin(static_cast<R&&>(r)) } -> contiguous_iterator;
 			end(static_cast<R&&>(r));
 		};
 

--- a/include/stl2/detail/range/concepts.hpp
+++ b/include/stl2/detail/range/concepts.hpp
@@ -36,7 +36,7 @@ namespace std {
 
 STL2_OPEN_NAMESPACE {
 	///////////////////////////////////////////////////////////////////////////
-	// Range [ranges.range]
+	// range [ranges.range]
 	//
 	template<class T>
 	using iterator_t = __begin_t<T&>;
@@ -52,24 +52,24 @@ STL2_OPEN_NAMESPACE {
 		};
 
 	template<class T>
-	META_CONCEPT Range = _RangeImpl<T&>;
+	META_CONCEPT range = _RangeImpl<T&>;
 
 	template<class T>
-	META_CONCEPT _ForwardingRange = Range<T> && _RangeImpl<T>;
+	META_CONCEPT _ForwardingRange = range<T> && _RangeImpl<T>;
 
 	template<class R>
-	META_CONCEPT SizedRange =
-		Range<R> && !disable_sized_range<__uncvref<R>> &&
+	META_CONCEPT sized_range =
+		range<R> && !disable_sized_range<__uncvref<R>> &&
 		requires(R& r) { size(r); };
 
 	///////////////////////////////////////////////////////////////////////////
-	// View [ranges.view]
+	// view [ranges.view]
 	//
 	struct view_base {};
 
 	template<class T>
 	META_CONCEPT _ContainerLike =
-		Range<T> && Range<const T> &&
+		range<T> && range<const T> &&
 		!same_as<iter_reference_t<iterator_t<T>>, iter_reference_t<iterator_t<const T>>>;
 
 	template<class T>
@@ -90,59 +90,59 @@ STL2_OPEN_NAMESPACE {
 	inline constexpr bool enable_view<std::unordered_multiset<Key, Hash, Pred, Alloc>> = false;
 
 	template<class T>
-	META_CONCEPT View =
-		Range<T> &&
+	META_CONCEPT view =
+		range<T> &&
 		semiregular<T> &&
 		enable_view<__uncvref<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// CommonRange
+	// common_range
 	//
 	template<class T>
-	META_CONCEPT CommonRange =
-		Range<T> && same_as<iterator_t<T>, sentinel_t<T>>;
+	META_CONCEPT common_range =
+		range<T> && same_as<iterator_t<T>, sentinel_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// OutputRange [ranges.output]
+	// output_range [ranges.output]
 	//
 	template<class R, class T>
-	META_CONCEPT OutputRange =
-		Range<R> && OutputIterator<iterator_t<R>, T>;
+	META_CONCEPT output_range =
+		range<R> && output_iterator<iterator_t<R>, T>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// InputRange [ranges.input]
+	// input_range [ranges.input]
 	//
 	template<class T>
-	META_CONCEPT InputRange =
-		Range<T> && InputIterator<iterator_t<T>>;
+	META_CONCEPT input_range =
+		range<T> && input_iterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// ForwardRange [ranges.forward]
+	// forward_range [ranges.forward]
 	//
 	template<class T>
-	META_CONCEPT ForwardRange =
-		InputRange<T> && ForwardIterator<iterator_t<T>>;
+	META_CONCEPT forward_range =
+		input_range<T> && forward_iterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// BidirectionalRange [ranges.bidirectional]
+	// bidirectional_range [ranges.bidirectional]
 	//
 	template<class T>
-	META_CONCEPT BidirectionalRange =
-		ForwardRange<T> && BidirectionalIterator<iterator_t<T>>;
+	META_CONCEPT bidirectional_range =
+		forward_range<T> && bidirectional_iterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// RandomAccessRange [ranges.random.access]
+	// random_access_range [ranges.random.access]
 	//
 	template<class T>
-	META_CONCEPT RandomAccessRange =
-		BidirectionalRange<T> && RandomAccessIterator<iterator_t<T>>;
+	META_CONCEPT random_access_range =
+		bidirectional_range<T> && random_access_iterator<iterator_t<T>>;
 
 	///////////////////////////////////////////////////////////////////////////
-	// ContiguousRange [ranges.contiguous]
+	// contiguous_range [ranges.contiguous]
 	//
 	template<class R>
-	META_CONCEPT ContiguousRange =
-		RandomAccessRange<R> && ContiguousIterator<iterator_t<R>> &&
+	META_CONCEPT contiguous_range =
+		random_access_range<R> && contiguous_iterator<iterator_t<R>> &&
 		requires(R& r) {
 			{ data(r) } -> same_as<std::add_pointer_t<iter_reference_t<iterator_t<R>>>>;
 		};
@@ -150,31 +150,31 @@ STL2_OPEN_NAMESPACE {
 	namespace ext {
 		template<class R>
 		META_CONCEPT SimpleView =
-			View<R> && Range<const R> &&
+			view<R> && range<const R> &&
 			same_as<iterator_t<R>, iterator_t<const R>> &&
 			same_as<sentinel_t<R>, sentinel_t<const R>>;
 	}
 
 	template<class Rng>
-	META_CONCEPT ViewableRange =
+	META_CONCEPT viewable_range =
 #if 1 // This is the PR of https://github.com/ericniebler/stl2/issues/623
-		View<__uncvref<Rng>> || _ForwardingRange<Rng>;
+		view<__uncvref<Rng>> || _ForwardingRange<Rng>;
 #else
-		Range<Rng> &&
-		(_RangeImpl<Rng> || View<std::decay_t<Rng>>);
+		range<Rng> &&
+		(_RangeImpl<Rng> || view<std::decay_t<Rng>>);
 #endif
 
 	namespace ext {
-		template<Range R>
+		template<range R>
 		using range_value_t = iter_value_t<iterator_t<R>>;
 
-		template<Range R>
+		template<range R>
 		using range_difference_t = iter_difference_t<iterator_t<R>>;
 
-		template<Range R>
+		template<range R>
 		using range_reference_t = iter_reference_t<iterator_t<R>>;
 
-		template<Range R>
+		template<range R>
 		using range_rvalue_reference_t = iter_rvalue_reference_t<iterator_t<R>>;
 	} // namespace ext
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/range/dangling.hpp
+++ b/include/stl2/detail/range/dangling.hpp
@@ -26,13 +26,13 @@ STL2_OPEN_NAMESPACE {
 		constexpr dangling(Arg&&) noexcept {}
 	};
 
-	template<Range R>
+	template<range R>
 	inline constexpr bool __is_forwarding_range = _ForwardingRange<R>;
 
-	template<Range R, class U>
+	template<range R, class U>
 	using __maybe_dangling = std::conditional_t<__is_forwarding_range<R>, U, dangling>;
 
-	template<Range R>
+	template<range R>
 	using safe_iterator_t = __maybe_dangling<R, iterator_t<R>>;
 
 } STL2_CLOSE_NAMESPACE

--- a/include/stl2/detail/range/nth_iterator.hpp
+++ b/include/stl2/detail/range/nth_iterator.hpp
@@ -21,22 +21,22 @@
 STL2_OPEN_NAMESPACE {
 	namespace ext {
 		struct __nth_iterator {
-			template<Range R>
+			template<range R>
 			constexpr auto operator()(R&& r, iter_difference_t<iterator_t<R>> n) const
 			{
 				STL2_EXPECT(n >= 0);
-				if constexpr (SizedRange<R>) {
+				if constexpr (sized_range<R>) {
 					auto const size = distance(r);
-					constexpr bool CommonNonRandom = CommonRange<R> && !RandomAccessRange<R>;
+					constexpr bool CommonNonRandom = common_range<R> && !random_access_range<R>;
 					if (n >= size) {
-						if constexpr (CommonNonRandom && !BidirectionalRange<R>) {
+						if constexpr (CommonNonRandom && !bidirectional_range<R>) {
 							// If the range is RandomAccess or Bidirectional, this is just extra codegen
 							// with no performance improvement over the following cases.
 							return end(r);
 						}
 						n = size;
 					}
-					if constexpr (CommonNonRandom && BidirectionalRange<R>) {
+					if constexpr (CommonNonRandom && bidirectional_range<R>) {
 						// Again, this would not be an improvement for RandomAccess ranges.
 						if (n > size / 2) {
 							return prev(end(r), size - n);

--- a/include/stl2/detail/range/primitives.hpp
+++ b/include/stl2/detail/range/primitives.hpp
@@ -19,7 +19,7 @@
 #include <stl2/detail/range/dangling.hpp>
 
 ///////////////////////////////////////////////////////////////////////////
-// Range primitives [range.primitives]
+// range primitives [range.primitives]
 //
 STL2_OPEN_NAMESPACE {
 	// enumerate
@@ -42,14 +42,14 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		struct __enumerate_fn {
-			template<Iterator I, Sentinel<I> S>
+			template<input_or_output_iterator I, sentinel_for<I> S>
 			constexpr enumerate_result<I, iter_difference_t<I>>
 			operator()(I first, S last) const {
-				if constexpr (SizedSentinel<S, I>) {
+				if constexpr (sized_sentinel_for<S, I>) {
 					auto d = last - first;
 					STL2_EXPECT(same_as<I, S> || d >= 0);
 					return {next(std::move(first), std::move(last)), d};
-				} else if constexpr (SizedSentinel<I, I>) {
+				} else if constexpr (sized_sentinel_for<I, I>) {
 					auto end = next(first, std::move(last));
 					auto n = end - first;
 					return {std::move(end), n};
@@ -67,7 +67,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr enumerate_result<iterator_t<R>,
 				iter_difference_t<iterator_t<R>>>
 			operator()(R&& r) const {
-				if constexpr (SizedRange<R>) {
+				if constexpr (sized_range<R>) {
 					using D = iter_difference_t<iterator_t<R>>;
 					auto n = static_cast<D>(size(r));
 					return {next(begin(r), end(r)), n};
@@ -81,13 +81,13 @@ STL2_OPEN_NAMESPACE {
 	}
 
 	struct __distance_fn : private __niebloid {
-		template<Iterator I, Sentinel<I> S>
+		template<input_or_output_iterator I, sentinel_for<I> S>
 		constexpr iter_difference_t<I> operator()(I first, S last) const {
 			iter_difference_t<I> n = 0;
-			if constexpr (SizedSentinel<S, I>) {
+			if constexpr (sized_sentinel_for<S, I>) {
 				n = last - first;
 				STL2_EXPECT(same_as<I, S> || n >= 0);
-			} else if constexpr (SizedSentinel<I, I>) {
+			} else if constexpr (sized_sentinel_for<I, I>) {
 				auto end = next(first, std::move(last));
 				n = end - first;
 			} else {
@@ -98,10 +98,10 @@ STL2_OPEN_NAMESPACE {
 			return n;
 		}
 
-		template<Range R>
+		template<range R>
 		constexpr iter_difference_t<iterator_t<R>> operator()(R&& r) const {
 			iter_difference_t<iterator_t<R>> n = 0;
-			if constexpr (SizedRange<R>) {
+			if constexpr (sized_range<R>) {
 				n = static_cast<iter_difference_t<iterator_t<R>>>(size(r));
 			} else {
 				n = (*this)(begin(r), end(r));

--- a/include/stl2/detail/span.hpp
+++ b/include/stl2/detail/span.hpp
@@ -30,9 +30,9 @@ STL2_OPEN_NAMESPACE {
 		template<class T>
 		using data_pointer_t = decltype(data(std::declval<T&>()));
 
-		template<class Range>
+		template<class range>
 		META_CONCEPT SizedContiguousRange =
-			ContiguousRange<Range> && SizedRange<Range>;
+			contiguous_range<range> && sized_range<range>;
 
 		namespace __span {
 			using index_t = std::ptrdiff_t;
@@ -93,14 +93,14 @@ STL2_OPEN_NAMESPACE {
 			requires requires { static_extent<T>::value; }
 			constexpr bool has_static_extent<T> = true;
 
-			template<class Range>
+			template<class range>
 			META_CONCEPT StaticSizedContiguousRange =
-				SizedContiguousRange<Range> && has_static_extent<Range>;
+				SizedContiguousRange<range> && has_static_extent<range>;
 
-			template<class Range, class ElementType>
-			META_CONCEPT compatible = SizedContiguousRange<Range> &&
+			template<class range, class ElementType>
+			META_CONCEPT compatible = SizedContiguousRange<range> &&
 				convertible_to<
-					std::remove_pointer_t<data_pointer_t<Range>>(*)[],
+					std::remove_pointer_t<data_pointer_t<range>>(*)[],
 					ElementType(*)[]>;
 
 			template<integral To, integral From>
@@ -151,17 +151,17 @@ STL2_OPEN_NAMESPACE {
 			{}
 
 			// FIXME: accept forwarding-range?
-			template<__span::compatible<ElementType> Range>
-			requires (Extent == __span::static_extent<Range>::value)
-			constexpr span(Range&& rng)
+			template<__span::compatible<ElementType> range>
+			requires (Extent == __span::static_extent<range>::value)
+			constexpr span(range&& rng)
 			noexcept(noexcept(__stl2::data(rng)))
 			: span{__stl2::data(rng), Extent}
 			{}
 
 			// FIXME: accept forwarding-range?
-			template<__span::compatible<ElementType> Range>
-			requires (Extent == dynamic_extent || !__span::has_static_extent<Range>)
-			constexpr span(Range&& rng)
+			template<__span::compatible<ElementType> range>
+			requires (Extent == dynamic_extent || !__span::has_static_extent<range>)
+			constexpr span(range&& rng)
 			noexcept(noexcept(__stl2::data(rng), __stl2::size(rng)))
 			: span{__stl2::data(rng), __span::narrow_cast<index_type>(__stl2::size(rng))}
 			{}

--- a/include/stl2/detail/view/view_closure.hpp
+++ b/include/stl2/detail/view/view_closure.hpp
@@ -83,30 +83,30 @@ STL2_OPEN_NAMESPACE {
 			constexpr explicit __view_closure(Fn, Ts&&... ts)
 			: __box<Is, Ts>{std::forward<Ts>(ts)}... {}
 
-			template<InputRange Rng>
-			requires ViewableRange<Rng> && invocable<Fn, Rng, Ts...> &&
-				View<invoke_result_t<Fn, Rng, Ts...>>
+			template<input_range Rng>
+			requires viewable_range<Rng> && invocable<Fn, Rng, Ts...> &&
+				view<invoke_result_t<Fn, Rng, Ts...>>
 			constexpr auto operator()(Rng&& rng) && {
 				return Fn{}(std::forward<Rng>(rng),
 					static_cast<__box<Is, Ts>&&>(*this).value_...);
 			}
-			template<InputRange Rng>
-			requires ViewableRange<Rng> && invocable<Fn, Rng, Ts &...> &&
-				View<invoke_result_t<Fn, Rng, Ts &...>>
+			template<input_range Rng>
+			requires viewable_range<Rng> && invocable<Fn, Rng, Ts &...> &&
+				view<invoke_result_t<Fn, Rng, Ts &...>>
 			constexpr auto operator()(Rng&& rng) & {
 				return Fn{}(std::forward<Rng>(rng),
 					static_cast<__box<Is, Ts>&>(*this).value_...);
 			}
-			template<InputRange Rng>
-			requires ViewableRange<Rng> && invocable<Fn, Rng, const Ts &...> &&
-				View<invoke_result_t<Fn, Rng, const Ts &...>>
+			template<input_range Rng>
+			requires viewable_range<Rng> && invocable<Fn, Rng, const Ts &...> &&
+				view<invoke_result_t<Fn, Rng, const Ts &...>>
 			constexpr auto operator()(Rng&& rng) const & {
 				return Fn{}(std::forward<Rng>(rng),
 					static_cast<const __box<Is, Ts>&>(*this).value_...);
 			}
-			template<InputRange Rng>
-			requires ViewableRange<Rng> && invocable<Fn, Rng, const Ts &...> &&
-				View<invoke_result_t<Fn, Rng, const Ts &...>>
+			template<input_range Rng>
+			requires viewable_range<Rng> && invocable<Fn, Rng, const Ts &...> &&
+				view<invoke_result_t<Fn, Rng, const Ts &...>>
 			void operator()(Rng&& rng) const && = delete;
 		};
 
@@ -130,17 +130,17 @@ STL2_OPEN_NAMESPACE {
 			constexpr __view_pipeline(A&& left, B&& right)
 			: left_(std::move(left)), right_(std::move(right)) {}
 
-			template<ViewableRange R>
+			template<viewable_range R>
 			requires invocable<A, R> && invocable<B, invoke_result_t<A, R>>
 			constexpr decltype(auto) operator()(R&& r) &&
 			{ return std::move(right_)(std::move(left_)(std::forward<R>(r))); }
 
-			template<ViewableRange R>
+			template<viewable_range R>
 			requires invocable<A&, R> && invocable<B&, invoke_result_t<A&, R>>
 			constexpr decltype(auto) operator()(R&& r) &
 			{ return right_(left_(std::forward<R>(r))); }
 
-			template<ViewableRange R>
+			template<viewable_range R>
 			requires invocable<const A&, R> &&
 				invocable<const B&, invoke_result_t<const A&, R>>
 			constexpr decltype(auto) operator()(R&& r) const &

--- a/include/stl2/view/all.hpp
+++ b/include/stl2/view/all.hpp
@@ -20,14 +20,14 @@
 #include <stl2/view/subrange.hpp>
 
 STL2_OPEN_NAMESPACE {
-	namespace view {
+	namespace views {
 		struct __all_fn : detail::__pipeable<__all_fn> {
 		private:
 			enum : unsigned { __throws = 1, __decay = 2, __ref = 4, __subrange = 6 };
 
-			template<ViewableRange _Range>
+			template<viewable_range _Range>
 			static constexpr unsigned __choose() noexcept {
-				if constexpr (View<__uncvref<_Range>>) {
+				if constexpr (view<__uncvref<_Range>>) {
 					return __decay | std::is_nothrow_constructible_v<__uncvref<_Range>, _Range>;
 				} else if constexpr (std::is_lvalue_reference_v<_Range>) {
 					return __ref | noexcept(ref_view{std::declval<_Range>()});
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 				}
 			}
 		public:
-			template<ViewableRange _Range, unsigned _Choice = __choose<_Range>()>
+			template<viewable_range _Range, unsigned _Choice = __choose<_Range>()>
 			constexpr auto operator()(_Range&& __r) const noexcept(_Choice & __throws) {
 				constexpr auto __strategy = _Choice & ~__throws;
 				if constexpr (__strategy == __decay) {
@@ -50,10 +50,10 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __all_fn all {};
-	} // namespace view
+	} // namespace views
 
-	template<ViewableRange R>
-	using all_view = decltype(view::all(std::declval<R>()));
+	template<viewable_range R>
+	using all_view = decltype(views::all(std::declval<R>()));
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/common.hpp
+++ b/include/stl2/view/common.hpp
@@ -22,8 +22,8 @@
 
 STL2_OPEN_NAMESPACE {
 	// common_view [range.common.view]
-	template<View V>
-	requires (!CommonRange<V>)
+	template<view V>
+	requires (!common_range<V>)
 	struct common_view : view_interface<common_view<V>> {
 		common_view() = default;
 
@@ -31,34 +31,34 @@ STL2_OPEN_NAMESPACE {
 
 		constexpr V base() const { return base_; }
 
-		constexpr auto size() requires (!ext::SimpleView<V> && SizedRange<V>) {
+		constexpr auto size() requires (!ext::SimpleView<V> && sized_range<V>) {
 			return __stl2::size(base_);
 		}
-		constexpr auto size() const requires SizedRange<const V> {
+		constexpr auto size() const requires sized_range<const V> {
 			return __stl2::size(base_);
 		}
 
 		constexpr auto begin() requires (!ext::SimpleView<V>) {
-			if constexpr (RandomAccessRange<V> && SizedRange<V>)
+			if constexpr (random_access_range<V> && sized_range<V>)
 				return __stl2::begin(base_);
 			else
 				return CI<false>{__stl2::begin(base_)};
 		}
-		constexpr auto begin() const requires Range<const V> {
-			if constexpr (RandomAccessRange<const V> && SizedRange<const V>)
+		constexpr auto begin() const requires range<const V> {
+			if constexpr (random_access_range<const V> && sized_range<const V>)
 				return __stl2::begin(base_);
 			else
 				return CI<true>{__stl2::begin(base_)};
 		}
 
 		constexpr auto end() requires (!ext::SimpleView<V>) {
-			if constexpr (RandomAccessRange<V> && SizedRange<V>)
+			if constexpr (random_access_range<V> && sized_range<V>)
 				return __stl2::begin(base_) + __stl2::size(base_);
 			else
 				return CI<false>{__stl2::end(base_)};
 		}
-		constexpr auto end() const requires Range<const V> {
-			if constexpr (RandomAccessRange<const V> && SizedRange<const V>)
+		constexpr auto end() const requires range<const V> {
+			if constexpr (random_access_range<const V> && sized_range<const V>)
 				return __stl2::begin(base_) + __stl2::size(base_);
 			else
 				return CI<true>{__stl2::end(base_)};
@@ -75,19 +75,19 @@ STL2_OPEN_NAMESPACE {
 	template<class R>
 	common_view(R&&) -> common_view<all_view<R>>;
 
-	namespace view {
+	namespace views {
 		struct __common_fn : detail::__pipeable<__common_fn> {
-			template<ViewableRange R>
+			template<viewable_range R>
 			constexpr auto operator()(R&& r) const {
-				if constexpr (CommonRange<R>)
-					return view::all(std::forward<R>(r));
+				if constexpr (common_range<R>)
+					return views::all(std::forward<R>(r));
 				else
 					return common_view{std::forward<R>(r)};
 			}
 		};
 
 		inline constexpr __common_fn common {};
-	} // namespace view
+	} // namespace views
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/counted.hpp
+++ b/include/stl2/view/counted.hpp
@@ -18,11 +18,11 @@
 #include <stl2/view/subrange.hpp>
 
 STL2_OPEN_NAMESPACE {
-	namespace view {
+	namespace views {
 		struct __counted_fn {
-			template<Iterator I>
+			template<input_or_output_iterator I>
 			constexpr auto operator()(I i, iter_difference_t<I> d) const {
-				if constexpr (RandomAccessIterator<I>) {
+				if constexpr (random_access_iterator<I>) {
 					return subrange{i, i + d};
 				} else {
 					return subrange{counted_iterator{i, d}, default_sentinel{}};

--- a/include/stl2/view/drop.hpp
+++ b/include/stl2/view/drop.hpp
@@ -27,10 +27,10 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View R>
+		template<view R>
 		class STL2_EMPTY_BASES drop_view
 		: public view_interface<drop_view<R>>
-		, private detail::cached_position<R, drop_view<R>, !RandomAccessRange<const R>> {
+		, private detail::cached_position<R, drop_view<R>, !random_access_range<const R>> {
 			using D = iter_difference_t<iterator_t<R>>;
 		public:
 			drop_view() = default;
@@ -41,25 +41,25 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr R base() const { return base_; }
 
-			constexpr auto begin() requires (!SimpleView<R> || !RandomAccessRange<R>)
+			constexpr auto begin() requires (!SimpleView<R> || !random_access_range<R>)
 			{ return begin_impl(*this); }
-			constexpr auto begin() const requires Range<const R> && RandomAccessRange<const R>
+			constexpr auto begin() const requires range<const R> && random_access_range<const R>
 			{ return begin_impl(*this); }
 
 			constexpr auto end() requires (!SimpleView<R>)
 			{ return end_impl(*this); }
-			constexpr auto end() const requires Range<const R>
+			constexpr auto end() const requires range<const R>
 			{ return end_impl(*this); }
 
-			constexpr auto size() requires (!SimpleView<R> && SizedRange<R>) { return size_impl(*this); }
-			constexpr auto size() const requires SizedRange<const R> { return size_impl(*this); }
+			constexpr auto size() requires (!SimpleView<R> && sized_range<R>) { return size_impl(*this); }
+			constexpr auto size() const requires sized_range<const R> { return size_impl(*this); }
 		private:
 			R base_;
 			D count_;
 
 			template<class X>
 			static constexpr auto begin_impl(X& x) {
-				if constexpr (RandomAccessRange<__maybe_const<std::is_const_v<X>, R>>) {
+				if constexpr (random_access_range<__maybe_const<std::is_const_v<X>, R>>) {
 					return __stl2::ext::nth_iterator(x.base_, x.count_);
 				} else {
 					using cache_t = typename drop_view::cached_position;
@@ -85,13 +85,13 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		template<Range R>
+		template<range R>
 		drop_view(R&&, iter_difference_t<iterator_t<R>>) -> drop_view<all_view<R>>;
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __drop_fn : detail::__pipeable<__drop_fn> {
-			template<Range Rng>
+			template<range Rng>
 			constexpr auto operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) const
 #if STL2_WORKAROUND_CLANGC_50
 			requires requires(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) {
@@ -113,7 +113,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __drop_fn drop {};
-	} // mamespace view::ext
+	} // mamespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_VIEW_DROP_HPP

--- a/include/stl2/view/drop_while.hpp
+++ b/include/stl2/view/drop_while.hpp
@@ -27,8 +27,8 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View R, IndirectPredicate<iterator_t<R>> Pred>
-		requires InputRange<R> && std::is_object_v<Pred>
+		template<view R, IndirectPredicate<iterator_t<R>> Pred>
+		requires input_range<R> && std::is_object_v<Pred>
 		class STL2_EMPTY_BASES drop_while_view
 		: public view_interface<drop_while_view<R, Pred>>
 		, private detail::semiregular_box<Pred>
@@ -72,22 +72,22 @@ STL2_OPEN_NAMESPACE {
 		drop_while_view(R&&, Pred) -> drop_while_view<all_view<R>, Pred>;
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __drop_while_fn : detail::__pipeable<__drop_while_fn> {
 			template<class Rng, class Pred>
 			constexpr auto operator()(Rng&& rng, Pred&& pred) const
 #if STL2_WORKAROUND_CLANGC_50
 			requires requires(Rng&& rng, Pred&& pred) {
 				__stl2::ext::drop_while_view{
-					view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
+					views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
 			} {
 				return __stl2::ext::drop_while_view{
-					view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
+					views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
 			}
 #else // ^^^ workaround / no workaround vvv
 			STL2_REQUIRES_RETURN(
 				__stl2::ext::drop_while_view{
-					view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
+					views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 

--- a/include/stl2/view/empty.hpp
+++ b/include/stl2/view/empty.hpp
@@ -28,7 +28,7 @@ STL2_OPEN_NAMESPACE {
 		friend constexpr T* end(empty_view) noexcept { return nullptr; }
 	};
 
-	namespace view {
+	namespace views {
 		template<class T>
 		inline constexpr empty_view<T> empty {};
 	}

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -25,8 +25,8 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<InputRange V, IndirectUnaryPredicate<iterator_t<V>> Pred>
-	requires View<V>
+	template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
+	requires view<V>
 	class filter_view : public view_interface<filter_view<V, Pred>> {
 	private:
 		class __iterator;
@@ -59,12 +59,12 @@ STL2_OPEN_NAMESPACE {
 		constexpr __sentinel end()
 		{ return __sentinel{*this}; }
 
-		constexpr __iterator end() requires CommonRange<V>
+		constexpr __iterator end() requires common_range<V>
 		{ return __iterator{*this, __stl2::end(base_)}; }
 	};
 
-	template<InputRange V, IndirectUnaryPredicate<iterator_t<V>> Pred>
-	requires View<V>
+	template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
+	requires view<V>
 	class filter_view<V, Pred>::__iterator {
 	private:
 		iterator_t<V> current_ {};
@@ -72,9 +72,9 @@ STL2_OPEN_NAMESPACE {
 		friend __sentinel;
 	public:
 		using iterator_category =
-			meta::if_c<BidirectionalIterator<iterator_t<V>>,
+			meta::if_c<bidirectional_iterator<iterator_t<V>>,
 				__stl2::bidirectional_iterator_tag,
-			meta::if_c<ForwardIterator<iterator_t<V>>,
+			meta::if_c<forward_iterator<iterator_t<V>>,
 				__stl2::forward_iterator_tag,
 				__stl2::input_iterator_tag>>;
 		using value_type = iter_value_t<iterator_t<V>>;
@@ -111,14 +111,14 @@ STL2_OPEN_NAMESPACE {
 		constexpr void operator++(int)
 		{ (void)++*this; }
 
-		constexpr __iterator operator++(int) requires ForwardRange<V>
+		constexpr __iterator operator++(int) requires forward_range<V>
 		{
 			auto tmp = *this;
 			++*this;
 			return tmp;
 		}
 
-		constexpr __iterator& operator--() requires BidirectionalRange<V>
+		constexpr __iterator& operator--() requires bidirectional_range<V>
 		{
 			do
 				--current_;
@@ -126,7 +126,7 @@ STL2_OPEN_NAMESPACE {
 			return *this;
 		}
 
-		constexpr __iterator operator--(int) requires BidirectionalRange<V>
+		constexpr __iterator operator--(int) requires bidirectional_range<V>
 		{
 			auto tmp = *this;
 			--*this;
@@ -151,8 +151,8 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.current_, y.current_); }
 	};
 
-	template<InputRange V, IndirectUnaryPredicate<iterator_t<V>> Pred>
-	requires View<V>
+	template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
+	requires view<V>
 	class filter_view<V, Pred>::__sentinel {
 	private:
 		sentinel_t<V> end_;
@@ -181,10 +181,10 @@ STL2_OPEN_NAMESPACE {
 	template<class R, class Pred>
 	filter_view(R&&, Pred) -> filter_view<all_view<R>, Pred>;
 
-	namespace view {
+	namespace views {
 		struct __filter_fn {
-			template<InputRange R, IndirectUnaryPredicate<iterator_t<R>> Pred>
-			requires ViewableRange<R>
+			template<input_range R, indirect_unary_predicate<iterator_t<R>> Pred>
+			requires viewable_range<R>
 			constexpr auto operator()(R&& rng, Pred pred) const
 #if STL2_WORKAROUND_CLANGC_50
 			requires requires(R&& rng, Pred pred) {

--- a/include/stl2/view/generate.hpp
+++ b/include/stl2/view/generate.hpp
@@ -109,7 +109,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __generate_fn : detail::__pipeable<__generate_fn> {
 			template<class F>
 			constexpr auto operator()(F&& f) const
@@ -128,7 +128,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __generate_fn generate {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_VIEW_GENERATE_HPP

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -22,10 +22,10 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View Rng>
+		template<view Rng>
 		requires
-			InputRange<Rng> &&
-			Readable<std::remove_reference_t<iter_reference_t<iterator_t<Rng>>>>
+			input_range<Rng> &&
+			readable<std::remove_reference_t<iter_reference_t<iterator_t<Rng>>>>
 		class STL2_EMPTY_BASES indirect_view
 		: public view_interface<indirect_view<Rng>>
 		, private detail::ebo_box<Rng, indirect_view<Rng>> {
@@ -48,25 +48,25 @@ STL2_OPEN_NAMESPACE {
 				decltype(auto) read() const { return **it_; }
 				void next() { ++it_; }
 				void prev()
-				requires BidirectionalIterator<iterator_t<IsConst>>
+				requires bidirectional_iterator<iterator_t<IsConst>>
 				{ --it_; }
 
 				bool equal(const cursor& that) const
-				requires Sentinel<iterator_t<IsConst>, iterator_t<IsConst>>
+				requires sentinel_for<iterator_t<IsConst>, iterator_t<IsConst>>
 				{ return it_ == that.it_; }
 				bool equal(const sentinel<IsConst>& s) const
 				{ return it_ == s.s_; }
 
 				iter_difference_t<iterator_t<IsConst>> distance_to(const cursor& that) const
-				requires SizedSentinel<iterator_t<IsConst>, iterator_t<IsConst>>
+				requires sized_sentinel_for<iterator_t<IsConst>, iterator_t<IsConst>>
 				{ return that.it_ - it_; }
 				iter_difference_t<iterator_t<IsConst>>
 				distance_to(const sentinel<IsConst>& that) const
-				requires SizedSentinel<sentinel_t<IsConst>, iterator_t<IsConst>>
+				requires sized_sentinel_for<sentinel_t<IsConst>, iterator_t<IsConst>>
 				{ return that.s_ - it_; }
 
 				void advance(iter_difference_t<iterator_t<IsConst>> n)
-				requires RandomAccessIterator<iterator_t<IsConst>>
+				requires random_access_iterator<iterator_t<IsConst>>
 				{ it_ += n; }
 			};
 		public:
@@ -74,35 +74,35 @@ STL2_OPEN_NAMESPACE {
 			indirect_view(Rng rng) : base_t{std::move(rng)} {}
 
 			basic_iterator<cursor<false>> begin()
-			requires (!Range<Rng const>)
+			requires (!range<Rng const>)
 			{ return basic_iterator<cursor<false>>{cursor<false>{__stl2::begin(get())}}; }
 
 			sentinel<false> end()
-			requires (!Range<Rng const>)
+			requires (!range<Rng const>)
 			{ return sentinel<false>{__stl2::end(get())}; }
 
 			basic_iterator<cursor<false>> end()
-			requires (!Range<Rng const> && CommonRange<Rng>)
+			requires (!range<Rng const> && common_range<Rng>)
 			{ return basic_iterator<cursor<false>>{cursor<false>{__stl2::end(get())}}; }
 
 			auto size()
-			requires (!Range<Rng const> && SizedRange<Rng>)
+			requires (!range<Rng const> && sized_range<Rng>)
 			{ return __stl2::size(get()); }
 
 			basic_iterator<cursor<true>> begin() const
-			requires Range<Rng const>
+			requires range<Rng const>
 			{ return basic_iterator<cursor<true>>{cursor<true>{__stl2::begin(get())}}; }
 
 			sentinel<true> end() const
-			requires Range<Rng const>
+			requires range<Rng const>
 			{ return sentinel<true>{__stl2::end(get())}; }
 
 			basic_iterator<cursor<true>> end() const
-			requires CommonRange<Rng const>
+			requires common_range<Rng const>
 			{ return basic_iterator<cursor<true>>{cursor<true>{__stl2::end(get())}}; }
 
 			auto size() const
-			requires SizedRange<Rng const>
+			requires sized_range<Rng const>
 			{ return __stl2::size(get()); }
 		};
 
@@ -113,7 +113,7 @@ STL2_OPEN_NAMESPACE {
 	template<class V>
 	inline constexpr bool enable_view<ext::indirect_view<V>> = true;
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __indirect_fn : detail::__pipeable<__indirect_fn> {
 			template<class Rng>
 			constexpr auto operator()(Rng&& rng) const
@@ -131,7 +131,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __indirect_fn indirect {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/iota.hpp
+++ b/include/stl2/view/iota.hpp
@@ -23,11 +23,11 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace detail {
-		template<WeaklyIncrementable I>
+		template<weakly_incrementable I>
 		struct iota_view_iterator_base {
 			using iterator_category = __stl2::input_iterator_tag;
 		};
-		template<Incrementable I>
+		template<incrementable I>
 		struct iota_view_iterator_base<I> {
 			using iterator_category = __stl2::forward_iterator_tag;
 		};
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 
-	template<WeaklyIncrementable I, semiregular Bound = unreachable>
+	template<weakly_incrementable I, semiregular Bound = unreachable>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view;
 
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	}
 
-	template<WeaklyIncrementable I, semiregular Bound>
+	template<weakly_incrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct STL2_EMPTY_BASES iota_view
 	: private __iota_view_detail::__adl_hook
@@ -91,16 +91,16 @@ STL2_OPEN_NAMESPACE {
 		constexpr auto size() const
 		requires (same_as<II, BB> && ext::RandomAccessIncrementable<II>) ||
 			(integral<II> && integral<BB>) ||
-			SizedSentinel<BB, II>
+			sized_sentinel_for<BB, II>
 		{ return bound_ - value_; }
 	};
 
-	template<WeaklyIncrementable I, semiregular Bound>
+	template<weakly_incrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound> &&
 		(!integral<I> || !integral<Bound> || std::is_signed_v<I> == std::is_signed_v<Bound>)
 	iota_view(I, Bound) -> iota_view<I, Bound>;
 
-	template<WeaklyIncrementable I, semiregular Bound>
+	template<weakly_incrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::__iterator
 	: detail::iota_view_iterator_base<I> {
@@ -123,7 +123,7 @@ STL2_OPEN_NAMESPACE {
 		}
 		constexpr void operator++(int)
 		{ ++*this; }
-		constexpr __iterator operator++(int) requires Incrementable<I>
+		constexpr __iterator operator++(int) requires incrementable<I>
 		{
 			auto tmp = *this;
 			++*this;
@@ -196,7 +196,7 @@ STL2_OPEN_NAMESPACE {
 		I value_ {};
 	};
 
-	template<WeaklyIncrementable I, semiregular Bound>
+	template<weakly_incrementable I, semiregular Bound>
 	requires WeaklyEqualityComparable<I, Bound>
 	struct iota_view<I, Bound>::__sentinel {
 		__sentinel() = default;
@@ -220,14 +220,14 @@ STL2_OPEN_NAMESPACE {
 		Bound bound_;
 	};
 
-	namespace view {
+	namespace views {
 		struct __iota_fn {
-			template<WeaklyIncrementable I>
+			template<weakly_incrementable I>
 			constexpr auto operator()(I value) const {
 				return iota_view{value};
 			}
 
-			template<WeaklyIncrementable I, semiregular Bound>
+			template<weakly_incrementable I, semiregular Bound>
 			requires WeaklyEqualityComparable<I, Bound> &&
 				(!integral<I> || !integral<Bound> ||
 					std::is_signed_v<I> == std::is_signed_v<Bound>)

--- a/include/stl2/view/istream.hpp
+++ b/include/stl2/view/istream.hpp
@@ -88,7 +88,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	} // namespace ext
 
-	namespace view {
+	namespace views {
 		template<class Val>
 		requires requires { typename __stl2::ext::istream_view<Val>; }
 		struct __istream_fn {
@@ -98,7 +98,7 @@ STL2_OPEN_NAMESPACE {
 
 		template<class Val>
 		inline constexpr __istream_fn<Val> istream{};
-	} // namespace view
+	} // namespace views
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/move.hpp
+++ b/include/stl2/view/move.hpp
@@ -24,8 +24,8 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View Rng>
-		requires InputRange<Rng>
+		template<view Rng>
+		requires input_range<Rng>
 		class STL2_EMPTY_BASES move_view
 		: detail::ebo_box<Rng, move_view<Rng>>
 		, public view_interface<move_view<Rng>> {
@@ -39,37 +39,37 @@ STL2_OPEN_NAMESPACE {
 			: base_t{std::move(rng)} {}
 
 			move_iterator<iterator_t<Rng>> begin() const
-			requires Range<const Rng>
+			requires range<const Rng>
 			{ return __stl2::make_move_iterator(__stl2::begin(get())); }
 			move_sentinel<sentinel_t<Rng>> end() const
-			requires Range<const Rng>
+			requires range<const Rng>
 			{ return __stl2::make_move_sentinel(__stl2::end(get())); }
 			move_iterator<iterator_t<Rng>> end() const
-			requires Range<const Rng> && CommonRange<const Rng>
+			requires range<const Rng> && common_range<const Rng>
 			{ return __stl2::make_move_iterator(__stl2::end(get())); }
 
 			auto size() const
-			requires Range<const Rng> && SizedRange<const Rng>
+			requires range<const Rng> && sized_range<const Rng>
 			{ return __stl2::size(get()); }
 			bool empty() const
-			requires Range<const Rng> && requires(const Rng& r) { __stl2::empty(r); }
+			requires range<const Rng> && requires(const Rng& r) { __stl2::empty(r); }
 			{ return __stl2::empty(get()); }
 
 			move_iterator<iterator_t<Rng>> begin()
-			requires (!Range<const Rng>)
+			requires (!range<const Rng>)
 			{ return __stl2::make_move_iterator(__stl2::begin(get())); }
 			move_sentinel<sentinel_t<Rng>> end()
-			requires (!Range<const Rng>)
+			requires (!range<const Rng>)
 			{ return __stl2::make_move_sentinel(__stl2::end(get())); }
 			move_iterator<iterator_t<Rng>> end()
-			requires (!Range<const Rng> && CommonRange<Rng>)
+			requires (!range<const Rng> && common_range<Rng>)
 			{ return __stl2::make_move_iterator(__stl2::end(get())); }
 
 			auto size()
-			requires (!Range<const Rng> && SizedRange<Rng>)
+			requires (!range<const Rng> && sized_range<Rng>)
 			{ return __stl2::size(get()); }
 			bool empty()
-			requires (!Range<const Rng>)
+			requires (!range<const Rng>)
 			{ return __stl2::empty(get()); }
 		};
 	} // namespace ext
@@ -77,18 +77,18 @@ STL2_OPEN_NAMESPACE {
 	template<class V>
 	inline constexpr bool enable_view<ext::move_view<V>> = true;
 
-	namespace view {
+	namespace views {
 		struct __move_fn : detail::__pipeable<__move_fn> {
-			template<InputRange Rng>
-			requires ViewableRange<Rng>
+			template<input_range Rng>
+			requires viewable_range<Rng>
 			constexpr __stl2::ext::move_view<all_view<Rng>> operator()(Rng&& rng) const {
 				return __stl2::ext::move_view<all_view<Rng>>{
-					view::all(std::forward<Rng>(rng))};
+					views::all(std::forward<Rng>(rng))};
 			}
 		};
 
 		inline constexpr __move_fn move {};
-	} // namespace view
+	} // namespace views
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/ref.hpp
+++ b/include/stl2/view/ref.hpp
@@ -25,7 +25,7 @@
 
 STL2_OPEN_NAMESPACE {
 	// ref_view [ranges.view.ref]
-	template<Range R>
+	template<range R>
 	requires std::is_object_v<R>
 	struct STL2_EMPTY_BASES ref_view;
 
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	}
 
-	template<Range R>
+	template<range R>
 	requires std::is_object_v<R>
 	struct STL2_EMPTY_BASES ref_view
 	: private __ref_view_detail::__adl_hook
@@ -78,11 +78,11 @@ STL2_OPEN_NAMESPACE {
 			return __stl2::empty(*r_);
 		}
 
-		constexpr auto size() const requires SizedRange<R> {
+		constexpr auto size() const requires sized_range<R> {
 			return __stl2::size(*r_);
 		}
 
-		constexpr auto data() const requires ContiguousRange<R> {
+		constexpr auto data() const requires contiguous_range<R> {
 			return __stl2::data(*r_);
 		}
 	};
@@ -91,7 +91,7 @@ STL2_OPEN_NAMESPACE {
 	template<class R>
 	ref_view(R&) -> ref_view<R>;
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __ref_fn : detail::__pipeable<__ref_fn> {
 			template<class R>
 			auto operator()(R&& r) const
@@ -107,7 +107,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __ref_fn ref {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/repeat.hpp
+++ b/include/stl2/view/repeat.hpp
@@ -88,7 +88,7 @@ STL2_OPEN_NAMESPACE {
 		repeat_view(T) -> repeat_view<T>;
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __repeat_fn {
 			template<class T>
 			constexpr auto operator()(T&& t) const
@@ -106,7 +106,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __repeat_fn repeat {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/repeat_n.hpp
+++ b/include/stl2/view/repeat_n.hpp
@@ -23,7 +23,7 @@ STL2_OPEN_NAMESPACE {
 		using repeat_n_view = take_exactly_view<repeat_view<T>>;
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __repeat_n_fn {
 		private:
 		template<class T> using V = __stl2::ext::repeat_n_view<__uncvref<T>>;
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __repeat_n_fn repeat_n {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/reverse.hpp
+++ b/include/stl2/view/reverse.hpp
@@ -22,11 +22,11 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<View V>
-	requires BidirectionalRange<V>
+	template<view V>
+	requires bidirectional_range<V>
 	class STL2_EMPTY_BASES reverse_view
 	: public view_interface<reverse_view<V>>
-	, private detail::cached_position<V, reverse_view<V>, !CommonRange<V>> {
+	, private detail::cached_position<V, reverse_view<V>, !common_range<V>> {
 	private:
 		V base_ = V();
 
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr V base() const { return base_; }
 
 		constexpr reverse_iterator<iterator_t<V>> begin() {
-			if constexpr (CommonRange<V>) {
+			if constexpr (common_range<V>) {
 				return reverse_iterator<iterator_t<V>>{__stl2::end(base_)};
 			} else {
 				const auto cached = static_cast<bool>(end_());
@@ -55,21 +55,21 @@ STL2_OPEN_NAMESPACE {
 			}
 		}
 
-		constexpr auto begin() const requires CommonRange<const V> {
+		constexpr auto begin() const requires common_range<const V> {
 			return reverse_iterator<iterator_t<const V>>{__stl2::end(base_)};
 		}
 
 		constexpr reverse_iterator<iterator_t<V>> end() {
 			return reverse_iterator<iterator_t<V>>{__stl2::begin(base_)};
 		}
-		constexpr auto end() const requires CommonRange<const V> {
+		constexpr auto end() const requires common_range<const V> {
 			return reverse_iterator<iterator_t<const V>>{__stl2::begin(base_)};
 		}
 
-		constexpr auto size() requires SizedRange<V> {
+		constexpr auto size() requires sized_range<V> {
 			return __stl2::size(base_);
 		}
-		constexpr auto size() const requires SizedRange<const V> {
+		constexpr auto size() const requires sized_range<const V> {
 			return __stl2::size(base_);
 		}
 	};
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 	template<class R>
 	reverse_view(R&&) -> reverse_view<all_view<R>>;
 
-	namespace view {
+	namespace views {
 		template<class>
 		inline constexpr bool __is_reversible_subrange = false;
 		template<class I, subrange_kind K>
@@ -85,14 +85,14 @@ STL2_OPEN_NAMESPACE {
 			subrange<reverse_iterator<I>, reverse_iterator<I>, K>> = true;
 
 		struct __reverse_fn : detail::__pipeable<__reverse_fn> {
-			template<BidirectionalRange R>
-			requires ViewableRange<R>
+			template<bidirectional_range R>
+			requires viewable_range<R>
 			constexpr auto operator()(R&& r) const {
 				if constexpr (_SpecializationOf<R, reverse_view>) {
 					return std::forward<R>(r).base();
 				} else if constexpr (__is_reversible_subrange<__uncvref<R>>) {
 					using I = decltype(begin(r).base());
-					if constexpr (SizedRange<R>) {
+					if constexpr (sized_range<R>) {
 						return subrange<I, I, subrange_kind::sized>(
 							r.end().base(), r.begin().base(), r.size());
 					} else {
@@ -106,7 +106,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __reverse_fn reverse {};
-	} // namespace view
+	} // namespace views
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/single.hpp
+++ b/include/stl2/view/single.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr const T* data() const noexcept { return std::addressof(value_.get()); }
 	};
 
-	namespace view {
+	namespace views {
 		struct __single_fn {
 			template<class T>
 			constexpr auto operator()(T&& t) const

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -23,7 +23,7 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<View R>
+	template<view R>
 	struct take_view : view_interface<take_view<R>> {
 	private:
 		template<bool> struct __sentinel;
@@ -35,8 +35,8 @@ STL2_OPEN_NAMESPACE {
 		template<class Self>
 		static constexpr auto begin_(Self& self) {
 			using RR = __maybe_const<std::is_const_v<Self>, R>;
-			if constexpr (SizedRange<RR>) {
-				if constexpr (RandomAccessRange<RR>) {
+			if constexpr (sized_range<RR>) {
+				if constexpr (random_access_range<RR>) {
 					return __stl2::begin(self.base_);
 				} else {
 					return counted_iterator{__stl2::begin(self.base_), static_cast<D>(self.size())};
@@ -49,9 +49,9 @@ STL2_OPEN_NAMESPACE {
 		static constexpr auto end_(Self& self) {
 			constexpr bool is_const = std::is_const_v<Self>;
 			using RR = __maybe_const<is_const, R>;
-			if constexpr (RandomAccessRange<RR> && SizedRange<RR>) {
+			if constexpr (random_access_range<RR> && sized_range<RR>) {
 				return __stl2::begin(self.base_) + self.size();
-			} else if constexpr (SizedRange<RR>) {
+			} else if constexpr (sized_range<RR>) {
 				return default_sentinel{};
 			} else {
 				return __sentinel<is_const>{__stl2::end(self.base_)};
@@ -72,20 +72,20 @@ STL2_OPEN_NAMESPACE {
 		constexpr R base() const { return base_; }
 
 		constexpr auto begin() requires (!ext::SimpleView<R>) { return begin_(*this); }
-		constexpr auto begin() const requires Range<const R> { return begin_(*this); }
+		constexpr auto begin() const requires range<const R> { return begin_(*this); }
 
 		constexpr auto end() requires (!ext::SimpleView<R>) { return end_(*this); }
-		constexpr auto end() const requires Range<const R> || SizedRange<R>
+		constexpr auto end() const requires range<const R> || sized_range<R>
 		{ return end_(*this); }
 
-		constexpr auto size() requires (!ext::SimpleView<R> && SizedRange<R>) { return size_(*this); }
-		constexpr auto size() const requires SizedRange<const R> { return size_(*this); }
+		constexpr auto size() requires (!ext::SimpleView<R> && sized_range<R>) { return size_(*this); }
+		constexpr auto size() const requires sized_range<const R> { return size_(*this); }
 	};
 
-	template<Range R>
+	template<range R>
 	take_view(R&&, iter_difference_t<iterator_t<R>>) -> take_view<all_view<R>>;
 
-	template<View R>
+	template<view R>
 	template<bool Const>
 	struct take_view<R>::__sentinel {
 	private:
@@ -112,19 +112,19 @@ STL2_OPEN_NAMESPACE {
 		friend constexpr bool operator!=(const CI& x, const __sentinel& y) { return !(y == x); }
 	};
 
-	namespace view {
+	namespace views {
 		struct __take_fn {
-			template<Range Rng>
+			template<range Rng>
 			constexpr auto operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) const
 #if STL2_WORKAROUND_CLANGC_50
 			requires requires(Rng&& rng, iter_difference_t<iterator_t<Rng>> count) {
-				take_view{view::all(static_cast<Rng&&>(rng)), count};
+				take_view{views::all(static_cast<Rng&&>(rng)), count};
 			} {
-				return take_view{view::all(static_cast<Rng&&>(rng)), count};
+				return take_view{views::all(static_cast<Rng&&>(rng)), count};
 			}
 #else // ^^^ workaround / no workaround vvv
 			STL2_REQUIRES_RETURN(
-				take_view{view::all(static_cast<Rng&&>(rng)), count}
+				take_view{views::all(static_cast<Rng&&>(rng)), count}
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -28,7 +28,7 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View Base>
+		template<view Base>
 		class STL2_EMPTY_BASES take_exactly_view
 		: public view_interface<take_exactly_view<Base>>
 		, private detail::ebo_box<Base, take_exactly_view<Base>>
@@ -47,21 +47,21 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr auto begin()
 			noexcept(noexcept(counted_iterator{__stl2::begin(std::declval<Base&>()), n_}))
-			requires (!Range<Base const>)
+			requires (!range<Base const>)
 			{ return counted_iterator{__stl2::begin(get()), n_}; }
 
 	#if 0 // FIXME: Untagged bug workaround
 			constexpr auto data()
 			noexcept(noexcept(__stl2::data(std::declval<Base&>())))
 			requires
-				(!Range<Base const> &&
+				(!range<Base const> &&
 				requires(Base& b) { __stl2::data(b); })
 			{ return __stl2::data(get()); }
 	#else
 			template<class B = Base>
 			requires
 				(same_as<B, Base> &&
-				!Range<B const> &&
+				!range<B const> &&
 				requires(B& b) { __stl2::data(b); })
 			constexpr auto data()
 			noexcept(noexcept(__stl2::data(std::declval<B&>())))
@@ -70,21 +70,21 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr auto begin() const
 			noexcept(noexcept(counted_iterator{__stl2::begin(std::declval<Base const&>()), n_}))
-			requires Range<Base const>
+			requires range<Base const>
 			{ return counted_iterator{__stl2::begin(get()), n_}; }
 
 	#if 0 // FIXME: Untagged bug workaround
 			constexpr auto data() const
 			noexcept(noexcept(__stl2::data(std::declval<Base const&>())))
 			requires
-				(!Range<Base const> &&
+				(!range<Base const> &&
 				requires(Base const& b) { __stl2::data(b); })
 			{ return __stl2::data(get()); }
 	#else
 			template<class B = Base>
 			requires
 				same_as<B, Base> &&
-				Range<B const> &&
+				range<B const> &&
 				requires(B const& b) { __stl2::data(b); }
 			constexpr auto data() const
 			noexcept(noexcept(__stl2::data(std::declval<B const&>())))
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 			constexpr bool empty() const noexcept { return n_ == 0; }
 		};
 
-		template<Range R>
+		template<range R>
 		take_exactly_view(R&& base, iter_difference_t<iterator_t<R>> n)
 			-> take_exactly_view<all_view<R>>;
 	} // namespace ext
@@ -104,7 +104,7 @@ STL2_OPEN_NAMESPACE {
 	template<class V>
 	inline constexpr bool enable_view<ext::take_exactly_view<V>> = true;
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __take_exactly_fn : detail::__pipeable<__take_exactly_fn> {
 			template<class V>
 			constexpr auto operator()(V&& view, iter_difference_t<iterator_t<V>> const n) const
@@ -127,7 +127,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __take_exactly_fn take_exactly {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -27,9 +27,9 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace ext {
-		template<View R, class Pred>
-		requires InputRange<R> && std::is_object_v<Pred> &&
-			IndirectUnaryPredicate<const Pred, iterator_t<R>>
+		template<view R, class Pred>
+		requires input_range<R> && std::is_object_v<Pred> &&
+			indirect_unary_predicate<const Pred, iterator_t<R>>
 		class STL2_EMPTY_BASES take_while_view
 		: public view_interface<take_while_view<R, Pred>>
 		, private detail::semiregular_box<Pred> {
@@ -46,10 +46,10 @@ STL2_OPEN_NAMESPACE {
 			constexpr const Pred& pred() const noexcept { return get(); }
 
 			constexpr auto begin() requires (!SimpleView<R>) { return begin_impl(*this); }
-			constexpr auto begin() const requires Range<const R> { return begin_impl(*this); }
+			constexpr auto begin() const requires range<const R> { return begin_impl(*this); }
 
 			constexpr auto end() requires (!SimpleView<R>) { return end_impl(*this); }
-			constexpr auto end() const requires Range<const R>
+			constexpr auto end() const requires range<const R>
 			{ return end_impl(*this); }
 		private:
 			R base_;
@@ -67,9 +67,9 @@ STL2_OPEN_NAMESPACE {
 		template<class R, class Pred>
 		take_while_view(R&&, Pred) -> take_while_view<all_view<R>, Pred>;
 
-		template<View R, class Pred>
-		requires InputRange<R> && std::is_object_v<Pred> &&
-			IndirectUnaryPredicate<const Pred, iterator_t<R>>
+		template<view R, class Pred>
+		requires input_range<R> && std::is_object_v<Pred> &&
+			indirect_unary_predicate<const Pred, iterator_t<R>>
 		template<bool Const>
 		class take_while_view<R, Pred>::__sentinel {
 			friend __sentinel<false>;
@@ -96,21 +96,21 @@ STL2_OPEN_NAMESPACE {
 		};
 	} // namespace ext
 
-	namespace view::ext {
+	namespace views::ext {
 		struct __take_while_fn : detail::__pipeable<__take_while_fn> {
 			template<class Rng, class Pred>
 			constexpr auto operator()(Rng&& rng, Pred&& pred) const
 #if STL2_WORKAROUND_CLANGC_50
 			requires requires(Rng&& rng, Pred&& pred) {
 				__stl2::ext::take_while_view{
-					view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
+					views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
 			} {
 				return __stl2::ext::take_while_view{
-					view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
+					views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)};
 			}
 #else // ^^^ workaround / no workaround vvv
 			STL2_REQUIRES_RETURN(
-				__stl2::ext::take_while_view{view::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
+				__stl2::ext::take_while_view{views::all(static_cast<Rng&&>(rng)), std::forward<Pred>(pred)}
 			)
 #endif // STL2_WORKAROUND_CLANGC_50
 
@@ -120,7 +120,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __take_while_fn take_while {};
-	} // namespace view::ext
+	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_VIEW_TAKE_WHILE_HPP

--- a/include/stl2/view/transform.hpp
+++ b/include/stl2/view/transform.hpp
@@ -27,8 +27,8 @@
 #include <stl2/view/view_interface.hpp>
 
 STL2_OPEN_NAMESPACE {
-	template<InputRange V, copy_constructible F>
-	requires View<V> && std::is_object_v<F> &&
+	template<input_range V, copy_constructible F>
+	requires view<V> && std::is_object_v<F> &&
 		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	class transform_view : public view_interface<transform_view<V, F>> {
 	private:
@@ -51,12 +51,12 @@ STL2_OPEN_NAMESPACE {
 
 		// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		template<class ConstV = const V>
-		constexpr __iterator<true> begin() const requires Range<ConstV> &&
+		constexpr __iterator<true> begin() const requires range<ConstV> &&
 			regular_invocable<const F&, iter_reference_t<iterator_t<ConstV>>>
 		{ return {*this, __stl2::begin(base_)}; }
 
 		constexpr auto end() {
-			if constexpr (CommonRange<V>) {
+			if constexpr (common_range<V>) {
 				return __iterator<false>{*this, __stl2::end(base_)};
 			} else {
 				return __sentinel<false>{__stl2::end(base_)};
@@ -65,28 +65,28 @@ STL2_OPEN_NAMESPACE {
 
 		// Template to work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
 		template<class ConstV = const V>
-		constexpr auto end() const requires Range<ConstV> &&
+		constexpr auto end() const requires range<ConstV> &&
 			regular_invocable<const F&, iter_reference_t<iterator_t<ConstV>>>
 		{
-			if constexpr (CommonRange<const V>) {
+			if constexpr (common_range<const V>) {
 				return __iterator<true>{*this, __stl2::end(base_)};
 			} else {
 				return __sentinel<true>{__stl2::end(base_)};
 			}
 		}
 
-		constexpr auto size() requires SizedRange<V>
+		constexpr auto size() requires sized_range<V>
 		{ return __stl2::size(base_); }
 
-		constexpr auto size() const requires SizedRange<const V>
+		constexpr auto size() const requires sized_range<const V>
 		{ return __stl2::size(base_); }
 	};
 
 	template<class R, class F>
 	transform_view(R&& r, F fun) -> transform_view<all_view<R>, F>;
 
-	template<InputRange V, copy_constructible F>
-	requires View<V> && std::is_object_v<F> &&
+	template<input_range V, copy_constructible F>
+	requires view<V> && std::is_object_v<F> &&
 		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	template<bool Const>
 	class transform_view<V, F>::__iterator {
@@ -126,19 +126,19 @@ STL2_OPEN_NAMESPACE {
 		}
 		constexpr void operator++(int)
 		{ ++current_; }
-		constexpr __iterator operator++(int) requires ForwardRange<Base>
+		constexpr __iterator operator++(int) requires forward_range<Base>
 		{
 			auto tmp = *this;
 			++*this;
 			return tmp;
 		}
 
-		constexpr __iterator& operator--() requires BidirectionalRange<Base>
+		constexpr __iterator& operator--() requires bidirectional_range<Base>
 		{
 			--current_;
 			return *this;
 		}
-		constexpr __iterator operator--(int) requires BidirectionalRange<Base>
+		constexpr __iterator operator--(int) requires bidirectional_range<Base>
 		{
 			auto tmp = *this;
 			--*this;
@@ -146,19 +146,19 @@ STL2_OPEN_NAMESPACE {
 		}
 
 		constexpr __iterator& operator+=(difference_type n)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{
 			current_ += n;
 			return *this;
 		}
 		constexpr __iterator& operator-=(difference_type n)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{
 			current_ -= n;
 			return *this;
 		}
 		constexpr decltype(auto) operator[](difference_type n) const
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return invoke(parent_->fun_.get(), current_[n]); }
 
 		friend constexpr bool operator==(const __iterator& x, const __iterator& y)
@@ -170,35 +170,35 @@ STL2_OPEN_NAMESPACE {
 		{ return !(x == y); }
 
 		friend constexpr bool operator<(const __iterator& x, const __iterator& y)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return x.current_ < y.current_; }
 
 		friend constexpr bool operator>(const __iterator& x, const __iterator& y)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return y < x; }
 
 		friend constexpr bool operator<=(const __iterator& x, const __iterator& y)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return !(y < x); }
 
 		friend constexpr bool operator>=(const __iterator& x, const __iterator& y)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return !(x < y); }
 
 		friend constexpr __iterator operator+(__iterator i, difference_type n)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return __iterator{*i.parent_, i.current_ + n}; }
 
 		friend constexpr __iterator operator+(difference_type n, __iterator i)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return __iterator{*i.parent_, i.current_ + n}; }
 
 		friend constexpr __iterator operator-(__iterator i, difference_type n)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return __iterator{*i.parent_, i.current_ - n}; }
 
 		friend constexpr difference_type operator-(const __iterator& x, const __iterator& y)
-		requires RandomAccessRange<Base>
+		requires random_access_range<Base>
 		{ return x.current_ - y.current_; }
 
 		friend constexpr decltype(auto) iter_move(const __iterator& i)
@@ -215,8 +215,8 @@ STL2_OPEN_NAMESPACE {
 		{ __stl2::iter_swap(x.current_, y.current_); }
 	};
 
-	template<InputRange V, copy_constructible F>
-	requires View<V> && std::is_object_v<F> &&
+	template<input_range V, copy_constructible F>
+	requires view<V> && std::is_object_v<F> &&
 		regular_invocable<F&, iter_reference_t<iterator_t<V>>>
 	template<bool Const>
 	class transform_view<V, F>::__sentinel {
@@ -258,20 +258,20 @@ STL2_OPEN_NAMESPACE {
 
 		friend constexpr iter_difference_t<iterator_t<Base>>
 		operator-(const __iterator<Const>& x, const __sentinel& y)
-		requires SizedSentinel<sentinel_t<Base>, iterator_t<Base>>
+		requires sized_sentinel_for<sentinel_t<Base>, iterator_t<Base>>
 		{ return -y.distance(x); }
 
 		friend constexpr iter_difference_t<iterator_t<Base>>
 		operator-(const __sentinel& y, const __iterator<Const>& x)
-		requires SizedSentinel<sentinel_t<Base>, iterator_t<Base>>
+		requires sized_sentinel_for<sentinel_t<Base>, iterator_t<Base>>
 		{ return y.distance(x); }
 	};
 
-	namespace view {
+	namespace views {
 		struct __transform_fn {
-			template<InputRange Rng, copy_constructible F>
+			template<input_range Rng, copy_constructible F>
 			requires
-				ViewableRange<Rng> && invocable<F&, iter_reference_t<iterator_t<Rng>>>
+				viewable_range<Rng> && invocable<F&, iter_reference_t<iterator_t<Rng>>>
 			constexpr auto operator()(Rng&& rng, F fun) const {
 				return transform_view{std::forward<Rng>(rng), std::move(fun)};
 			}
@@ -283,7 +283,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		inline constexpr __transform_fn transform {};
-	} // namespace view
+	} // namespace views
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/view/view_interface.hpp
+++ b/include/stl2/view/view_interface.hpp
@@ -21,36 +21,36 @@
 
 STL2_OPEN_NAMESPACE {
 	namespace detail {
-		template<Range Rng>
+		template<range Rng>
 		struct __range_common_iterator_impl {
 			using type = common_iterator<iterator_t<Rng>, sentinel_t<Rng>>;
 		};
-		template<CommonRange Rng>
+		template<common_range Rng>
 		struct __range_common_iterator_impl<Rng> {
 			using type = iterator_t<Rng>;
 		};
-		template<Range Rng>
+		template<range Rng>
 		using __range_common_iterator =
 			typename __range_common_iterator_impl<Rng>::type;
 
 		template<class R>
-		META_CONCEPT CanEmpty = Range<R> && requires(R& r) { empty(r); };
+		META_CONCEPT CanEmpty = range<R> && requires(R& r) { empty(r); };
 		template<class R>
-		META_CONCEPT SizedSentinelForwardRange = ForwardRange<R> && SizedSentinel<sentinel_t<R>, iterator_t<R>>;
+		META_CONCEPT SizedSentinelForwardRange = forward_range<R> && sized_sentinel_for<sentinel_t<R>, iterator_t<R>>;
 		template<class C, class R> // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82507
-		META_CONCEPT ContainerConvertibleGCCBugs = InputRange<R> &&
+		META_CONCEPT ContainerConvertibleGCCBugs = input_range<R> &&
 			convertible_to<iter_reference_t<iterator_t<R>>, iter_value_t<iterator_t<C>>> &&
 			constructible_from<C, __range_common_iterator<R>, __range_common_iterator<R>>;
 		template<class C, class R>
-		META_CONCEPT ContainerConvertible = ForwardRange<C> && !View<C> &&
+		META_CONCEPT ContainerConvertible = forward_range<C> && !view<C> &&
 			ContainerConvertibleGCCBugs<C, R>;
 
-		template<Range R>
+		template<range R>
 		constexpr bool is_in_range(R& r, iter_difference_t<iterator_t<R>> n) noexcept {
 			return 0 <= n;
 		}
 
-		template<SizedRange R>
+		template<sized_range R>
 		constexpr bool is_in_range(R& r, iter_difference_t<iterator_t<R>> n)
 			noexcept(noexcept(size(r)))
 		{
@@ -75,11 +75,11 @@ STL2_OPEN_NAMESPACE {
 			return static_cast<const D&>(*this);
 		}
 	public:
-		constexpr bool empty() requires ForwardRange<D> {
+		constexpr bool empty() requires forward_range<D> {
 			auto& d = derived();
 			return __stl2::begin(d) == __stl2::end(d);
 		}
-		constexpr bool empty() const requires ForwardRange<const D> {
+		constexpr bool empty() const requires forward_range<const D> {
 			auto& d = derived();
 			return begin(d) == end(d);
 		}
@@ -94,15 +94,15 @@ STL2_OPEN_NAMESPACE {
 		constexpr explicit operator bool() const {
 			return !__stl2::empty(derived());
 		}
-		template<Range R = D>
-		requires ContiguousIterator<iterator_t<R>>
+		template<range R = D>
+		requires contiguous_iterator<iterator_t<R>>
 		constexpr auto data() {
 			auto& d = derived();
 			return __stl2::empty(d) ? nullptr
 				: std::addressof(*begin(d));
 		}
-		template<Range R = const D>
-		requires ContiguousIterator<iterator_t<R>>
+		template<range R = const D>
+		requires contiguous_iterator<iterator_t<R>>
 		constexpr auto data() const {
 			auto& d = derived();
 			return __stl2::empty(d) ? nullptr
@@ -115,39 +115,39 @@ STL2_OPEN_NAMESPACE {
 			auto& d = derived();
 			return end(d) - begin(d);
 		}
-		constexpr decltype(auto) front() requires ForwardRange<D> {
+		constexpr decltype(auto) front() requires forward_range<D> {
 			auto& d = derived();
 			const auto first = begin(d);
 			STL2_EXPECT(first != end(d));
 			return *first;
 		}
-		constexpr decltype(auto) front() const requires ForwardRange<const D> {
+		constexpr decltype(auto) front() const requires forward_range<const D> {
 			auto& d = derived();
 			const auto first = begin(d);
 			STL2_EXPECT(first != end(d));
 			return *first;
 		}
 		constexpr decltype(auto) back()
-		requires BidirectionalRange<D> && CommonRange<D> {
+		requires bidirectional_range<D> && common_range<D> {
 			auto& d = derived();
 			auto last = end(d);
 			STL2_EXPECT(begin(d) != last);
 			return *--last;
 		}
 		constexpr decltype(auto) back() const
-		requires BidirectionalRange<const D> && CommonRange<const D> {
+		requires bidirectional_range<const D> && common_range<const D> {
 			auto& d = derived();
 			auto last = end(d);
 			STL2_EXPECT(begin(d) != last);
 			return *--last;
 		}
-		template<RandomAccessRange R = D>
+		template<random_access_range R = D>
 		constexpr decltype(auto) operator[](iter_difference_t<iterator_t<R>> n) {
 			auto& d = derived();
 			STL2_EXPECT(detail::is_in_range(d, n));
 			return begin(d)[n];
 		}
-		template<RandomAccessRange R = const D>
+		template<random_access_range R = const D>
 		constexpr decltype(auto) operator[](iter_difference_t<iterator_t<R>> n) const {
 			auto& d = derived();
 			STL2_EXPECT(detail::is_in_range(d, n));

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -19,7 +19,7 @@
 
 namespace ranges = __stl2;
 
-template<ranges::InputIterator I>
+template<ranges::input_iterator I>
 	requires ranges::regular<ranges::iter_value_t<I>>
 struct delimiter {
 	delimiter() = default;

--- a/test/algorithm/count.cpp
+++ b/test/algorithm/count.cpp
@@ -20,7 +20,7 @@ struct S
 
 int main()
 {
-	using namespace __stl2;
+	using __stl2::count, __stl2::size, __stl2::subrange;
 
 	int ia[] = {0, 1, 2, 2, 0, 1, 2, 3};
 	constexpr unsigned cia = size(ia);

--- a/test/algorithm/count_if.cpp
+++ b/test/algorithm/count_if.cpp
@@ -26,7 +26,7 @@ struct T
 
 int main()
 {
-	using namespace __stl2;
+	using __stl2::count_if, __stl2::size, __stl2::subrange;
 
 	auto equals = [](auto&& i){
 	  return [i = static_cast<decltype(i)>(i)](const auto& j) {

--- a/test/algorithm/equal.cpp
+++ b/test/algorithm/equal.cpp
@@ -33,7 +33,7 @@ bool counting_equals(const T &a, const T &b) {
 }
 
 int main() {
-	using namespace ranges;
+	using ranges::equal, ranges::distance, ranges::subrange;
 
 	auto test_case = [](const bool result, const int count,
 		const auto first1, const auto last1, const auto first2, const auto last2)

--- a/test/algorithm/equal_range.cpp
+++ b/test/algorithm/equal_range.cpp
@@ -74,7 +74,7 @@ void test(Iter first, Sent last, const T& value, Proj proj = {}) {
 
 template<class Iter, class Sent = Iter>
 void test() {
-	using namespace ranges::view;
+	using namespace ranges::views;
 	static constexpr unsigned M = 10;
 	std::vector<int> v;
 	auto input = iota(0) | take(100) | transform([](int i){return ext::repeat_n(i,M);}) | join;

--- a/test/algorithm/fill_n.cpp
+++ b/test/algorithm/fill_n.cpp
@@ -28,14 +28,14 @@
 
 namespace ranges = __stl2;
 
-template<ranges::ForwardIterator I, ranges::Sentinel<I> S, class T>
-	requires ranges::Writable<I, const T&>
+template<ranges::forward_iterator I, ranges::sentinel_for<I> S, class T>
+	requires ranges::writable<I, const T&>
 I count_and_fill(I i, S s, const T& t) {
 	return ranges::fill_n(i, ranges::distance(i, s), t);
 }
 
-template<ranges::ForwardRange Rng, class T>
-	requires ranges::Writable<ranges::iterator_t<Rng>, const T&>
+template<ranges::forward_range Rng, class T>
+	requires ranges::writable<ranges::iterator_t<Rng>, const T&>
 ranges::safe_iterator_t<Rng> count_and_fill(Rng&& rng, const T& t) {
 	return ranges::fill_n(ranges::begin(rng), ranges::distance(rng), t);
 }

--- a/test/algorithm/find.cpp
+++ b/test/algorithm/find.cpp
@@ -30,7 +30,7 @@ struct S {
 };
 
 int main() {
-	using namespace ranges;
+	using ranges::find, ranges::size, ranges::subrange, ranges::end;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	auto first = [&ia]{ return input_iterator<const int*>{ia}; };

--- a/test/algorithm/find_first_of.cpp
+++ b/test/algorithm/find_first_of.cpp
@@ -35,11 +35,10 @@ namespace rng = ranges;
 
 void test_iter()
 {
-	using namespace ranges;
 	int ia[] = {0, 1, 2, 3, 0, 1, 2, 3};
-	static constexpr unsigned sa = size(ia);
+	static constexpr unsigned sa = rng::size(ia);
 	int ib[] = {1, 3, 5, 7};
-	static constexpr unsigned sb = size(ib);
+	static constexpr unsigned sb = rng::size(ib);
 	CHECK(rng::find_first_of(input_iterator<const int*>(ia),
 							 sentinel<const int*>(ia + sa),
 							 forward_iterator<const int*>(ib),
@@ -65,11 +64,10 @@ void test_iter()
 
 void test_iter_pred()
 {
-	using namespace ranges;
 	int ia[] = {0, 1, 2, 3, 0, 1, 2, 3};
-	static constexpr unsigned sa = size(ia);
+	static constexpr unsigned sa = rng::size(ia);
 	int ib[] = {1, 3, 5, 7};
-	static constexpr unsigned sb = size(ib);
+	static constexpr unsigned sb = rng::size(ib);
 	CHECK(rng::find_first_of(input_iterator<const int*>(ia),
 							 sentinel<const int*>(ia + sa),
 							 forward_iterator<const int*>(ib),
@@ -99,83 +97,81 @@ void test_iter_pred()
 
 void test_rng()
 {
-	using namespace ranges;
 	int ia[] = {0, 1, 2, 3, 0, 1, 2, 3};
-	static constexpr unsigned sa = size(ia);
+	static constexpr unsigned sa = rng::size(ia);
 	int ib[] = {1, 3, 5, 7};
-	static constexpr unsigned sb = size(ib);
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	static constexpr unsigned sb = rng::size(ib);
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ib),
+							 rng::subrange(forward_iterator<const int*>(ib),
 							 forward_iterator<const int*>(ib + sb))) ==
 							 input_iterator<const int*>(ia+1));
-	CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa)),
-							 subrange(forward_iterator<const int*>(ib),
+							 rng::subrange(forward_iterator<const int*>(ib),
 							 forward_iterator<const int*>(ib + sb))) ==
 							 input_iterator<const int*>(ia+1));
 	int ic[] = {7};
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic + 1))) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic))) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic+1))) ==
 							 input_iterator<const int*>(ia));
-	CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa)),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic + 1))) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa)),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic))) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia)),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic+1))) ==
 							 input_iterator<const int*>(ia));
 }
 
 void test_rng_pred()
 {
-	using namespace ranges;
 	int ia[] = {0, 1, 2, 3, 0, 1, 2, 3};
-	static constexpr unsigned sa = size(ia);
+	static constexpr unsigned sa = rng::size(ia);
 	int ib[] = {1, 3, 5, 7};
-	static constexpr unsigned sb = size(ib);
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	static constexpr unsigned sb = rng::size(ib);
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ib),
+							 rng::subrange(forward_iterator<const int*>(ib),
 							 forward_iterator<const int*>(ib + sb)),
 							 std::equal_to<int>()) ==
 							 input_iterator<const int*>(ia+1));
 	int ic[] = {7};
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic + 1)),
 							 std::equal_to<int>()) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia + sa))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic)),
 							 std::equal_to<int>()) ==
 							 input_iterator<const int*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const int*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const int*>(ia),
 							 input_iterator<const int*>(ia))),
-							 subrange(forward_iterator<const int*>(ic),
+							 rng::subrange(forward_iterator<const int*>(ic),
 							 forward_iterator<const int*>(ic+1)),
 							 std::equal_to<int>()) ==
 							 input_iterator<const int*>(ia));
@@ -188,33 +184,32 @@ struct S
 
 void test_rng_pred_proj()
 {
-	using namespace ranges;
 	S ia[] = {S{0}, S{1}, S{2}, S{3}, S{0}, S{1}, S{2}, S{3}};
-	static constexpr unsigned sa = size(ia);
+	static constexpr unsigned sa = rng::size(ia);
 	S ib[] = {S{1}, S{3}, S{5}, S{7}};
-	static constexpr unsigned sb = size(ib);
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
+	static constexpr unsigned sb = rng::size(ib);
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const S*>(ia),
 							 input_iterator<const S*>(ia + sa))),
-							 subrange(forward_iterator<const S*>(ib),
+							 rng::subrange(forward_iterator<const S*>(ib),
 							 forward_iterator<const S*>(ib + sb)),
 							 std::equal_to<int>(), &S::i, &S::i) ==
 							 input_iterator<const S*>(ia+1));
 	S ic[] = {S{7}};
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const S*>(ia),
 							 input_iterator<const S*>(ia + sa))),
-							 subrange(forward_iterator<const S*>(ic),
+							 rng::subrange(forward_iterator<const S*>(ic),
 							 forward_iterator<const S*>(ic + 1)),
 							 std::equal_to<int>(), &S::i, &S::i) ==
 							 input_iterator<const S*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const S*>(ia),
 							 input_iterator<const S*>(ia + sa))),
-							 subrange(forward_iterator<const S*>(ic),
+							 rng::subrange(forward_iterator<const S*>(ic),
 							 forward_iterator<const S*>(ic)),
 							 std::equal_to<int>(), &S::i, &S::i) ==
 							 input_iterator<const S*>(ia+sa));
-	CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
+	CHECK(rng::find_first_of(as_lvalue(rng::subrange(input_iterator<const S*>(ia),
 							 input_iterator<const S*>(ia))),
-							 subrange(forward_iterator<const S*>(ic),
+							 rng::subrange(forward_iterator<const S*>(ic),
 							 forward_iterator<const S*>(ic+1)),
 							 std::equal_to<int>(), &S::i, &S::i) ==
 							 input_iterator<const S*>(ia));

--- a/test/algorithm/find_if.cpp
+++ b/test/algorithm/find_if.cpp
@@ -30,7 +30,7 @@ struct S
 
 int main()
 {
-	using namespace __stl2;
+	using __stl2::find_if, __stl2::size, __stl2::end, __stl2::subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	constexpr unsigned s = size(ia);

--- a/test/algorithm/find_if_not.cpp
+++ b/test/algorithm/find_if_not.cpp
@@ -30,7 +30,7 @@ struct S
 
 int main()
 {
-	using namespace __stl2;
+	using __stl2::find_if_not, __stl2::size, __stl2::end, __stl2::subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	constexpr unsigned s = size(ia);

--- a/test/algorithm/is_permutation.cpp
+++ b/test/algorithm/is_permutation.cpp
@@ -310,7 +310,7 @@ int main() {
 			forward_iterator<const T*>(ib), sentinel<const T*>(ib + sa),
 			std::equal_to<int const>(), &S::i, &T::i) == true);
 
-		// Iterator tests, with sentinels, with predicate and projections:
+		// input_or_output_iterator tests, with sentinels, with predicate and projections:
 		CHECK(ranges::is_permutation(
 			forward_iterator<const S*>(ia), sentinel<const S*>(ia + sa),
 			forward_iterator<const T*>(ib), sentinel<const T*>(ib + sa),

--- a/test/algorithm/is_permutation.cpp
+++ b/test/algorithm/is_permutation.cpp
@@ -310,7 +310,7 @@ int main() {
 			forward_iterator<const T*>(ib), sentinel<const T*>(ib + sa),
 			std::equal_to<int const>(), &S::i, &T::i) == true);
 
-		// input_or_output_iterator tests, with sentinels, with predicate and projections:
+		// Iterator tests, with sentinels, with predicate and projections:
 		CHECK(ranges::is_permutation(
 			forward_iterator<const S*>(ia), sentinel<const S*>(ia + sa),
 			forward_iterator<const T*>(ib), sentinel<const T*>(ib + sa),

--- a/test/algorithm/partition_point.cpp
+++ b/test/algorithm/partition_point.cpp
@@ -134,7 +134,7 @@ void test_range() {
 	}
 }
 
-template<ranges::Iterator I>
+template<ranges::input_or_output_iterator I>
 ranges::subrange<ranges::counted_iterator<I>, ranges::default_sentinel>
 make_counted_view(I i, ranges::iter_difference_t<I> n) {
 	return {ranges::counted_iterator{std::move(i), n}, {}};

--- a/test/algorithm/push_heap.cpp
+++ b/test/algorithm/push_heap.cpp
@@ -24,7 +24,7 @@
 
 // <algorithm>
 
-// template<RandomAccessIterator Iter>
+// template<random_access_iterator Iter>
 //   requires ShuffleIterator<Iter>
 //         && LessThanComparable<Iter::value_type>
 //   void

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -35,7 +35,7 @@
 namespace ranges = __stl2;
 
 namespace {
-	template<class I, ranges::Sentinel<I> S>
+	template<class I, ranges::sentinel_for<I> S>
 	bool in_sequence(I first, I mid, S last)
 	{
 		for (; first != mid; ++first)

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -300,12 +300,12 @@ int main()
 	{
 		using namespace ranges;
 		std::vector<int> v0 =
-			view::for_each(view::ints(1,6) | view::reverse, [](int i){
-				return ranges::yield_from(view::repeat_n(i,i));
+			views::for_each(views::ints(1,6) | views::reverse, [](int i){
+				return ranges::yield_from(views::repeat_n(i,i));
 			});
 		auto v1 = ranges::to_<std::vector<Int>>(
 			{1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
-		auto rng = view::zip(v0, v1);
+		auto rng = views::zip(v0, v1);
 		CHECK_EQUAL(v0,{5,5,5,5,5,4,4,4,4,3,3,3,2,2,1});
 		CHECK_EQUAL(v1,{1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
 		using Rng = decltype(rng);

--- a/test/concepts/iterator.cpp
+++ b/test/concepts/iterator.cpp
@@ -167,11 +167,11 @@ namespace readable_test {
 		using value_type = int;
 	};
 
-	CONCEPT_ASSERT(!ranges::Readable<void>);
-	CONCEPT_ASSERT(!ranges::Readable<void*>);
-	CONCEPT_ASSERT(ranges::Readable<int*>);
-	CONCEPT_ASSERT(ranges::Readable<const int*>);
-	CONCEPT_ASSERT(ranges::Readable<A>);
+	CONCEPT_ASSERT(!ranges::readable<void>);
+	CONCEPT_ASSERT(!ranges::readable<void*>);
+	CONCEPT_ASSERT(ranges::readable<int*>);
+	CONCEPT_ASSERT(ranges::readable<const int*>);
+	CONCEPT_ASSERT(ranges::readable<A>);
 	CONCEPT_ASSERT(ranges::same_as<ns::iter_value_t<A>,int>);
 
 	struct MoveOnlyReadable {
@@ -179,14 +179,14 @@ namespace readable_test {
 		value_type operator*() const;
 	};
 
-	CONCEPT_ASSERT(ranges::Readable<MoveOnlyReadable>);
+	CONCEPT_ASSERT(ranges::readable<MoveOnlyReadable>);
 
 	struct ArrayReadable {
 		using value_type = int[2];
 		value_type& operator*() const;
 	};
 
-	CONCEPT_ASSERT(ranges::Readable<ArrayReadable>);
+	CONCEPT_ASSERT(ranges::readable<ArrayReadable>);
 
 	struct Abstract {
 		virtual void foo() = 0;
@@ -196,7 +196,7 @@ namespace readable_test {
 		Abstract& operator*() const;
 	};
 
-	CONCEPT_ASSERT(ranges::Readable<AbstractReadable>);
+	CONCEPT_ASSERT(ranges::readable<AbstractReadable>);
 }
 
 namespace writable_test {
@@ -204,32 +204,32 @@ namespace writable_test {
 		int& operator*() const;
 	};
 
-	CONCEPT_ASSERT(ranges::Writable<std::unique_ptr<int>*, std::unique_ptr<int>&&>);
-	CONCEPT_ASSERT(!ranges::Writable<std::unique_ptr<int>*, std::unique_ptr<int>&>);
-	CONCEPT_ASSERT(!ranges::Writable<void, int>);
-	CONCEPT_ASSERT(!ranges::Writable<void*, void>);
-	CONCEPT_ASSERT(ranges::Writable<int*, int>);
-	CONCEPT_ASSERT(ranges::Writable<int*, int&>);
-	CONCEPT_ASSERT(ranges::Writable<int*, const int&>);
-	CONCEPT_ASSERT(ranges::Writable<int*, const int>);
-	CONCEPT_ASSERT(!ranges::Writable<const int*, int>);
-	CONCEPT_ASSERT(ranges::Writable<A, int>);
-	CONCEPT_ASSERT(ranges::Writable<A, const int&>);
-	CONCEPT_ASSERT(ranges::Writable<A, double>);
-	CONCEPT_ASSERT(ranges::Writable<A, const double&>);
+	CONCEPT_ASSERT(ranges::writable<std::unique_ptr<int>*, std::unique_ptr<int>&&>);
+	CONCEPT_ASSERT(!ranges::writable<std::unique_ptr<int>*, std::unique_ptr<int>&>);
+	CONCEPT_ASSERT(!ranges::writable<void, int>);
+	CONCEPT_ASSERT(!ranges::writable<void*, void>);
+	CONCEPT_ASSERT(ranges::writable<int*, int>);
+	CONCEPT_ASSERT(ranges::writable<int*, int&>);
+	CONCEPT_ASSERT(ranges::writable<int*, const int&>);
+	CONCEPT_ASSERT(ranges::writable<int*, const int>);
+	CONCEPT_ASSERT(!ranges::writable<const int*, int>);
+	CONCEPT_ASSERT(ranges::writable<A, int>);
+	CONCEPT_ASSERT(ranges::writable<A, const int&>);
+	CONCEPT_ASSERT(ranges::writable<A, double>);
+	CONCEPT_ASSERT(ranges::writable<A, const double&>);
 } // namespace writable_test
 
-CONCEPT_ASSERT(ranges::WeaklyIncrementable<int>);
-CONCEPT_ASSERT(ranges::WeaklyIncrementable<unsigned int>);
-CONCEPT_ASSERT(!ranges::WeaklyIncrementable<void>);
-CONCEPT_ASSERT(ranges::WeaklyIncrementable<int*>);
-CONCEPT_ASSERT(ranges::WeaklyIncrementable<const int*>);
+CONCEPT_ASSERT(ranges::weakly_incrementable<int>);
+CONCEPT_ASSERT(ranges::weakly_incrementable<unsigned int>);
+CONCEPT_ASSERT(!ranges::weakly_incrementable<void>);
+CONCEPT_ASSERT(ranges::weakly_incrementable<int*>);
+CONCEPT_ASSERT(ranges::weakly_incrementable<const int*>);
 
-CONCEPT_ASSERT(ranges::Incrementable<int>);
-CONCEPT_ASSERT(ranges::Incrementable<unsigned int>);
-CONCEPT_ASSERT(!ranges::Incrementable<void>);
-CONCEPT_ASSERT(ranges::Incrementable<int*>);
-CONCEPT_ASSERT(ranges::Incrementable<const int*>);
+CONCEPT_ASSERT(ranges::incrementable<int>);
+CONCEPT_ASSERT(ranges::incrementable<unsigned int>);
+CONCEPT_ASSERT(!ranges::incrementable<void>);
+CONCEPT_ASSERT(ranges::incrementable<int*>);
+CONCEPT_ASSERT(ranges::incrementable<const int*>);
 
 namespace iterator_sentinel_test {
 	struct A {
@@ -245,18 +245,18 @@ namespace iterator_sentinel_test {
 		bool operator != (const A&) const;
 	};
 
-	CONCEPT_ASSERT(ranges::Iterator<int*>);
-	CONCEPT_ASSERT(ranges::Iterator<const int*>);
-	CONCEPT_ASSERT(!ranges::Iterator<void*>);
-	CONCEPT_ASSERT(ranges::Iterator<A>);
-	CONCEPT_ASSERT(ranges::InputIterator<A>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<int*>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<const int*>);
+	CONCEPT_ASSERT(!ranges::input_or_output_iterator<void*>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<A>);
+	CONCEPT_ASSERT(ranges::input_iterator<A>);
 
-	CONCEPT_ASSERT(ranges::Iterator<int*>);
-	CONCEPT_ASSERT(ranges::Sentinel<int*, int*>);
-	CONCEPT_ASSERT(ranges::Sentinel<const int*, const int*>);
-	CONCEPT_ASSERT(ranges::Sentinel<const int*, int*>);
-	CONCEPT_ASSERT(!ranges::Sentinel<void*, void*>);
-	CONCEPT_ASSERT(ranges::Sentinel<A, A>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<int*>);
+	CONCEPT_ASSERT(ranges::sentinel_for<int*, int*>);
+	CONCEPT_ASSERT(ranges::sentinel_for<const int*, const int*>);
+	CONCEPT_ASSERT(ranges::sentinel_for<const int*, int*>);
+	CONCEPT_ASSERT(!ranges::sentinel_for<void*, void*>);
+	CONCEPT_ASSERT(ranges::sentinel_for<A, A>);
 } // namespace iterator_sentinel_test
 
 namespace indirectly_callable_test {
@@ -340,20 +340,20 @@ namespace contiguous_test {
 		bool operator!=(allocator<U>);
 	};
 
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::array<int, 42>::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::array<int, 42>::const_iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::string::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::string::const_iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::basic_string<char, std::char_traits<char>, allocator<char>>::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::basic_string<char, std::char_traits<char>, allocator<char>>::const_iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::string_view::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::string_view::const_iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<ranges::iterator_t<std::valarray<double>>>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<ranges::iterator_t<const std::valarray<double>>>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::vector<int>::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::vector<int>::const_iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::vector<int, allocator<int>>::iterator>);
-	CONCEPT_ASSERT(ranges::ContiguousIterator<std::vector<int, allocator<int>>::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::array<int, 42>::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::array<int, 42>::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::string::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::string::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::basic_string<char, std::char_traits<char>, allocator<char>>::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::basic_string<char, std::char_traits<char>, allocator<char>>::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::string_view::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::string_view::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<ranges::iterator_t<std::valarray<double>>>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<ranges::iterator_t<const std::valarray<double>>>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::vector<int>::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::vector<int>::const_iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::vector<int, allocator<int>>::iterator>);
+	CONCEPT_ASSERT(ranges::contiguous_iterator<std::vector<int, allocator<int>>::const_iterator>);
 }
 
 int main() {

--- a/test/concepts/range.cpp
+++ b/test/concepts/range.cpp
@@ -150,334 +150,334 @@ namespace ranges {
 #endif
 
 void ridiculously_exhaustive_range_property_test() {
-	CONCEPT_ASSERT(!ranges::Range<void>);
-	CONCEPT_ASSERT(!ranges::SizedRange<void>);
+	CONCEPT_ASSERT(!ranges::range<void>);
+	CONCEPT_ASSERT(!ranges::sized_range<void>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<void>);
-	CONCEPT_ASSERT(!ranges::View<void>);
+	CONCEPT_ASSERT(!ranges::view<void>);
 
 	using I = int*;
 	using CI = const int*;
 
-	CONCEPT_ASSERT(ranges::Iterator<I>);
-	CONCEPT_ASSERT(ranges::Iterator<CI>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<I>);
+	CONCEPT_ASSERT(ranges::input_or_output_iterator<CI>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<int[2]>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<int[2]>, I>);
-	CONCEPT_ASSERT(ranges::Range<int[2]>);
-	CONCEPT_ASSERT(ranges::SizedRange<int[2]>);
+	CONCEPT_ASSERT(ranges::range<int[2]>);
+	CONCEPT_ASSERT(ranges::sized_range<int[2]>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<int[2]>);
-	CONCEPT_ASSERT(!ranges::View<int[2]>);
+	CONCEPT_ASSERT(!ranges::view<int[2]>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<int(&)[2]>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<int(&)[2]>, I>);
-	CONCEPT_ASSERT(ranges::Range<int(&)[2]>);
-	CONCEPT_ASSERT(ranges::SizedRange<int(&)[2]>);
+	CONCEPT_ASSERT(ranges::range<int(&)[2]>);
+	CONCEPT_ASSERT(ranges::sized_range<int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<int(&)[2]>);
-	CONCEPT_ASSERT(!ranges::View<int(&)[2]>);
+	CONCEPT_ASSERT(!ranges::view<int(&)[2]>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const int[2]>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const int[2]>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const int[2]>);
-	CONCEPT_ASSERT(ranges::SizedRange<const int[2]>);
+	CONCEPT_ASSERT(ranges::range<const int[2]>);
+	CONCEPT_ASSERT(ranges::sized_range<const int[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const int[2]>);
-	CONCEPT_ASSERT(!ranges::View<const int[2]>);
+	CONCEPT_ASSERT(!ranges::view<const int[2]>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const int(&)[2]>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const int(&)[2]>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const int(&)[2]>);
-	CONCEPT_ASSERT(ranges::SizedRange<const int(&)[2]>);
+	CONCEPT_ASSERT(ranges::range<const int(&)[2]>);
+	CONCEPT_ASSERT(ranges::sized_range<const int(&)[2]>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const int(&)[2]>);
-	CONCEPT_ASSERT(!ranges::View<const int(&)[2]>);
+	CONCEPT_ASSERT(!ranges::view<const int(&)[2]>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_unsized_range>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_unsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_unsized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_unsized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_unsized_range>);
-	CONCEPT_ASSERT(!ranges::View<mutable_unsized_range>);
+	CONCEPT_ASSERT(!ranges::view<mutable_unsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_unsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_unsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_unsized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_unsized_range&>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_unsized_range>);
-	CONCEPT_ASSERT(!ranges::View<mutable_unsized_range>);
+	CONCEPT_ASSERT(!ranges::view<mutable_unsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_unsized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<const mutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::range<const mutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<const mutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_unsized_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_unsized_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_unsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_unsized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<const mutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::range<const mutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<const mutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_unsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_unsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_unsized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_no_size_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_no_size_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_no_size_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_no_size_range>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_only_no_size_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_no_size_range>);
-	CONCEPT_ASSERT(ranges::View<mutable_only_no_size_range>);
+	CONCEPT_ASSERT(ranges::view<mutable_only_no_size_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_no_size_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_no_size_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_only_no_size_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_only_no_size_range&>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_no_size_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_no_size_range>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_no_size_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_no_size_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_no_size_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_no_size_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_no_size_range>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_no_size_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_no_size_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_unsized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<immutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::range<immutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<immutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_unsized_range>);
-	CONCEPT_ASSERT(ranges::View<immutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::view<immutable_unsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_unsized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<immutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::range<immutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_unsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<immutable_unsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<immutable_unsized_range&>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_unsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_unsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_unsized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<const immutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::range<const immutable_unsized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<const immutable_unsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_unsized_range>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_unsized_range>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_unsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_unsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_unsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_unsized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<const immutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::range<const immutable_unsized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<const immutable_unsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_unsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_unsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_unsized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_sized_range>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_sized_range>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_sized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_sized_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_sized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_sized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_sized_range>);
-	CONCEPT_ASSERT(!ranges::View<mutable_sized_range>);
+	CONCEPT_ASSERT(!ranges::view<mutable_sized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_sized_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_sized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_sized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_sized_range&>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_sized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<const mutable_sized_range>);
+	CONCEPT_ASSERT(ranges::range<const mutable_sized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<const mutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_sized_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_sized_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_sized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_sized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<const mutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::range<const mutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<const mutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_sized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_sized_range>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_sized_range>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_sized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_sized_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_sized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_only_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_sized_range>);
-	CONCEPT_ASSERT(ranges::View<mutable_only_sized_range>);
+	CONCEPT_ASSERT(ranges::view<mutable_only_sized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_sized_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_sized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_sized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<mutable_only_sized_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_sized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<mutable_only_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_only_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_only_sized_range&>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_sized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_sized_range>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_sized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_sized_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_sized_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_sized_range>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_sized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_sized_range&>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_sized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_sized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_sized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<immutable_sized_range>);
+	CONCEPT_ASSERT(ranges::range<immutable_sized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<immutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_sized_range>);
-	CONCEPT_ASSERT(ranges::View<immutable_sized_range>);
+	CONCEPT_ASSERT(ranges::view<immutable_sized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_sized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<immutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::range<immutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<immutable_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<immutable_sized_range&>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_sized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_sized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_sized_range>);
-	CONCEPT_ASSERT(ranges::SizedRange<const immutable_sized_range>);
+	CONCEPT_ASSERT(ranges::range<const immutable_sized_range>);
+	CONCEPT_ASSERT(ranges::sized_range<const immutable_sized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_sized_range>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_sized_range>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_sized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_sized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_sized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_sized_range&>);
-	CONCEPT_ASSERT(ranges::SizedRange<const immutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::range<const immutable_sized_range&>);
+	CONCEPT_ASSERT(ranges::sized_range<const immutable_sized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_sized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_sized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_sized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_badsized_range>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_badsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<mutable_badsized_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<mutable_badsized_range>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<mutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::View<mutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::view<mutable_badsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_badsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_badsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<mutable_badsized_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_badsized_range&>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_badsized_range>);
+	CONCEPT_ASSERT(ranges::range<const mutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_badsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const mutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const mutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const mutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_badsized_range&>);
+	CONCEPT_ASSERT(ranges::range<const mutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_badsized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_badsized_range>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_badsized_range>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<mutable_only_badsized_range>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<mutable_only_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_badsized_range>);
-	CONCEPT_ASSERT(ranges::View<mutable_only_badsized_range>);
+	CONCEPT_ASSERT(ranges::view<mutable_only_badsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<mutable_only_badsized_range&>, I>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<mutable_only_badsized_range&>, I>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<mutable_only_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<mutable_only_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_only_badsized_range&>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_badsized_range>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_badsized_range>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_badsized_range>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_badsized_range>);
 
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<const mutable_only_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const mutable_only_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_badsized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<immutable_badsized_range>);
+	CONCEPT_ASSERT(ranges::range<immutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_badsized_range>);
-	CONCEPT_ASSERT(ranges::View<immutable_badsized_range>);
+	CONCEPT_ASSERT(ranges::view<immutable_badsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<immutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<immutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<immutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<immutable_badsized_range&>);
+	CONCEPT_ASSERT(ranges::range<immutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<immutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<immutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<immutable_badsized_range&>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_badsized_range>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_badsized_range>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const immutable_badsized_range>);
+	CONCEPT_ASSERT(ranges::range<const immutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::sized_range<const immutable_badsized_range>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_badsized_range>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_badsized_range>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_badsized_range>);
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<const immutable_badsized_range&>, CI>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<const immutable_badsized_range&>, CI>);
-	CONCEPT_ASSERT(ranges::Range<const immutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::SizedRange<const immutable_badsized_range&>);
+	CONCEPT_ASSERT(ranges::range<const immutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::sized_range<const immutable_badsized_range&>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<const immutable_badsized_range&>);
-	CONCEPT_ASSERT(!ranges::View<const immutable_badsized_range&>);
+	CONCEPT_ASSERT(!ranges::view<const immutable_badsized_range&>);
 
 
 	CONCEPT_ASSERT(ranges::same_as<ns::iterator_t<std::vector<int>>, std::vector<int>::iterator>);
 	CONCEPT_ASSERT(ranges::same_as<ns::sentinel_t<std::vector<int>>, std::vector<int>::iterator>);
-	CONCEPT_ASSERT(ranges::Range<std::vector<int>>);
-	CONCEPT_ASSERT(ranges::SizedRange<std::vector<int>>);
+	CONCEPT_ASSERT(ranges::range<std::vector<int>>);
+	CONCEPT_ASSERT(ranges::sized_range<std::vector<int>>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<std::vector<int>>);
-	CONCEPT_ASSERT(!ranges::View<std::vector<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::vector<int>>);
 
 
-	CONCEPT_ASSERT(ranges::Range<strange_view>);
-	CONCEPT_ASSERT(ranges::Range<strange_view&>);
-	CONCEPT_ASSERT(ranges::View<strange_view>);
-	CONCEPT_ASSERT(!ranges::View<strange_view&>);
-	CONCEPT_ASSERT(!ranges::View<const strange_view>);
+	CONCEPT_ASSERT(ranges::range<strange_view>);
+	CONCEPT_ASSERT(ranges::range<strange_view&>);
+	CONCEPT_ASSERT(ranges::view<strange_view>);
+	CONCEPT_ASSERT(!ranges::view<strange_view&>);
+	CONCEPT_ASSERT(!ranges::view<const strange_view>);
 
-	CONCEPT_ASSERT(ranges::Range<strange_view2>);
-	CONCEPT_ASSERT(ranges::Range<strange_view2&>);
-	CONCEPT_ASSERT(ranges::View<strange_view2>);
-	CONCEPT_ASSERT(!ranges::View<strange_view2&>);
-	CONCEPT_ASSERT(!ranges::View<const strange_view2>);
+	CONCEPT_ASSERT(ranges::range<strange_view2>);
+	CONCEPT_ASSERT(ranges::range<strange_view2&>);
+	CONCEPT_ASSERT(ranges::view<strange_view2>);
+	CONCEPT_ASSERT(!ranges::view<strange_view2&>);
+	CONCEPT_ASSERT(!ranges::view<const strange_view2>);
 
-	CONCEPT_ASSERT(ranges::Range<strange_view3>);
-	CONCEPT_ASSERT(ranges::Range<strange_view3&>);
-	CONCEPT_ASSERT(!ranges::View<strange_view3>);
-	CONCEPT_ASSERT(!ranges::View<strange_view3&>);
-	CONCEPT_ASSERT(!ranges::View<const strange_view3>);
+	CONCEPT_ASSERT(ranges::range<strange_view3>);
+	CONCEPT_ASSERT(ranges::range<strange_view3&>);
+	CONCEPT_ASSERT(!ranges::view<strange_view3>);
+	CONCEPT_ASSERT(!ranges::view<strange_view3&>);
+	CONCEPT_ASSERT(!ranges::view<const strange_view3>);
 
-	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(ranges::Range<mutable_only_no_size_range>);
-	CONCEPT_ASSERT(ranges::View<mutable_only_no_size_range>);
-	CONCEPT_ASSERT(!ranges::View<mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(!ranges::View<mutable_only_no_size_range&&>);
-	CONCEPT_ASSERT(!ranges::Range<const mutable_only_no_size_range&>);
-	CONCEPT_ASSERT(!ranges::View<const mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(ranges::range<mutable_only_no_size_range>);
+	CONCEPT_ASSERT(ranges::view<mutable_only_no_size_range>);
+	CONCEPT_ASSERT(!ranges::view<mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::view<mutable_only_no_size_range&&>);
+	CONCEPT_ASSERT(!ranges::range<const mutable_only_no_size_range&>);
+	CONCEPT_ASSERT(!ranges::view<const mutable_only_no_size_range&>);
 }
 
 #if VALIDATE_RANGES
 template<class I, class S,
-	CONCEPT_REQUIRES_(ranges::InputIterator<I> && ranges::Sentinel<S, I>)>
+	CONCEPT_REQUIRES_(ranges::input_iterator<I> && ranges::sentinel_for<S, I>)>
 #elif VALIDATE_STL2
-template<ns::InputIterator I, ns::Sentinel<I> S>
+template<ns::input_iterator I, ns::sentinel_for<I> S>
 #endif
 I complicated_algorithm(I i, S s) {
 	static constexpr bool output = false;
@@ -493,9 +493,9 @@ I complicated_algorithm(I i, S s) {
 }
 
 #if VALIDATE_RANGES
-template<class R, CONCEPT_REQUIRES_(ranges::Range<R>)>
+template<class R, CONCEPT_REQUIRES_(ranges::range<R>)>
 #elif VALIDATE_STL2
-template<ns::InputRange R>
+template<ns::input_range R>
 #endif
 ns::iterator_t<R> complicated_algorithm(R&& r) {
 	return complicated_algorithm(ns::begin(r), ns::end(r));
@@ -517,15 +517,15 @@ struct array_view {
 
 void complicated_algorithm_test() {
 	static int some_ints[] = {2, 3, 5, 7};
-	CONCEPT_ASSERT(ranges::Range<decltype(some_ints)>);
-	CONCEPT_ASSERT(ranges::SizedRange<decltype(some_ints)>);
+	CONCEPT_ASSERT(ranges::range<decltype(some_ints)>);
+	CONCEPT_ASSERT(ranges::sized_range<decltype(some_ints)>);
 	CONCEPT_ASSERT(ranges::_ContainerLike<decltype(some_ints)>);
-	CONCEPT_ASSERT(!ranges::View<decltype(some_ints)>);
+	CONCEPT_ASSERT(!ranges::view<decltype(some_ints)>);
 	CHECK(complicated_algorithm(some_ints) == ns::end(some_ints));
-	CONCEPT_ASSERT(ranges::Range<array_view<int>>);
-	CONCEPT_ASSERT(ranges::SizedRange<array_view<int>>);
+	CONCEPT_ASSERT(ranges::range<array_view<int>>);
+	CONCEPT_ASSERT(ranges::sized_range<array_view<int>>);
 	CONCEPT_ASSERT(!ranges::_ContainerLike<array_view<int>>);
-	CONCEPT_ASSERT(ranges::View<array_view<int>>);
+	CONCEPT_ASSERT(ranges::view<array_view<int>>);
 	CHECK(complicated_algorithm(array_view<int>{some_ints}) == ns::end(some_ints));
 }
 
@@ -535,23 +535,23 @@ int main() {
 
 	{
 		using T = int[2];
-		CONCEPT_ASSERT(ranges::CommonRange<T>);
-		CONCEPT_ASSERT(ranges::OutputRange<T, int>);
-		CONCEPT_ASSERT(ranges::OutputRange<T, const int&>);
-		CONCEPT_ASSERT(ranges::InputRange<T>);
-		CONCEPT_ASSERT(ranges::ForwardRange<T>);
-		CONCEPT_ASSERT(ranges::BidirectionalRange<T>);
-		CONCEPT_ASSERT(ranges::RandomAccessRange<T>);
+		CONCEPT_ASSERT(ranges::common_range<T>);
+		CONCEPT_ASSERT(ranges::output_range<T, int>);
+		CONCEPT_ASSERT(ranges::output_range<T, const int&>);
+		CONCEPT_ASSERT(ranges::input_range<T>);
+		CONCEPT_ASSERT(ranges::forward_range<T>);
+		CONCEPT_ASSERT(ranges::bidirectional_range<T>);
+		CONCEPT_ASSERT(ranges::random_access_range<T>);
 #if VALIDATE_STL2
-		CONCEPT_ASSERT(ranges::ContiguousRange<T>);
+		CONCEPT_ASSERT(ranges::contiguous_range<T>);
 #endif
 	}
 
-	CONCEPT_ASSERT(!ranges::View<std::vector<int>>);
-	CONCEPT_ASSERT(!ranges::View<std::set<int>>);
-	CONCEPT_ASSERT(!ranges::View<std::multiset<int>>);
-	CONCEPT_ASSERT(!ranges::View<std::unordered_set<int>>);
-	CONCEPT_ASSERT(!ranges::View<std::unordered_multiset<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::vector<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::set<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::multiset<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::unordered_set<int>>);
+	CONCEPT_ASSERT(!ranges::view<std::unordered_multiset<int>>);
 
 	return ::test_result();
 }

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -281,11 +281,11 @@ struct proxy_array {
 		O&& indirect_move() const noexcept { return std::move(*ptr_); }
 	};
 
-	static_assert(ranges::cursor::Readable<cursor<false>>);
+	static_assert(ranges::cursor::readable<cursor<false>>);
 	static_assert(ranges::cursor::IndirectMove<cursor<false>>);
 	static_assert(ranges::same_as<T&&, ranges::cursor::rvalue_reference_t<cursor<false>>>);
 
-	static_assert(ranges::cursor::Readable<cursor<true>>);
+	static_assert(ranges::cursor::readable<cursor<true>>);
 	static_assert(ranges::cursor::IndirectMove<cursor<true>>);
 	static_assert(ranges::same_as<const T&&, ranges::cursor::rvalue_reference_t<cursor<true>>>);
 
@@ -312,7 +312,7 @@ struct proxy_array {
 	}
 };
 
-template<ranges::InputRange R>
+template<ranges::input_range R>
 requires
 	(ranges::StreamInsertable<ranges::iter_value_t<ranges::iterator_t<R>>> &&
 	 !ranges::same_as<char, std::remove_cv_t<
@@ -338,20 +338,20 @@ void test_fl() {
 	using Rng = decltype(list);
 	using I = decltype(list.begin());
 	using S = decltype(list.end());
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
 	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
 	static_assert(ranges::copyable<I>);
 	static_assert(ranges::default_initializable<I>);
 	static_assert(ranges::semiregular<I>);
-	static_assert(ranges::Incrementable<I>);
+	static_assert(ranges::incrementable<I>);
 	static_assert(ranges::equality_comparable<I>);
-	static_assert(ranges::ForwardIterator<I>);
-	static_assert(ranges::Sentinel<S, I>);
-	static_assert(ranges::ForwardRange<Rng>);
+	static_assert(ranges::forward_iterator<I>);
+	static_assert(ranges::sentinel_for<S, I>);
+	static_assert(ranges::forward_range<Rng>);
 	static_assert(ranges::common_with<S, I>);
 	static_assert(ranges::same_as<ranges::common_type_t<S, I>, I>);
 	std::cout << list << '\n';
@@ -379,14 +379,14 @@ void test_rv() {
 
 	using Rng = decltype(rv);
 	using I = decltype(rv.begin());
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
 	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
-	static_assert(ranges::RandomAccessIterator<I>);
-	static_assert(ranges::RandomAccessRange<Rng>);
+	static_assert(ranges::random_access_iterator<I>);
+	static_assert(ranges::random_access_range<Rng>);
 	CHECK(I{} == I{});
 
 	auto i = rv.begin();
@@ -418,17 +418,17 @@ void test_array() {
 	using Rng = decltype(a);
 	using I = decltype(a.begin());
 	CHECK(noexcept(a.begin()));
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int&>);
 	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int&&>);
-	static_assert(ranges::ContiguousIterator<I>);
-	static_assert(ranges::RandomAccessRange<Rng>);
-	static_assert(ranges::RandomAccessRange<const Rng>);
-	static_assert(ranges::CommonRange<Rng>);
-	static_assert(ranges::CommonRange<const Rng>);
+	static_assert(ranges::contiguous_iterator<I>);
+	static_assert(ranges::random_access_range<Rng>);
+	static_assert(ranges::random_access_range<const Rng>);
+	static_assert(ranges::common_range<Rng>);
+	static_assert(ranges::common_range<const Rng>);
 	CHECK(I{} == I{});
 	CHECK(noexcept(I{} == I{}));
 
@@ -461,14 +461,14 @@ void test_counted() {
 	std::cout << "test_counted:\n";
 	int some_ints[] = {0,1,2,3};
 	using I = counted_iterator<const int*>;
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, const int&>);
 	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, const int&&>);
-	static_assert(ranges::RandomAccessIterator<I>);
-	static_assert(ranges::ContiguousIterator<I>);
+	static_assert(ranges::random_access_iterator<I>);
+	static_assert(ranges::contiguous_iterator<I>);
 	CHECK(I{} == I{});
 	auto first = I{some_ints, 4};
 	CHECK(first.base() == some_ints);
@@ -476,9 +476,9 @@ void test_counted() {
 	auto last = I{some_ints + 4, 0};
 	CHECK(last.base() == some_ints + 4);
 	CHECK(last.count() == 0);
-	static_assert(ranges::SizedSentinel<I, I>);
+	static_assert(ranges::sized_sentinel_for<I, I>);
 	CHECK((last - first) == 4);
-	static_assert(ranges::SizedSentinel<ranges::default_sentinel, I>);
+	static_assert(ranges::sized_sentinel_for<ranges::default_sentinel, I>);
 	CHECK((ranges::default_sentinel{} - first) == 4);
 	auto out = ranges::ostream_iterator<>{std::cout, " "};
 	ranges::copy(first, last, out);
@@ -512,13 +512,13 @@ void test_always() {
 	using I = decltype(i);
 	static_assert(std::is_empty<I>());
 	static_assert(sizeof(I) == 1);
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	static_assert(ranges::same_as<ranges::iter_value_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, int>);
 	static_assert(ranges::same_as<ranges::iter_rvalue_reference_t<I>, int>);
-	static_assert(ranges::RandomAccessIterator<I>);
+	static_assert(ranges::random_access_iterator<I>);
 	CHECK(I{} == I{});
 	ranges::copy_n(i, 13, ranges::ostream_iterator<>{std::cout, " "});
 	std::cout << '\n';
@@ -533,12 +533,12 @@ void test_back_inserter() {
 	auto vec = std::vector<int>{};
 	auto i = ranges::back_inserter(vec);
 	using I = decltype(i);
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
 	static_assert(ranges::same_as<ranges::iter_reference_t<I>, I&>);
-	static_assert(!ranges::Readable<I>);
-	static_assert(ranges::OutputIterator<I, int>);
-	static_assert(!ranges::InputIterator<I>);
+	static_assert(!ranges::readable<I>);
+	static_assert(ranges::output_iterator<I, int>);
+	static_assert(!ranges::input_iterator<I>);
 	static_assert(!ranges::equality_comparable<I>);
 	ranges::copy_n(always_iterator<int, 42>{}, 13, i);
 	CHECK(vec.size() == 13u);
@@ -558,9 +558,9 @@ void test_proxy_array() {
 	using Rng = decltype(a);
 
 	using I = ranges::iterator_t<Rng>;
-	static_assert(ranges::WeaklyIncrementable<I>);
+	static_assert(ranges::weakly_incrementable<I>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(ranges::Readable<I>);
+	static_assert(ranges::readable<I>);
 	using R = ranges::iter_reference_t<I>;
 	static_assert(ranges::same_as<proxy_wrapper<int>, R>);
 	using V = ranges::iter_value_t<I>;
@@ -572,13 +572,13 @@ void test_proxy_array() {
 	static_assert(ranges::__iter_move::has_customization<I&>);
 	using RR = ranges::iter_rvalue_reference_t<I>;
 	static_assert(ranges::same_as<int&&, RR>);
-	static_assert(ranges::RandomAccessIterator<I>);
-	static_assert(!ranges::ContiguousIterator<I>);
-	static_assert(ranges::RandomAccessRange<Rng>);
-	static_assert(ranges::CommonRange<Rng>);
+	static_assert(ranges::random_access_iterator<I>);
+	static_assert(!ranges::contiguous_iterator<I>);
+	static_assert(ranges::random_access_range<Rng>);
+	static_assert(ranges::common_range<Rng>);
 
 	using CI = ranges::iterator_t<const Rng>;
-	static_assert(ranges::WeaklyIncrementable<CI>);
+	static_assert(ranges::weakly_incrementable<CI>);
 	static_assert(ranges::same_as<ranges::iter_difference_t<CI>, std::ptrdiff_t>);
 	using CR = ranges::iter_reference_t<CI>;
 	static_assert(ranges::same_as<proxy_wrapper<const int>, CR>);
@@ -593,22 +593,22 @@ void test_proxy_array() {
 	static_assert(ranges::common_reference_with<CR, CV&>);
 	static_assert(ranges::common_reference_with<CR, CRR>);
 	static_assert(ranges::common_reference_with<CRR, const CV&>);
-	static_assert(ranges::Readable<CI>);
+	static_assert(ranges::readable<CI>);
 	static_assert(ranges::same_as<const int&&, decltype(iter_move(std::declval<const CI&>()))>);
 	static_assert(ranges::same_as<const int&&, decltype(iter_move(std::declval<CI&>()))>);
 
-	static_assert(ranges::RandomAccessIterator<CI>);
-	static_assert(!ranges::ContiguousIterator<CI>);
-	static_assert(ranges::RandomAccessRange<const Rng>);
-	static_assert(ranges::CommonRange<const Rng>);
+	static_assert(ranges::random_access_iterator<CI>);
+	static_assert(!ranges::contiguous_iterator<CI>);
+	static_assert(ranges::random_access_range<const Rng>);
+	static_assert(ranges::common_range<const Rng>);
 
 	static_assert(ranges::same_as<I, decltype(a.begin() + 2)>);
 	static_assert(ranges::common_reference_with<const R&, const R&>);
 	static_assert(!ranges::swappable_with<R, R>);
-	static_assert(ranges::IndirectlyMovableStorable<I, I>);
+	static_assert(ranges::indirectly_movable_storable<I, I>);
 
 	// swappable<R, R> is not satisfied, and
-	// IndirectlyMovableStorable<I, I> is satisfied,
+	// indirectly_movable_storable<I, I> is satisfied,
 	// so this should resolve to the second overload of iter_swap.
 	ranges::iter_swap(a.begin() + 1, a.begin() + 3);
 	CHECK(a[0] == 0);

--- a/test/iterator/common_iterator.cpp
+++ b/test/iterator/common_iterator.cpp
@@ -108,12 +108,12 @@ namespace {
 int main() {
 	{
 		static_assert(
-			ranges::ForwardIterator<
+			ranges::forward_iterator<
 				__stl2::common_iterator<
 					bidirectional_iterator<const char *>,
 					sentinel<const char *>>>);
 		static_assert(
-			!ranges::BidirectionalIterator<
+			!ranges::bidirectional_iterator<
 				__stl2::common_iterator<
 					bidirectional_iterator<const char *>,
 					sentinel<const char *>>>);
@@ -136,7 +136,7 @@ int main() {
 			>::value);
 		// Sized iterator range tests
 		static_assert(
-			!ranges::SizedSentinel<
+			!ranges::sized_sentinel_for<
 				__stl2::common_iterator<
 					forward_iterator<int*>,
 					sentinel<int*, true> >,
@@ -144,7 +144,7 @@ int main() {
 					forward_iterator<int*>,
 					sentinel<int*, true> > >);
 		static_assert(
-			ranges::SizedSentinel<
+			ranges::sized_sentinel_for<
 				__stl2::common_iterator<
 					random_access_iterator<int*>,
 					sentinel<int*, true> >,
@@ -152,7 +152,7 @@ int main() {
 					random_access_iterator<int*>,
 					sentinel<int*, true> > >);
 		static_assert(
-			!ranges::SizedSentinel<
+			!ranges::sized_sentinel_for<
 				__stl2::common_iterator<
 					random_access_iterator<int*>,
 					sentinel<int*, false> >,

--- a/test/iterator/counted_iterator.cpp
+++ b/test/iterator/counted_iterator.cpp
@@ -85,13 +85,16 @@ static_assert(test_constexpr());
 
 int main()
 {
-	using namespace ranges;
+	using ranges::counted_iterator, ranges::common_iterator;
+	using ranges::default_sentinel, ranges::sized_sentinel_for;
+	using ranges::distance;
+	using ranges::begin, ranges::size;
 
 	{
 		int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 		auto i = counted_iterator{forward_iterator<int*>{rgi}, size(rgi)};
 		static_assert(std::is_same<decltype(i),counted_iterator<forward_iterator<int*>>>());
-		static_assert(SizedSentinel<default_sentinel, decltype(i)>);
+		static_assert(sized_sentinel_for<default_sentinel, decltype(i)>);
 		CHECK(static_cast<std::size_t>(default_sentinel{} - i) == size(rgi));
 		CHECK(&*i.base() == begin(rgi));
 		CHECK(std::size_t(i.count()) == size(rgi));
@@ -106,7 +109,7 @@ int main()
 		std::list<int> l;
 		auto a = counted_iterator{l.begin(), 0};
 		auto b = counted_iterator{l.cbegin(), 0};
-		static_assert(std::is_same<common_type_t<decltype(a), decltype(b)>, decltype(b)>());
+		static_assert(std::is_same<ranges::common_type_t<decltype(a), decltype(b)>, decltype(b)>());
 		CHECK((a - a) == 0);
 		CHECK((b - b) == 0);
 		CHECK((a - b) == 0);
@@ -116,7 +119,7 @@ int main()
 	{
 		counted_iterator<char*> c{nullptr, 0};
 		counted_iterator<char const*> d{c};
-		static_assert(!assignable_from<decltype(c)&, decltype(d)>);
+		static_assert(!ranges::assignable_from<decltype(c)&, decltype(d)>);
 		CHECK((c - c) == 0);
 		CHECK((d - d) == 0);
 		CHECK((c - d) == 0);
@@ -126,11 +129,11 @@ int main()
 	{
 		int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 		counted_iterator<output_iterator<int*>> e{output_iterator<int*>{rgi}, 10};
-		fill(e, default_sentinel{}, 0);
+		ranges::fill(e, default_sentinel{}, 0);
 		int expected[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 		CHECK(std::equal(rgi, rgi + size(rgi), expected));
 		// Make sure advance compiles
-		advance(e, 4);
+		ranges::advance(e, 4);
 		CHECK(e.base().base() == rgi + 4);
 		CHECK(e.count() == 10 - 4);
 	}

--- a/test/iterator/incomplete.cpp
+++ b/test/iterator/incomplete.cpp
@@ -8,6 +8,6 @@ static_assert(ranges::same_as<std::ptrdiff_t,ranges::iter_difference_t<foo*>>);
 static_assert(ranges::same_as<foo*,ranges::common_type_t<foo*, foo*>>);
 struct foo {};
 
-static_assert(ranges::ContiguousIterator<foo*>);
+static_assert(ranges::contiguous_iterator<foo*>);
 
 int main() {}

--- a/test/iterator/istream_iterator.cpp
+++ b/test/iterator/istream_iterator.cpp
@@ -28,18 +28,18 @@ struct Int {
 int main() {
 	{
 		using I = istream_iterator<int>;
-		static_assert(WeaklyIncrementable<I>);
+		static_assert(weakly_incrementable<I>);
 		static_assert(same_as<iter_difference_t<I>, std::ptrdiff_t>);
-		static_assert(Readable<I>);
+		static_assert(readable<I>);
 		static_assert(same_as<iter_value_t<I>, int>);
 		static_assert(same_as<iter_reference_t<I>, const int&>);
 		static_assert(same_as<iter_rvalue_reference_t<I>, const int&&>);
-		static_assert(Iterator<I>);
-		static_assert(InputIterator<I>);
-		static_assert(!ForwardIterator<I>);
+		static_assert(input_or_output_iterator<I>);
+		static_assert(input_iterator<I>);
+		static_assert(!forward_iterator<I>);
 
-		static_assert(Sentinel<I, I>);
-		static_assert(Sentinel<default_sentinel, I>);
+		static_assert(sentinel_for<I, I>);
+		static_assert(sentinel_for<default_sentinel, I>);
 		static_assert(common_with<default_sentinel, I>);
 		static_assert(same_as<I, common_type_t<I, default_sentinel>>);
 

--- a/test/iterator/istreambuf_iterator.cpp
+++ b/test/iterator/istreambuf_iterator.cpp
@@ -25,27 +25,27 @@ namespace {
 		static_assert(same_as<typename traits::off_type, cursor::difference_type_t<C>>);
 		static_assert(cursor::Next<C>);
 		static_assert(same_as<charT, cursor::value_type_t<C>>);
-		static_assert(cursor::Readable<C>);
+		static_assert(cursor::readable<C>);
 		static_assert(same_as<charT, cursor::reference_t<C>>);
 		static_assert(cursor::Input<C>);
-		static_assert(cursor::Sentinel<C, C>);
-		static_assert(cursor::Sentinel<default_sentinel, C>);
+		static_assert(cursor::sentinel_for<C, C>);
+		static_assert(cursor::sentinel_for<default_sentinel, C>);
 		static_assert(!cursor::Forward<C>);
 		static_assert(cursor::PostIncrement<C>);
 
 		using I = istreambuf_iterator<charT, traits>;
-		static_assert(WeaklyIncrementable<I>);
+		static_assert(weakly_incrementable<I>);
 		static_assert(same_as<typename traits::off_type, iter_difference_t<I>>);
 		static_assert(same_as<charT, iter_value_t<I>>);
-		static_assert(Readable<I>);
+		static_assert(readable<I>);
 		static_assert(same_as<charT, iter_reference_t<I>>);
 		static_assert(same_as<charT, iter_rvalue_reference_t<I>>);
-		static_assert(Iterator<I>);
+		static_assert(input_or_output_iterator<I>);
 		static_assert(same_as<input_iterator_tag, iterator_category_t<I>>);
-		static_assert(InputIterator<I>);
-		static_assert(!ForwardIterator<I>);
-		static_assert(Sentinel<I, I>);
-		static_assert(Sentinel<default_sentinel, I>);
+		static_assert(input_iterator<I>);
+		static_assert(!forward_iterator<I>);
+		static_assert(sentinel_for<I, I>);
+		static_assert(sentinel_for<default_sentinel, I>);
 		static_assert(common_with<I, default_sentinel>);
 		static_assert(same_as<I, common_type_t<I, default_sentinel>>);
 

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -161,18 +161,18 @@ std::ostream& operator<<(std::ostream& sout, category c) {
 
 template<class>
 constexpr category iterator_dispatch() { return category::none; }
-template<ranges::OutputIterator<const int&> I>
-requires (!ranges::InputIterator<I>)
+template<ranges::output_iterator<const int&> I>
+requires (!ranges::input_iterator<I>)
 constexpr category iterator_dispatch() { return category::output; }
-template<ranges::InputIterator>
+template<ranges::input_iterator>
 constexpr category iterator_dispatch() { return category::input; }
-template<ranges::ForwardIterator>
+template<ranges::forward_iterator>
 constexpr category iterator_dispatch() { return category::forward; }
-template<ranges::BidirectionalIterator>
+template<ranges::bidirectional_iterator>
 constexpr category iterator_dispatch() { return category::bidirectional; }
-template<ranges::RandomAccessIterator>
+template<ranges::random_access_iterator>
 constexpr category iterator_dispatch() { return category::random_access; }
-template<ranges::ContiguousIterator>
+template<ranges::contiguous_iterator>
 constexpr category iterator_dispatch() { return category::contiguous; }
 
 template<class C, bool EC, class R = int&>
@@ -245,62 +245,62 @@ arbitrary_iterator<C, B, R> operator+(
 
 void test_iterator_dispatch() {
 	CHECK(iterator_dispatch<void>() == category::none);
-	static_assert(ranges::ContiguousIterator<int*>);
+	static_assert(ranges::contiguous_iterator<int*>);
 	CHECK(iterator_dispatch<int*>() == category::contiguous);
 
 	{
-		static_assert(ranges::Readable<int* const>);
+		static_assert(ranges::readable<int* const>);
 	}
 
 	{
 		using I = arbitrary_iterator<ranges::input_iterator_tag, false>;
-		static_assert(ranges::InputIterator<I>);
+		static_assert(ranges::input_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::input);
 	}
 	{
 		using I = arbitrary_iterator<ranges::input_iterator_tag, true>;
-		static_assert(ranges::InputIterator<I>);
+		static_assert(ranges::input_iterator<I>);
 		static_assert(ranges::equality_comparable<I>);
 		CHECK(iterator_dispatch<I>() == category::input);
 	}
 	{
 		using I = arbitrary_iterator<ranges::forward_iterator_tag, true>;
-		static_assert(ranges::ForwardIterator<I>);
+		static_assert(ranges::forward_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::forward);
 	}
 	{
 		using I = arbitrary_iterator<ranges::bidirectional_iterator_tag, true>;
-		static_assert(ranges::BidirectionalIterator<I>);
+		static_assert(ranges::bidirectional_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::bidirectional);
 	}
 	{
 		using I = arbitrary_iterator<ranges::random_access_iterator_tag, true>;
-		static_assert(ranges::RandomAccessIterator<I>);
+		static_assert(ranges::random_access_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::random_access);
 	}
 	{
 		using I = arbitrary_iterator<ranges::contiguous_iterator_tag, true>;
-		static_assert(ranges::ContiguousIterator<I>);
+		static_assert(ranges::contiguous_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::contiguous);
 	}
 
 	{
 		using I = arbitrary_iterator<void, false>;
-		static_assert(ranges::OutputIterator<I, const int&>);
-		static_assert(!ranges::InputIterator<I>);
+		static_assert(ranges::output_iterator<I, const int&>);
+		static_assert(!ranges::input_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::output);
 	}
 	{
 		using I = arbitrary_iterator<void, true>;
-		static_assert(ranges::OutputIterator<I, const int&>);
+		static_assert(ranges::output_iterator<I, const int&>);
 		static_assert(ranges::equality_comparable<I>);
-		static_assert(!ranges::InputIterator<I>);
+		static_assert(!ranges::input_iterator<I>);
 		CHECK(iterator_dispatch<I>() == category::output);
 	}
 }
 
-template<ranges::InputIterator I, ranges::Sentinel<I> S, class O>
-requires ranges::IndirectlyCopyable<I, O>
+template<ranges::input_iterator I, ranges::sentinel_for<I> S, class O>
+requires ranges::indirectly_copyable<I, O>
 bool copy(I first, S last, O o) {
 	for (; first != last; ++first, ++o) {
 		*o = *first;
@@ -308,10 +308,10 @@ bool copy(I first, S last, O o) {
 	return false;
 }
 
-template<ranges::ContiguousIterator I, ranges::SizedSentinel<I> S,
-	ranges::ContiguousIterator O>
+template<ranges::contiguous_iterator I, ranges::sized_sentinel_for<I> S,
+	ranges::contiguous_iterator O>
 requires
-	ranges::IndirectlyCopyable<I, O> &&
+	ranges::indirectly_copyable<I, O> &&
 	ranges::same_as<ranges::iter_value_t<I>, ranges::iter_value_t<O>> &&
 	std::is_trivially_copyable<ranges::iter_value_t<I>>::value
 bool copy(I first, S last, O o) {
@@ -371,7 +371,7 @@ void test_iter_swap2() {
 		auto b = std::make_unique<int>(13);
 		using I = decltype(a);
 		static_assert(ranges::same_as<I, decltype(b)>);
-		static_assert(ranges::Readable<I>);
+		static_assert(ranges::readable<I>);
 		using R = ranges::iter_reference_t<I>;
 		static_assert(ranges::same_as<int&, R>);
 		using RR = ranges::iter_rvalue_reference_t<I>;
@@ -391,7 +391,7 @@ void test_iter_swap2() {
 	{
 		auto a = array<int, 4>{0,1,2,3};
 		using I = decltype(a.begin());
-		static_assert(ranges::Readable<I>);
+		static_assert(ranges::readable<I>);
 		using V = ranges::iter_value_t<I>;
 		static_assert(ranges::same_as<int, V>);
 		using R = ranges::iter_reference_t<I>;
@@ -402,10 +402,10 @@ void test_iter_swap2() {
 		static_assert(ranges::same_as<I, decltype(a.begin() + 2)>);
 		static_assert(ranges::common_reference_with<const R&, const R&>);
 		static_assert(!ranges::swappable_with<R, R>);
-		static_assert(ranges::IndirectlyMovableStorable<I, I>);
+		static_assert(ranges::indirectly_movable_storable<I, I>);
 
 		// swappable<R, R> is not satisfied, and
-		// IndirectlyMovableStorable<I, I> is satisfied,
+		// indirectly_movable_storable<I, I> is satisfied,
 		// so this should resolve to the second overload of iter_swap.
 		ranges::iter_swap(a.begin() + 1, a.begin() + 3);
 		CHECK(a[0] == 0);
@@ -475,12 +475,12 @@ struct MakeString {
 	std::string operator*() const;
 };
 
-static_assert(ranges::Readable<MakeString>);
-static_assert(!ranges::Writable<MakeString, std::string>);
-static_assert(!ranges::Writable<MakeString, const std::string &>);
-static_assert(!ranges::IndirectlyMovable<MakeString, MakeString>);
-static_assert(!ranges::IndirectlyCopyable<MakeString, MakeString>);
-static_assert(!ranges::IndirectlySwappable<MakeString, MakeString>);
+static_assert(ranges::readable<MakeString>);
+static_assert(!ranges::writable<MakeString, std::string>);
+static_assert(!ranges::writable<MakeString, const std::string &>);
+static_assert(!ranges::indirectly_movable<MakeString, MakeString>);
+static_assert(!ranges::indirectly_copyable<MakeString, MakeString>);
+static_assert(!ranges::indirectly_swappable<MakeString, MakeString>);
 
 int main() {
 	test_iter_swap2();

--- a/test/iterator/make_range.cpp
+++ b/test/iterator/make_range.cpp
@@ -7,14 +7,14 @@ int main() {
 	{
 		using I = subrange<int*, int*>;
 		using CI = subrange<const int*, const int*>;
-		static_assert(View<I>);
-		static_assert(SizedRange<I>);
-		static_assert(ContiguousRange<I>);
-		static_assert(CommonRange<I>);
-		static_assert(View<CI>);
-		static_assert(SizedRange<CI>);
-		static_assert(ContiguousRange<CI>);
-		static_assert(CommonRange<CI>);
+		static_assert(view<I>);
+		static_assert(sized_range<I>);
+		static_assert(contiguous_range<I>);
+		static_assert(common_range<I>);
+		static_assert(view<CI>);
+		static_assert(sized_range<CI>);
+		static_assert(contiguous_range<CI>);
+		static_assert(common_range<CI>);
 	}
 
 	{
@@ -22,10 +22,10 @@ int main() {
 		static constexpr std::size_t n = size(some_ints);
 		auto r = subrange(some_ints + 0, some_ints + n);
 		using R = decltype(r);
-		static_assert(View<R>);
-		static_assert(SizedRange<R>);
-		static_assert(ContiguousRange<R>);
-		static_assert(CommonRange<R>);
+		static_assert(view<R>);
+		static_assert(sized_range<R>);
+		static_assert(contiguous_range<R>);
+		static_assert(common_range<R>);
 
 		CHECK(begin(r) == some_ints + 0);
 		CHECK(end(r) == some_ints + n);

--- a/test/iterator/move_iterator.cpp
+++ b/test/iterator/move_iterator.cpp
@@ -65,9 +65,9 @@ void test_move_iterator() {
 	{
 		auto first = ranges::make_move_iterator(ranges::begin(vec)),
 			last = ranges::make_move_iterator(ranges::end(vec));
-		static_assert(ranges::RandomAccessIterator<decltype(ranges::begin(vec))>);
-		static_assert(ranges::InputIterator<decltype(first)>);
-		static_assert(!ranges::ForwardIterator<decltype(first)>);
+		static_assert(ranges::random_access_iterator<decltype(ranges::begin(vec))>);
+		static_assert(ranges::input_iterator<decltype(first)>);
+		static_assert(!ranges::forward_iterator<decltype(first)>);
 		auto out = ranges::back_inserter(vec2);
 
 		for (; first != last; ++first, ++out) {
@@ -218,8 +218,8 @@ void test_proxy_iterator() {
 		CHECK(ranges::size(vec2) == N);
 		CHECK(A::copy_count == std::size_t{0});
 		CHECK(A::move_count == N);
-		CHECK(ranges::equal(vec2, ranges::view::iota(0) | ranges::view::take(N), std::equal_to{}));
-		CHECK(ranges::equal(vec, ranges::view::ext::repeat_n(-1, N), std::equal_to{}));
+		CHECK(ranges::equal(vec2, ranges::views::iota(0) | ranges::views::take(N), std::equal_to{}));
+		CHECK(ranges::equal(vec, ranges::views::ext::repeat_n(-1, N), std::equal_to{}));
 
 		first = ranges::make_move_iterator(proxy_iterator<A>{ranges::data(vec)});
 		std::iota(vec.begin(), vec.end(), 0);
@@ -231,8 +231,8 @@ void test_proxy_iterator() {
 		CHECK(ranges::size(vec2) == N);
 		CHECK(A::copy_count == std::size_t{0});
 		CHECK(A::move_count == 2*N);
-		CHECK(ranges::equal(vec2, ranges::view::iota(0) | ranges::view::take(N), std::equal_to{}));
-		CHECK(ranges::equal(vec, ranges::view::ext::repeat_n(-1, N), std::equal_to{}));
+		CHECK(ranges::equal(vec2, ranges::views::iota(0) | ranges::views::take(N), std::equal_to{}));
+		CHECK(ranges::equal(vec, ranges::views::ext::repeat_n(-1, N), std::equal_to{}));
 	}
 
 	{
@@ -265,11 +265,11 @@ void test_proxy_iterator() {
 	{
 		auto first = ranges::counted_iterator(vec.begin(), vec.size());
 		auto last = ranges::default_sentinel{};
-		static_assert(ranges::SizedSentinel<decltype(last), decltype(first)>);
+		static_assert(ranges::sized_sentinel_for<decltype(last), decltype(first)>);
 		CHECK((static_cast<std::size_t>(last - first) == vec.size()));
 		auto mfirst = ranges::make_move_iterator(first);
 		auto mlast = ranges::make_move_sentinel(last);
-		static_assert(ranges::SizedSentinel<decltype(mlast), decltype(mfirst)>);
+		static_assert(ranges::sized_sentinel_for<decltype(mlast), decltype(mfirst)>);
 		CHECK((static_cast<std::size_t>(mlast - mfirst) == vec.size()));
 	}
 }

--- a/test/iterator/operations.cpp
+++ b/test/iterator/operations.cpp
@@ -65,7 +65,7 @@ namespace {
 
         {
             auto rng = ranges::ext::take_exactly_view<ranges::iota_view<int>>{{}, 42};
-            static_assert(ranges::RandomAccessRange<decltype(rng)>);
+            static_assert(ranges::random_access_range<decltype(rng)>);
             auto pos = ranges::begin(rng);
             // advance(i, n)
             ranges::advance(pos, 1);
@@ -169,7 +169,7 @@ namespace {
 
         {
             auto rng = ranges::ext::take_exactly_view<ranges::iota_view<int>>{{}, 42};
-            static_assert(ranges::RandomAccessRange<decltype(rng)>);
+            static_assert(ranges::random_access_range<decltype(rng)>);
             // next(i, n)
             auto pos = ranges::next(ranges::begin(rng), 1);
             if (*pos != 1) return false;
@@ -259,7 +259,7 @@ namespace {
 
         {
             auto rng = ranges::ext::take_exactly_view<ranges::iota_view<int>>{{}, 42};
-            static_assert(ranges::RandomAccessRange<decltype(rng)>);
+            static_assert(ranges::random_access_range<decltype(rng)>);
             // prev(i, n)
             auto pos = ranges::prev(ranges::next(ranges::begin(rng), ranges::end(rng)), 1);
             if (pos != ranges::begin(rng) + 41) return false;

--- a/test/iterator/ostream_iterator.cpp
+++ b/test/iterator/ostream_iterator.cpp
@@ -24,7 +24,7 @@ namespace {
 		O out;
 	};
 
-	template<InputIterator I, Sentinel<I> S, OutputIterator<iter_reference_t<I>> O>
+	template<input_iterator I, sentinel_for<I> S, output_iterator<iter_reference_t<I>> O>
 	constexpr result<I, O> copy(I first, S last, O out) {
 		for (; first != last; ++first, void(), ++out) {
 			*out = *first;
@@ -38,12 +38,12 @@ int main() {
 	static constexpr int some_ints[] = {0, 7, 1, 6, 2, 5, 3, 4};
 
 	using I = ostream_iterator<int>;
-	static_assert(WeaklyIncrementable<I>);
+	static_assert(weakly_incrementable<I>);
 	static_assert(same_as<iter_difference_t<I>, std::ptrdiff_t>);
-	static_assert(Iterator<I>);
+	static_assert(input_or_output_iterator<I>);
 	static_assert(same_as<iter_reference_t<I>, I&>);
-	static_assert(OutputIterator<I, const int&>);
-	static_assert(!InputIterator<I>);
+	static_assert(output_iterator<I, const int&>);
+	static_assert(!input_iterator<I>);
 
 	I i{ss, " "};
 	static_assert(same_as<I::difference_type, std::ptrdiff_t>);

--- a/test/iterator/ostreambuf_iterator.cpp
+++ b/test/iterator/ostreambuf_iterator.cpp
@@ -24,7 +24,7 @@ namespace {
 		O out;
 	};
 
-	template<InputIterator I, Sentinel<I> S, OutputIterator<iter_reference_t<I>> O>
+	template<input_iterator I, sentinel_for<I> S, output_iterator<iter_reference_t<I>> O>
 	constexpr result<I, O> copy(I first, S last, O out) {
 		for (; first != last; ++first, void(), ++out) {
 			*out = *first;
@@ -32,7 +32,7 @@ namespace {
 		return {first, out};
 	}
 
-	template<InputRange R, OutputIterator<iter_reference_t<iterator_t<R>>> O>
+	template<input_range R, output_iterator<iter_reference_t<iterator_t<R>>> O>
 	constexpr result<safe_iterator_t<R>, O>
 	copy(R&& range, O out) {
 		return ::copy(begin(range), end(range), std::move(out));
@@ -41,8 +41,8 @@ namespace {
 
 int main() {
 	using I = ostreambuf_iterator<char>;
-	static_assert(OutputIterator<I, const char&>);
-	static_assert(Sentinel<default_sentinel, I>);
+	static_assert(output_iterator<I, const char&>);
+	static_assert(sentinel_for<default_sentinel, I>);
 	static_assert(common_with<I, default_sentinel>);
 	static_assert(std::is_same<I, common_type_t<I, default_sentinel>>());
 

--- a/test/iterator/reverse_iterator.cpp
+++ b/test/iterator/reverse_iterator.cpp
@@ -283,10 +283,10 @@ static_assert(test_constexpr());
 int main() {
 	{
 		static_assert(
-				ranges::BidirectionalIterator<
+				ranges::bidirectional_iterator<
 					ranges::reverse_iterator<bidirectional_iterator<const char *>>>);
 		static_assert(
-				ranges::RandomAccessIterator<
+				ranges::random_access_iterator<
 					ranges::reverse_iterator<random_access_iterator<const char *>>>);
 	}
 	{ // test

--- a/test/memory/uninitialized_move.cpp
+++ b/test/memory/uninitialized_move.cpp
@@ -31,7 +31,7 @@ namespace ranges = __stl2;
 using ranges::ext::span;
 
 namespace {
-	template<ranges::InputRange Rng>
+	template<ranges::input_range Rng>
 	requires requires {
 		typename ranges::iter_value_t<Rng>;
 		&ranges::iter_value_t<Rng>::empty;
@@ -44,7 +44,7 @@ namespace {
 			&ranges::iter_value_t<Rng>::empty);
 	}
 
-	template<ranges::InputRange Rng>
+	template<ranges::input_range Rng>
 	requires requires {
 		typename ranges::iter_value_t<Rng>;
 		requires std::is_fundamental_v<ranges::iter_value_t<Rng>>;

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -130,7 +130,7 @@ namespace begin_testing {
 		static_assert(!CanBegin<const A>);
 		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const A&>())), const int*>);
 
-		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
+		// Valid: Both member and non-member begin, but non-member returns non-input_or_output_iterator.
 		static_assert(CanBegin<B&>);
 		static_assert(!CanBegin<B>);
 		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<B&>())), int*>);
@@ -138,7 +138,7 @@ namespace begin_testing {
 		static_assert(!CanBegin<const B>);
 		static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const B&>())), const int*>);
 
-		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
+		// Valid: Both member and non-member begin, but non-member returns non-input_or_output_iterator.
 		static_assert(CanBegin<C&>);
 		static_assert(!CanBegin<C>);
 		static_assert(CanBegin<const C&>);
@@ -235,8 +235,8 @@ namespace X {
 
 using I = int*;
 using CI = const int*;
-static_assert(ranges::Iterator<I>);
-static_assert(ranges::Iterator<CI>);
+static_assert(ranges::input_or_output_iterator<I>);
+static_assert(ranges::input_or_output_iterator<CI>);
 
 void test_string_view_p0970() {
 	// basic_string_views are non-dangling

--- a/test/view/common_view.cpp
+++ b/test/view/common_view.cpp
@@ -15,28 +15,31 @@
 #include "../test_iterators.hpp"
 
 namespace ranges = __stl2;
+namespace views = ranges::views;
 
 int main() {
-	using namespace ranges;
+	using ranges::same_as;
+	using ranges::view, ranges::sized_range, ranges::common_range;
+	using ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range;
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
-		auto x = rg | view::common;
+		auto x = rg | views::common;
 		CHECK_EQUAL(x, {0,1,2,3,4,5,6,7,8,9});
-		static_assert(View<decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(CommonRange<decltype(x)>);
-		static_assert(RandomAccessRange<decltype(x)>);
+		static_assert(view<decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(common_range<decltype(x)>);
+		static_assert(random_access_range<decltype(x)>);
 	}
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
-		auto x = view::counted(bidirectional_iterator(rg), 5) | view::common;
+		auto x = views::counted(bidirectional_iterator(rg), 5) | views::common;
 		CHECK_EQUAL(x, {0,1,2,3,4});
-		static_assert(View<decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(CommonRange<decltype(x)>);
-		static_assert(ForwardRange<decltype(x)>);
-		static_assert(!BidirectionalRange<decltype(x)>);
-		static_assert(same_as<decltype(x), decltype(view::common(x))>);
+		static_assert(view<decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(common_range<decltype(x)>);
+		static_assert(forward_range<decltype(x)>);
+		static_assert(!bidirectional_range<decltype(x)>);
+		static_assert(same_as<decltype(x), decltype(views::common(x))>);
 	}
 	return test_result();
 }

--- a/test/view/counted_view.cpp
+++ b/test/view/counted_view.cpp
@@ -14,27 +14,29 @@
 #include "../test_iterators.hpp"
 
 namespace ranges = __stl2;
+namespace views = ranges::views;
 
 int main() {
-	using namespace ranges;
+	using ranges::view, ranges::sized_range, ranges::common_range;
+	using ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range;
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9};
-		auto x = view::counted(rg, 10);
+		auto x = views::counted(rg, 10);
 		CHECK_EQUAL(x, {0,1,2,3,4,5,6,7,8,9});
-		static_assert(View<decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(CommonRange<decltype(x)>);
-		static_assert(RandomAccessRange<decltype(x)>);
+		static_assert(view<decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(common_range<decltype(x)>);
+		static_assert(random_access_range<decltype(x)>);
 	}
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9};
-		auto x = view::counted(forward_iterator(rg), 10);
+		auto x = views::counted(forward_iterator(rg), 10);
 		CHECK_EQUAL(x, {0,1,2,3,4,5,6,7,8,9});
-		static_assert(View<decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(!CommonRange<decltype(x)>);
-		static_assert(ForwardRange<decltype(x)>);
-		static_assert(!BidirectionalRange<decltype(x)>);
+		static_assert(view<decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(!common_range<decltype(x)>);
+		static_assert(forward_range<decltype(x)>);
+		static_assert(!bidirectional_range<decltype(x)>);
 	}
 	return test_result();
 }

--- a/test/view/drop_view.cpp
+++ b/test/view/drop_view.cpp
@@ -23,9 +23,9 @@
 
 namespace ranges = __stl2;
 
-namespace view {
-	using namespace ranges::view;
-	using ranges::view::ext::drop;
+namespace views {
+	using namespace ranges::views;
+	using ranges::views::ext::drop;
 }
 
 int main()
@@ -33,53 +33,53 @@ int main()
 	{
 		int rgi[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-		auto rng0 = rgi | view::drop(6);
-		static_assert(ranges::View<decltype(rng0)>);
-		static_assert(ranges::SizedRange<decltype(rng0)>);
-		static_assert(ranges::RandomAccessIterator<decltype(ranges::begin(rng0))>);
+		auto rng0 = rgi | views::drop(6);
+		static_assert(ranges::view<decltype(rng0)>);
+		static_assert(ranges::sized_range<decltype(rng0)>);
+		static_assert(ranges::random_access_iterator<decltype(ranges::begin(rng0))>);
 		CHECK_EQUAL(rng0, {6, 7, 8, 9, 10});
 		CHECK(ranges::size(rng0) == 5u);
 
-		auto rng1 = rng0 | view::reverse;
-		static_assert(ranges::View<decltype(rng1)>);
-		static_assert(ranges::SizedRange<decltype(rng1)>);
-		static_assert(ranges::RandomAccessIterator<decltype(ranges::begin(rng1))>);
+		auto rng1 = rng0 | views::reverse;
+		static_assert(ranges::view<decltype(rng1)>);
+		static_assert(ranges::sized_range<decltype(rng1)>);
+		static_assert(ranges::random_access_iterator<decltype(ranges::begin(rng1))>);
 		CHECK_EQUAL(rng1, {10, 9, 8, 7, 6});
 	}
 
 	{
 		std::vector<int> v{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-		auto rng = v | view::drop(6) | view::reverse;
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(ranges::SizedRange<decltype(rng)>);
-		static_assert(ranges::RandomAccessIterator<decltype(ranges::begin(rng))>);
+		auto rng = v | views::drop(6) | views::reverse;
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(ranges::sized_range<decltype(rng)>);
+		static_assert(ranges::random_access_iterator<decltype(ranges::begin(rng))>);
 		CHECK_EQUAL(rng, {10, 9, 8, 7, 6});
 	}
 
 	{
 		std::list<int> l{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-		auto rng = l | view::drop(6);
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(ranges::SizedRange<decltype(rng)>);
-		static_assert(ranges::BidirectionalIterator<decltype(ranges::begin(rng))>);
+		auto rng = l | views::drop(6);
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(ranges::sized_range<decltype(rng)>);
+		static_assert(ranges::bidirectional_iterator<decltype(ranges::begin(rng))>);
 		CHECK_EQUAL(rng, {6, 7, 8, 9, 10});
 	}
 
 	{
-		auto rng = view::iota(10) | view::drop(10);
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(!ranges::SizedRange<decltype(rng)>);
+		auto rng = views::iota(10) | views::drop(10);
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(!ranges::sized_range<decltype(rng)>);
 		// static_assert(ranges::is_infinite<decltype(rng4)>::value, "");
 		auto b = ranges::begin(rng);
 		CHECK(*b == 20);
 		CHECK(*(b+1) == 21);
 	}
 
-#if 0 // Test DISABLED while view::take(n) | view::reverse isn't possible.
+#if 0 // Test DISABLED while views::take(n) | views::reverse isn't possible.
 	{
-		auto rng = view::iota(10) | view::drop(10) | view::take(10) | view::reverse;
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(ranges::SizedRange<decltype(rng)>);
+		auto rng = views::iota(10) | views::drop(10) | views::take(10) | views::reverse;
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(ranges::sized_range<decltype(rng)>);
 		static_assert(!ranges::is_infinite<decltype(rng5)>::value, "");
 		CHECK_EQUAL(rng, {29, 28, 27, 26, 25, 24, 23, 22, 21, 20});
 		CHECK(ranges::size(rng) == 10u);
@@ -87,9 +87,9 @@ int main()
 #endif
 	{
 		// consolation for the above not being possible
-		auto rng = view::iota(10) | view::drop(10) | view::take(10);
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(!ranges::SizedRange<decltype(rng)>);
+		auto rng = views::iota(10) | views::drop(10) | views::take(10);
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(!ranges::sized_range<decltype(rng)>);
 		// static_assert(!ranges::is_infinite<decltype(rng5)>::value, "");
 		CHECK_EQUAL(rng, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29});
 	}
@@ -97,7 +97,7 @@ int main()
 	{
 		int some_ints[] = {0,1,2};
 		auto rng = ranges::subrange(some_ints + 0, some_ints + 1);
-		auto rng2 = view::drop(rng, 2);
+		auto rng2 = views::drop(rng, 2);
 		CHECK(ranges::begin(rng2) == some_ints + 1);
 		CHECK(ranges::size(rng2) == 0u);
 	}
@@ -106,11 +106,11 @@ int main()
 	{
 		// Regression test for https://github.com/ericniebler/range-v3/issues/413
 		auto skips = [](std::vector<int> xs) -> std::vector<std::vector<int>> {
-			return view::iota(0, (int)xs.size())
-				  | view::transform([&](int n) {
-						 return xs | view::chunk(n + 1)
-									  | view::transform(view::drop(n))
-									  | view::join;
+			return views::iota(0, (int)xs.size())
+				  | views::transform([&](int n) {
+						 return xs | views::chunk(n + 1)
+									  | views::transform(views::drop(n))
+									  | views::join;
 					 });
 		};
 		auto skipped = skips({1,2,3,4,5,6,7,8});
@@ -130,20 +130,20 @@ int main()
 
 	{
 		static int const some_ints[] = {0,1,2,3};
-		auto rng = debug_input_view<int const>{some_ints} | view::drop(2);
+		auto rng = debug_input_view<int const>{some_ints} | views::drop(2);
 		using R = decltype(rng);
 		CONCEPT_ASSERT(InputView<R>());
-		CONCEPT_ASSERT(!ForwardRange<R>());
+		CONCEPT_ASSERT(!forward_range<R>());
 		CONCEPT_ASSERT(same_as<int const&, ranges::iter_reference_t<R>>());
 		CHECK_EQUAL(rng, {2,3});
 	}
 
 	{
 		// regression test for ericniebler/range-v3#728
-		auto rng1 = view::iota(1) | view::chunk(6) | view::take(3);
+		auto rng1 = views::iota(1) | views::chunk(6) | views::take(3);
 		int i = 2;
 		for (auto o1 : rng1) {
-			auto rng2 = o1 | view::drop(1);
+			auto rng2 = o1 | views::drop(1);
 			CHECK_EQUAL(rng2, {i, i+1, i+2, i+3, i+4});
 			i += 6;
 		}
@@ -153,7 +153,7 @@ int main()
 	{
 		// regression test for ericniebler/range-v3#813
 		static int const some_ints[] = {0,1,2,3};
-		auto rng = some_ints | view::drop(10);
+		auto rng = some_ints | views::drop(10);
 		CHECK(ranges::empty(rng));
 	}
 

--- a/test/view/drop_while_view.cpp
+++ b/test/view/drop_while_view.cpp
@@ -18,50 +18,50 @@
 
 namespace ranges = __stl2;
 
-namespace view {
-	using namespace ranges::view;
-	using view::ext::drop_while;
+namespace views {
+	using namespace ranges::views;
+	using views::ext::drop_while;
 }
 
 int main()
 {
 	{
-		auto rng0 = view::iota(10) | view::drop_while([](int i) { return i < 25; });
+		auto rng0 = views::iota(10) | views::drop_while([](int i) { return i < 25; });
 		//  static_assert(range_cardinality<decltype(rng0)>::value == unknown);
-		static_assert(ranges::RandomAccessRange<decltype(rng0)>);
-		static_assert(!ranges::CommonRange<decltype(rng0)>);
+		static_assert(ranges::random_access_range<decltype(rng0)>);
+		static_assert(!ranges::common_range<decltype(rng0)>);
 		auto b = rng0.begin();
 		CHECK(*b == 25);
 		CHECK(*(b+1) == 26);
-		CHECK_EQUAL(rng0 | view::take(10), {25, 26, 27, 28, 29, 30, 31, 32, 33, 34});
+		CHECK_EQUAL(rng0 | views::take(10), {25, 26, 27, 28, 29, 30, 31, 32, 33, 34});
 	}
 
 	std::list<int> vi{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	auto rng1 = vi | view::drop_while([](int i) { return i != 50; });
+	auto rng1 = vi | views::drop_while([](int i) { return i != 50; });
 	//  static_assert(range_cardinality<decltype(rng1)>::value == ranges::finite);
-	static_assert(ranges::BidirectionalRange<decltype(rng1)>);
-	static_assert(ranges::CommonRange<decltype(rng1)>);
+	static_assert(ranges::bidirectional_range<decltype(rng1)>);
+	static_assert(ranges::common_range<decltype(rng1)>);
 	CHECK(rng1.begin() == rng1.end());
 
 
 	// Check with a mutable predicate
 	{
-		auto rng0 = view::iota(10) | view::drop_while([b = true](int i) mutable { b = !b; return i < 25; });
+		auto rng0 = views::iota(10) | views::drop_while([b = true](int i) mutable { b = !b; return i < 25; });
 		//  static_assert(range_cardinality<decltype(rng0)>::value == unknown);
-		static_assert(ranges::RandomAccessRange<decltype(rng0)>);
-		static_assert(!ranges::CommonRange<decltype(rng0)>);
+		static_assert(ranges::random_access_range<decltype(rng0)>);
+		static_assert(!ranges::common_range<decltype(rng0)>);
 		auto b = rng0.begin();
 		CHECK(*b == 25);
 		CHECK(*(b+1) == 26);
-		CHECK_EQUAL(rng0 | view::take(10), {25, 26, 27, 28, 29, 30, 31, 32, 33, 34});
+		CHECK_EQUAL(rng0 | views::take(10), {25, 26, 27, 28, 29, 30, 31, 32, 33, 34});
 	}
 
 	//  {
 	//      // Check with move-only subview
-	//      auto rng = debug_input_view<const int>{rgi} | view::drop_while([](int i){ return i < 4; });
+	//      auto rng = debug_input_view<const int>{rgi} | views::drop_while([](int i){ return i < 4; });
 	//      using R = decltype(rng);
 	//      static_assert(InputView<R>());
-	//      static_assert(!ForwardRange<R>());
+	//      static_assert(!forward_range<R>());
 	//      static_assert(!BoundedRange<R>());
 	//      static_assert(same_as<int const&, range_reference_t<R>>());
 	//      CHECK_EQUAL(rng, {4,5,6,7,8,9});

--- a/test/view/empty_view.cpp
+++ b/test/view/empty_view.cpp
@@ -18,7 +18,7 @@ int main() {
 	using namespace ranges;
 
 	{
-		auto rng = view::empty<double>;
+		auto rng = views::empty<double>;
 
 		CHECK(ranges::begin(rng) == nullptr);
 		CHECK(rng.begin() == nullptr);
@@ -31,10 +31,10 @@ int main() {
 	}
 
 	{
-		CHECK(ranges::begin(view::empty<int>) == nullptr);
-		CHECK(ranges::end(view::empty<int>) == nullptr);
-		CHECK(ranges::data(view::empty<int>) == nullptr);
-		CHECK(ranges::size(view::empty<int>) == 0);
+		CHECK(ranges::begin(views::empty<int>) == nullptr);
+		CHECK(ranges::end(views::empty<int>) == nullptr);
+		CHECK(ranges::data(views::empty<int>) == nullptr);
+		CHECK(ranges::size(views::empty<int>) == 0);
 	}
 
 	return test_result();

--- a/test/view/filter_view.cpp
+++ b/test/view/filter_view.cpp
@@ -45,24 +45,24 @@ int main() {
 	using namespace ranges;
 
 	int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-	static_assert(size(view::all(rgi))==10);
+	static_assert(size(views::all(rgi))==10);
 
-	auto rng = rgi | view::filter(is_odd());
+	auto rng = rgi | views::filter(is_odd());
 	static_assert(same_as<int &, decltype(*begin(rgi))>);
 	static_assert(same_as<int &, decltype(*begin(rng))>);
-	static_assert(View<decltype(rng)>);
-	static_assert(InputRange<decltype(rng)>);
-	static_assert(CommonRange<decltype(rng)>);
-	static_assert(!SizedRange<decltype(rng)>);
-	static_assert(BidirectionalRange<decltype(rng)>);
-	static_assert(!RandomAccessRange<decltype(rng)>);
+	static_assert(view<decltype(rng)>);
+	static_assert(input_range<decltype(rng)>);
+	static_assert(common_range<decltype(rng)>);
+	static_assert(!sized_range<decltype(rng)>);
+	static_assert(bidirectional_range<decltype(rng)>);
+	static_assert(!random_access_range<decltype(rng)>);
 	CHECK_EQUAL(rng, {1,3,5,7,9});
 
-	CHECK_EQUAL(rng | view::reverse, {9,7,5,3,1});
-	auto tmp = rng | view::reverse;
+	CHECK_EQUAL(rng | views::reverse, {9,7,5,3,1});
+	auto tmp = rng | views::reverse;
 	CHECK(&*begin(tmp) == &rgi[8]);
 
-	// auto rng2 = view::counted(rgi, 10) | view::remove_if(not_fn(is_odd()));
+	// auto rng2 = views::counted(rgi, 10) | views::remove_if(not_fn(is_odd()));
 	// static_assert(same_as<int &, decltype(*begin(rng2))>);
 	// static_assert(BidirectionalView<__f<decltype(rng2)>>);
 	// static_assert(!RandomAccessView<__f<decltype(rng2)>>);
@@ -71,7 +71,7 @@ int main() {
 	// CHECK_EQUAL(rng2, {1,3,5,7,9});
 	// CHECK(&*begin(rng2) == &rgi[0]);
 
-	// auto rng3 = view::counted(bidirectional_iterator<int*>{rgi}, 10) | view::remove_if(is_even());
+	// auto rng3 = views::counted(bidirectional_iterator<int*>{rgi}, 10) | views::remove_if(is_even());
 	// static_assert(same_as<int &, decltype(*begin(rng3))>);
 	// static_assert(BidirectionalView<__f<decltype(rng3)>>);
 	// static_assert(!RandomAccessView<__f<decltype(rng3)>>);
@@ -87,31 +87,31 @@ int main() {
 	detail::semiregular_box<decltype(f)> b{f};
 	auto b2 = b;
 	b = b2;
-	auto mutable_rng = view::filter(rgi, [flag](int) mutable { return flag = !flag;});
+	auto mutable_rng = views::filter(rgi, [flag](int) mutable { return flag = !flag;});
 	CHECK_EQUAL(mutable_rng, {1,3,5,7,9});
-	static_assert(Range<decltype(mutable_rng)>);
+	static_assert(range<decltype(mutable_rng)>);
 	static_assert(copyable<decltype(mutable_rng)>);
-	static_assert(!View<decltype(mutable_rng) const>);
+	static_assert(!view<decltype(mutable_rng) const>);
 
 	// {
 	//	 const std::array<int, 3> a{{0, 1, 2}};
 	//	 const std::vector<int> b{3, 4, 5, 6};
 
-	//	 auto r = view::concat(a, b);
+	//	 auto r = views::concat(a, b);
 	//	 auto f = [](int i) { return i != 1 && i != 5; };
-	//	 auto r2 = r | view::remove_if(f);
+	//	 auto r2 = r | views::remove_if(f);
 	//	 CHECK_EQUAL(r2, {1,5});
 	// }
 
 	// {
-	//	 auto rng = debug_input_view<int const>{rgi} | view::remove_if(is_even{});
+	//	 auto rng = debug_input_view<int const>{rgi} | views::remove_if(is_even{});
 	//	 CHECK_EQUAL(rng, {1,3,5,7,9});
 	// }
 
 	{
 		// Test operator-> with pointer
 		std::pair<int, int> pairs[] = {{1, 99}, {2, 1}, {3, 99}, {4, 3}};
-		auto rng = view::filter(pairs, [](auto&& p) { return p.first % 2 == 0; });
+		auto rng = views::filter(pairs, [](auto&& p) { return p.first % 2 == 0; });
 		auto i = ranges::begin(rng);
 		auto const e = ranges::end(rng);
 		int sum = 0;
@@ -124,7 +124,7 @@ int main() {
 	{
 		// Test operator-> with non-pointer
 		std::list<std::pair<int, int>> pairs = {{1, 99}, {2, 1}, {3, 99}, {4, 3}};
-		auto rng = view::filter(pairs, [](auto&& p) { return p.first % 2 == 0; });
+		auto rng = views::filter(pairs, [](auto&& p) { return p.first % 2 == 0; });
 		auto i = ranges::begin(rng);
 		auto const e = ranges::end(rng);
 		int sum = 0;
@@ -136,13 +136,13 @@ int main() {
 
 	{
 		auto yes = [](int) { return true; };
-		(void) (view::iota(0) | view::filter(yes));
+		(void) (views::iota(0) | views::filter(yes));
 	}
 
 	{
 		auto yes = [](int) { return true; };
-		auto const rng = view::iota(0) | view::filter(yes);
-		view::all(rng);
+		auto const rng = views::iota(0) | views::filter(yes);
+		views::all(rng);
 	}
 
 	return test_result();

--- a/test/view/generate_view.cpp
+++ b/test/view/generate_view.cpp
@@ -18,32 +18,32 @@
 
 namespace ranges = __stl2;
 
-namespace view {
-	using namespace ranges::view;
+namespace views {
+	using namespace ranges::views;
 	using namespace ext;
-} // namespace view
+} // namespace views
 
 int main()
 {
 	// Test for constant generator functions
 	{
 		int i = 0, j = 1;
-		auto fib = view::generate([&]{ int tmp = i; i += j; std::swap(i, j); return tmp; });
-		static_assert(ranges::InputRange<decltype(fib)>);
-		static_assert(ranges::View<decltype(fib)>);
-		CHECK_EQUAL(fib | view::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
+		auto fib = views::generate([&]{ int tmp = i; i += j; std::swap(i, j); return tmp; });
+		static_assert(ranges::input_range<decltype(fib)>);
+		static_assert(ranges::view<decltype(fib)>);
+		CHECK_EQUAL(fib | views::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
 	}
 
 	// Test for mutable-only generator functions
 	{
 		int i = 0, j = 1;
-		auto fib = view::generate([=]()mutable->int{int tmp = i; i += j; std::swap(i, j); return tmp;});
-		static_assert(ranges::InputRange<decltype(fib)>);
-		static_assert(ranges::View<decltype(fib)>);
-		CHECK_EQUAL(fib | view::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
+		auto fib = views::generate([=]()mutable->int{int tmp = i; i += j; std::swap(i, j); return tmp;});
+		static_assert(ranges::input_range<decltype(fib)>);
+		static_assert(ranges::view<decltype(fib)>);
+		CHECK_EQUAL(fib | views::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
 		// The generator cannot be called when it's const-qualified, so "fib const"
-		// does not model View.
-		static_assert(!ranges::View<decltype(fib) const>);
+		// does not model view.
+		static_assert(!ranges::view<decltype(fib) const>);
 	}
 
 #if 0 // unlike range-v3, cmcstl2 doesn't support move-only input views
@@ -56,9 +56,9 @@ int main()
 			char operator()()
 			{ return str_.sz_[i_++]; }
 		};
-		auto r = view::generate(MoveOnlyFunction{"Hello, world!", 0}) | view::take_exactly(5);
-		static_assert(ranges::InputRange<decltype(r)>);
-		static_assert(ranges::View<decltype(r)>);
+		auto r = views::generate(MoveOnlyFunction{"Hello, world!", 0}) | views::take_exactly(5);
+		static_assert(ranges::input_range<decltype(r)>);
+		static_assert(ranges::view<decltype(r)>);
 		CHECK_EQUAL(r, {'H', 'e', 'l', 'l', 'o'});
 	}
 #endif // 0
@@ -69,14 +69,14 @@ int main()
 		using cmcstl2_test::move_only_string;
 
 		char str[] = "gi";
-		auto r = view::generate([&]{str[0]++; return move_only_string{str};}) | view::take_exactly(2);
+		auto r = views::generate([&]{str[0]++; return move_only_string{str};}) | views::take_exactly(2);
 		auto i = r.begin();
 		CHECK(bool(*i == move_only_string{"hi"}));
 		CHECK(bool(*i == move_only_string{"hi"}));
 		CHECK(bool(*r.begin() == move_only_string{"hi"}));
 		CHECK(bool(*r.begin() == move_only_string{"hi"}));
-		static_assert(ranges::InputRange<decltype(r)>);
-		static_assert(ranges::View<decltype(r)>);
+		static_assert(ranges::input_range<decltype(r)>);
+		static_assert(ranges::view<decltype(r)>);
 		CHECK_EQUAL(r, {move_only_string{"hi"}, move_only_string{"ii"}});
 		static_assert(std::is_same<ranges::ext::range_reference_t<decltype(r)>, move_only_string&&>::value, "");
 	}
@@ -85,19 +85,19 @@ int main()
 	// https://github.com/ericniebler/range-v3/issues/807
 	{
 		int i = 42;
-		auto r = view::generate([i]{return &i;});
+		auto r = views::generate([i]{return &i;});
 		auto rng2 = std::move(r);
 		auto it = rng2.begin();
 		auto p = *it;
 		auto p2 = *++it;
 		CHECK(p == p2);
 	}
-	
+
 	// Test that we only call the function once for each dereferenceable position
 	// https://github.com/ericniebler/range-v3/issues/819
 	{
 		int i = 0;
-		auto r = view::generate([&i]{return ++i;});
+		auto r = views::generate([&i]{return ++i;});
 		auto rng2 = std::move(r);
 		auto it = rng2.begin();
 		CHECK(i == 0);

--- a/test/view/indirect_view.cpp
+++ b/test/view/indirect_view.cpp
@@ -15,14 +15,14 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-namespace view = __stl2::view::ext;
+namespace views = __stl2::views::ext;
 
 int main()
 {
 	std::vector<std::shared_ptr<int>> vp;
 	for(int i = 0; i < 10; ++i)
 		vp.push_back(std::make_shared<int>(i));
-	auto && rng = vp | view::indirect;
+	auto && rng = vp | views::indirect;
 	CHECK(&*begin(rng) == vp[0].get());
 	CHECK_EQUAL(rng, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
@@ -33,7 +33,7 @@ int main()
 			some_ints + 0, some_ints + 1, some_ints + 2, some_ints + 3
 		};
 		auto make_range = [&]{
-			return debug_input_view<int const *>{some_int_pointers} | view::indirect;
+			return debug_input_view<int const *>{some_int_pointers} | views::indirect;
 		};
 		auto rng = make_range();
 		CHECK_EQUAL(rng, some_ints);

--- a/test/view/istream_view.cpp
+++ b/test/view/istream_view.cpp
@@ -38,6 +38,6 @@ namespace ranges = __stl2;
 int main() {
 	constexpr std::string_view test = "abcd3210";
 	std::istringstream ss{test.data()};
-	CHECK_EQUAL(ranges::view::istream<moveonly>(ss), test);
+	CHECK_EQUAL(ranges::views::istream<moveonly>(ss), test);
 	return ::test_result();
 }

--- a/test/view/join_view.cpp
+++ b/test/view/join_view.cpp
@@ -31,52 +31,52 @@ int main()
 		std::vector<std::string> vs{"this","is","his","face"};
 		join_view jv{vs};
 		CHECK_EQUAL(jv, {'t','h','i','s','i','s','h','i','s','f','a','c','e'});
-		static_assert(BidirectionalRange<decltype(jv)>);
-		static_assert(BidirectionalRange<const decltype(jv)>);
-		static_assert(CommonRange<decltype(jv)>);
-		static_assert(CommonRange<const decltype(jv)>);
+		static_assert(bidirectional_range<decltype(jv)>);
+		static_assert(bidirectional_range<const decltype(jv)>);
+		static_assert(common_range<decltype(jv)>);
+		static_assert(common_range<const decltype(jv)>);
 	}
 
 	{
-		auto rng = view::iota(0,4)
-			| view::transform([](int i) {return view::iota(0,i);})
-			| view::join;
+		auto rng = views::iota(0,4)
+			| views::transform([](int i) {return views::iota(0,i);})
+			| views::join;
 		CHECK_EQUAL(rng, {0,0,1,0,1,2});
-		static_assert(InputRange<decltype(rng)>);
-		static_assert(!Range<const decltype(rng)>);
-		static_assert(!ForwardRange<decltype(rng)>);
-		static_assert(!CommonRange<decltype(rng)>);
+		static_assert(input_range<decltype(rng)>);
+		static_assert(!range<const decltype(rng)>);
+		static_assert(!forward_range<decltype(rng)>);
+		static_assert(!common_range<decltype(rng)>);
 	}
 
 	{
-		auto rng = view::iota(0,4)
-			| view::transform([](int i) {return view::iota(0,i);})
-			| view::filter([](auto){ return true; })
-			| view::join;
+		auto rng = views::iota(0,4)
+			| views::transform([](int i) {return views::iota(0,i);})
+			| views::filter([](auto){ return true; })
+			| views::join;
 		CHECK_EQUAL(rng, {0,0,1,0,1,2});
-		static_assert(InputRange<decltype(rng)>);
-		static_assert(!Range<const decltype(rng)>);
-		static_assert(!ForwardRange<decltype(rng)>);
-		static_assert(!CommonRange<decltype(rng)>);
+		static_assert(input_range<decltype(rng)>);
+		static_assert(!range<const decltype(rng)>);
+		static_assert(!forward_range<decltype(rng)>);
+		static_assert(!common_range<decltype(rng)>);
 	}
 
 	{
 		// https://github.com/ericniebler/stl2/issues/604
-		auto rng0 = view::iota(0, 4)
-			| view::transform([](int i) { return view::iota(0, i); });
+		auto rng0 = views::iota(0, 4)
+			| views::transform([](int i) { return views::iota(0, i); });
 		auto rng1 = ref_view{rng0};
-		static_assert(RandomAccessRange<decltype(rng1)>);
-		static_assert(Range<const decltype(rng1)>);
-		static_assert(CommonRange<decltype(rng1)>);
-		static_assert(RandomAccessRange<ext::range_reference_t<decltype(rng1)>>);
+		static_assert(random_access_range<decltype(rng1)>);
+		static_assert(range<const decltype(rng1)>);
+		static_assert(common_range<decltype(rng1)>);
+		static_assert(random_access_range<ext::range_reference_t<decltype(rng1)>>);
 		static_assert(ext::SimpleView<decltype(rng1)>);
 		static_assert(!std::is_reference_v<ext::range_reference_t<decltype(rng1)>>);
-		auto rng2 = rng1 | view::join;
+		auto rng2 = rng1 | views::join;
 		CHECK_EQUAL(rng2, {0,0,1,0,1,2});
-		static_assert(InputRange<decltype(rng2)>);
-		static_assert(!Range<const decltype(rng2)>);
-		static_assert(!ForwardRange<decltype(rng2)>);
-		static_assert(!CommonRange<decltype(rng2)>);
+		static_assert(input_range<decltype(rng2)>);
+		static_assert(!range<const decltype(rng2)>);
+		static_assert(!forward_range<decltype(rng2)>);
+		static_assert(!common_range<decltype(rng2)>);
 	}
 
 	return ::test_result();

--- a/test/view/move_view.cpp
+++ b/test/view/move_view.cpp
@@ -25,11 +25,11 @@ namespace ranges = __stl2;
 namespace {
 	template<ranges::integral I>
 	auto make_interval(I from, I to) {
-		return ranges::view::iota(from, to);
+		return ranges::views::iota(from, to);
 	}
 
-	void test(ranges::Range&& base) {
-		auto rng = base | ranges::view::move;
+	void test(ranges::range&& base) {
+		auto rng = base | ranges::views::move;
 		CHECK(static_cast<std::size_t>(ranges::size(rng)) == ranges::size(base));
 		CHECK(!ranges::empty(rng));
 		int count = 0;

--- a/test/view/repeat_n_view.cpp
+++ b/test/view/repeat_n_view.cpp
@@ -19,10 +19,10 @@ namespace ranges = __stl2;
 int main() {
 	static constexpr int N = 13;
 	static constexpr int value = 42;
-	auto v = ranges::view::ext::repeat_n(value, N);
+	auto v = ranges::views::ext::repeat_n(value, N);
 	using V = decltype(v);
-	static_assert(ranges::View<V>);
-	static_assert(ranges::SizedRange<V>);
+	static_assert(ranges::view<V>);
+	static_assert(ranges::sized_range<V>);
 
 	CHECK(ranges::size(v) == N);
 	CHECK(ranges::count(v, value) == N);
@@ -36,17 +36,17 @@ int main() {
 			bool operator!=(empty const&) const noexcept { return false; }
 		};
 		auto e = empty{};
-		auto v2 = ranges::view::ext::repeat_n(e, 3);
+		auto v2 = ranges::views::ext::repeat_n(e, 3);
 		CHECK_EQUAL(v2, {e, e, e});
 
-		auto v3 = ranges::view::ext::repeat_n(std::move(e), 3);
+		auto v3 = ranges::views::ext::repeat_n(std::move(e), 3);
 		CHECK_EQUAL(v2, v3);
 	}
 	{
-		auto v = ranges::view::ext::repeat_n(9, 10);
-		static_assert(ranges::View<decltype(v)>);
-		static_assert(ranges::RandomAccessIterator<decltype(v.begin())>);
-		static_assert(ranges::SizedRange<decltype(v)>);
+		auto v = ranges::views::ext::repeat_n(9, 10);
+		static_assert(ranges::view<decltype(v)>);
+		static_assert(ranges::random_access_iterator<decltype(v.begin())>);
+		static_assert(ranges::sized_range<decltype(v)>);
 		CHECK_EQUAL(v, {9, 9, 9, 9, 9, 9, 9, 9, 9, 9});
 	}
 

--- a/test/view/repeat_view.cpp
+++ b/test/view/repeat_view.cpp
@@ -21,10 +21,10 @@ int main() {
 	{
 		auto v = ranges::ext::repeat_view{42};
 		using R = decltype(v);
-		static_assert(ranges::View<R>);
-		static_assert(ranges::RandomAccessRange<R>);
-		static_assert(!ranges::ContiguousRange<R>);
-		static_assert(!ranges::CommonRange<R>);
+		static_assert(ranges::view<R>);
+		static_assert(ranges::random_access_range<R>);
+		static_assert(!ranges::contiguous_range<R>);
+		static_assert(!ranges::common_range<R>);
 		static_assert(sizeof(v) == sizeof(int));
 		CHECK(v.value() == 42);
 
@@ -36,9 +36,9 @@ int main() {
 		CHECK(ranges::next(first) == first);
 
 		auto const& cv = v;
-		static_assert(ranges::RandomAccessRange<const R>);
-		static_assert(!ranges::ContiguousRange<const R>);
-		static_assert(!ranges::CommonRange<const R>);
+		static_assert(ranges::random_access_range<const R>);
+		static_assert(!ranges::contiguous_range<const R>);
+		static_assert(!ranges::common_range<const R>);
 		CHECK(cv.value() == 42);
 		CHECK(std::addressof(v.value()) == std::addressof(cv.value()));
 
@@ -59,9 +59,9 @@ int main() {
 		CHECK(*cfirst == 13);
 	}
 	{
-		auto v = ranges::view::ext::repeat(9) | ranges::view::take(10);
-		static_assert(ranges::View<decltype(v)>);
-		static_assert(ranges::RandomAccessIterator<decltype(v.begin())>);
+		auto v = ranges::views::ext::repeat(9) | ranges::views::take(10);
+		static_assert(ranges::view<decltype(v)>);
+		static_assert(ranges::random_access_iterator<decltype(v.begin())>);
 		CHECK_EQUAL(v, {9, 9, 9, 9, 9, 9, 9, 9, 9, 9});
 	}
 	{
@@ -71,10 +71,10 @@ int main() {
 		};
 
 		auto e = empty{};
-		auto v2 = ranges::view::ext::repeat(e) | ranges::view::take(3);
+		auto v2 = ranges::views::ext::repeat(e) | ranges::views::take(3);
 		CHECK_EQUAL(v2, {e, e, e});
 
-		auto v3 = ranges::view::ext::repeat(std::move(e)) | ranges::view::take(3);
+		auto v3 = ranges::views::ext::repeat(std::move(e)) | ranges::views::take(3);
 		CHECK_EQUAL(v2, v3);
 	}
 

--- a/test/view/reverse_view.cpp
+++ b/test/view/reverse_view.cpp
@@ -16,36 +16,38 @@
 #include "../test_iterators.hpp"
 
 namespace ranges = __stl2;
+namespace views = ranges::views;
 
 int main() {
-	using namespace ranges;
+	using ranges::view, ranges::range, ranges::sized_range, ranges::common_range;
+	using ranges::bidirectional_range, ranges::random_access_range;
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
-		auto x = rg | view::reverse;
+		auto x = rg | views::reverse;
 		CHECK_EQUAL(x, {9,8,7,6,5,4,3,2,1,0});
-		static_assert(View<decltype(x)>);
-		static_assert(Range<const decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(CommonRange<decltype(x)>);
-		static_assert(RandomAccessRange<decltype(x)>);
+		static_assert(view<decltype(x)>);
+		static_assert(range<const decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(common_range<decltype(x)>);
+		static_assert(random_access_range<decltype(x)>);
 	}
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
-		auto x = view::counted(bidirectional_iterator(rg), 5) | view::reverse;
+		auto x = views::counted(bidirectional_iterator(rg), 5) | views::reverse;
 		CHECK_EQUAL(x, {4,3,2,1,0});
-		static_assert(View<decltype(x)>);
-		static_assert(!Range<const decltype(x)>);
-		static_assert(SizedRange<decltype(x)>);
-		static_assert(CommonRange<decltype(x)>);
-		static_assert(BidirectionalRange<decltype(x)>);
-		static_assert(!RandomAccessRange<decltype(x)>);
+		static_assert(view<decltype(x)>);
+		static_assert(!range<const decltype(x)>);
+		static_assert(sized_range<decltype(x)>);
+		static_assert(common_range<decltype(x)>);
+		static_assert(bidirectional_range<decltype(x)>);
+		static_assert(!random_access_range<decltype(x)>);
 	}
 	{
 		// Regression test for CaseyCarter/cmcstl2#223
 		int a[] = {1, 7, 3, 6, 5, 2, 4, 8};
-		auto r0 = ranges::view::reverse(a);
+		auto r0 = views::reverse(a);
 		auto is_even = [](int i) { return i % 2 == 0; };
-		auto r1 = ranges::view::filter(r0, is_even);
+		auto r1 = views::filter(r0, is_even);
 		int sum = 0;
 		for (auto i : r1) {
 			sum += i;
@@ -56,16 +58,17 @@ int main() {
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
 #if 0
-		auto x = rg | view::reverse | view::reverse;
+		auto x = rg | views::reverse | views::reverse;
 		static_assert(same_as<decltype(x), ref_view<decltype(rg)>>);
 		CHECK(&x.base() == &rg);
 #else
-		auto x = view::reverse(rg);
+		using ranges::_RangeImpl, ranges::viewable_range;
+		auto x = views::reverse(rg);
 		using R = decltype(x);
-		static_assert(Range<R>);
+		static_assert(range<R>);
 		static_assert(!_RangeImpl<R>);
-		static_assert(View<R>);
-		static_assert(ViewableRange<R>);
+		static_assert(view<R>);
+		static_assert(viewable_range<R>);
 #endif
 	}
  	return test_result();

--- a/test/view/single_view.cpp
+++ b/test/view/single_view.cpp
@@ -24,9 +24,9 @@ using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
 template<class V, class T>
 void test_one(V& v, const T& t) {
-    static_assert(ranges::ContiguousRange<V>);
-    static_assert(ranges::SizedRange<V>);
-    static_assert(ranges::CommonRange<V>);
+    static_assert(ranges::contiguous_range<V>);
+    static_assert(ranges::sized_range<V>);
+    static_assert(ranges::common_range<V>);
     using I = ranges::iterator_t<V>;
     static_assert(std::is_pointer_v<I>);
     static_assert(ranges::same_as<T, ranges::iter_value_t<I>>);
@@ -41,7 +41,7 @@ void test_one(V& v, const T& t) {
 template<class T>
 void test(T&& t) {
     using D = remove_cvref_t<T>;
-    auto v = ranges::view::single(std::forward<T>(t));
+    auto v = ranges::views::single(std::forward<T>(t));
     static_assert(ranges::same_as<ranges::single_view<D>, decltype(v)>);
     test_one(v, t);
     test_one(std::as_const(v), t);

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -1074,8 +1074,8 @@ int main() {
 	test_case_interop_with_std_regex();
 	test_case_default_initializable();
 
-	static_assert(ranges::ContiguousRange<span<int>> && ranges::View<span<int>>);
-	static_assert(ranges::ContiguousRange<span<int, 42>> && ranges::View<span<int, 42>>);
+	static_assert(ranges::contiguous_range<span<int>> && ranges::view<span<int>>);
+	static_assert(ranges::contiguous_range<span<int, 42>> && ranges::view<span<int, 42>>);
 
 	// spans are non-dangling
 	static_assert(ranges::same_as<decltype(ranges::begin(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);

--- a/test/view/split_view.cpp
+++ b/test/view/split_view.cpp
@@ -94,7 +94,7 @@ int main() {
 		CHECK_EQUAL(*i, {'m','i','l','k'});
 		++i;
 		CHECK(i != sv.end());
-		CHECK_EQUAL(*i, view::empty<char>);
+		CHECK_EQUAL(*i, views::empty<char>);
 		++i;
 		CHECK(i != sv.end());
 		CHECK_EQUAL(*i, {'b','u','t','t','e','r'});
@@ -108,7 +108,7 @@ int main() {
 		auto rng = subrange{
 			istreambuf_iterator<char>{sin},
 			default_sentinel{}};
-		auto sv = rng | view::split(',');
+		auto sv = rng | views::split(',');
 		auto i = sv.begin();
 		CHECK(i != sv.end());
 		CHECK_EQUAL(*i, {'e','g','g','s'});
@@ -117,7 +117,7 @@ int main() {
 		CHECK_EQUAL(*i, {'m','i','l','k'});
 		++i;
 		CHECK(i != sv.end());
-		CHECK_EQUAL(*i, view::empty<char>);
+		CHECK_EQUAL(*i, views::empty<char>);
 		++i;
 		CHECK(i != sv.end());
 		CHECK_EQUAL(*i, {'b','u','t','t','e','r'});
@@ -127,7 +127,7 @@ int main() {
 
 	{
 		std::string hello("hello");
-		split_view sv{hello, view::empty<char>};
+		split_view sv{hello, views::empty<char>};
 		auto i = sv.begin();
 		CHECK(i != sv.end());
 		CHECK_EQUAL(*i, single_view{'h'});
@@ -153,7 +153,7 @@ int main() {
 		auto rng = subrange{
 			istreambuf_iterator<char>{sin},
 			default_sentinel{}};
-		auto sv = view::split(rng, view::empty<char>);
+		auto sv = views::split(rng, views::empty<char>);
 		auto i = sv.begin();
 		CHECK(i != sv.end());
 		CHECK_EQUAL(*i, single_view{'h'});
@@ -175,7 +175,7 @@ int main() {
 
 	{
 		std::string hello{"hello"};
-		auto sv = view::split(hello, view::empty<char>);
+		auto sv = views::split(hello, views::empty<char>);
 		auto i = sv.begin();
 		CHECK(i != sv.end());
 		++i;
@@ -198,7 +198,7 @@ int main() {
 		auto rng = subrange{
 			istreambuf_iterator<char>{sin},
 			default_sentinel{}};
-		auto sv = view::split(rng, view::empty<char>);
+		auto sv = views::split(rng, views::empty<char>);
 		auto i = sv.begin();
 		CHECK(i != sv.end());
 		++i;

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -21,7 +21,7 @@ namespace ranges = __stl2;
 
 using namespace ranges;
 
-template<Range Rng>
+template<range Rng>
 safe_subrange_t<Rng> algorithm(Rng &&rng);
 
 struct Base {};
@@ -79,7 +79,7 @@ int main() {
 		std::tuple_element<0, decltype(r0)>::type>);
 	static_assert(same_as<std::vector<int>::iterator,
 		std::tuple_element<1, decltype(r0)>::type>);
-	static_assert(SizedRange<decltype(r0)>);
+	static_assert(sized_range<decltype(r0)>);
 	CHECK(r0.size() == 4);
 	CHECK(r0.begin() == vi.begin());
 	CHECK(get<0>(r0) == vi.begin());
@@ -105,8 +105,8 @@ int main() {
 		std::tuple_element<0, decltype(r1)>::type>);
 	static_assert(same_as<unreachable,
 		std::tuple_element<1, decltype(r1)>::type>);
-	static_assert(View<decltype(r1)>);
-	static_assert(!SizedRange<decltype(r1)>);
+	static_assert(view<decltype(r1)>);
+	static_assert(!sized_range<decltype(r1)>);
 	CHECK(r1.begin() == vi.begin()+1);
 	r1.end() = unreachable{};
 
@@ -126,7 +126,7 @@ int main() {
 	std::list<int> li{1,2,3,4};
 	ext::sized_subrange<std::list<int>::iterator> l0 {li.begin(), li.end(),
 		static_cast<std::ptrdiff_t>(li.size())};
-	static_assert(View<decltype(l0)> && SizedRange<decltype(l0)>);
+	static_assert(view<decltype(l0)> && sized_range<decltype(l0)>);
 	CHECK(l0.begin() == li.begin());
 	CHECK(l0.end() == li.end());
 	CHECK(l0.size() == static_cast<std::ptrdiff_t>(li.size()));
@@ -135,10 +135,10 @@ int main() {
 	CHECK(l0.end() == li.end());
 	CHECK(l0.size() == static_cast<std::ptrdiff_t>(li.size()) - 1);
 
-	l0 = view::all(li);
+	l0 = views::all(li);
 
 	subrange<std::list<int>::iterator> l1 = l0;
-	static_assert(!SizedRange<decltype(l1)>);
+	static_assert(!sized_range<decltype(l1)>);
 	CHECK(l1.begin() == li.begin());
 	CHECK(l1.end() == li.end());
 
@@ -157,8 +157,8 @@ int main() {
 	{
 		subrange s0{vi};
 		subrange s1{li};
-		subrange s2{view::all(vi)};
-		subrange s3{view::all(li)};
+		subrange s2{views::all(vi)};
+		subrange s3{views::all(li)};
 		static_assert(same_as<decltype(r0), decltype(s0)>);
 		static_assert(same_as<decltype(l0), decltype(s1)>);
 		static_assert(same_as<decltype(r0), decltype(s2)>);
@@ -175,8 +175,8 @@ int main() {
 	{
 		subrange s0{vi, ranges::distance(vi)};
 		subrange s1{li, ranges::distance(li)};
-		subrange s2{view::all(vi), ranges::distance(vi)};
-		subrange s3{view::all(li), ranges::distance(li)};
+		subrange s2{views::all(vi), ranges::distance(vi)};
+		subrange s3{views::all(li), ranges::distance(li)};
 		static_assert(same_as<decltype(r0), decltype(s0)>);
 		static_assert(same_as<decltype(l0), decltype(s1)>);
 		static_assert(same_as<decltype(r0), decltype(s2)>);

--- a/test/view/take_exactly_view.cpp
+++ b/test/view/take_exactly_view.cpp
@@ -37,24 +37,24 @@ int main()
 	using namespace ranges;
 
 	{
-		auto rng = view::iota(0) | view::ext::take_exactly(10);
-		static_assert(View<decltype(rng)>);
-		static_assert(!SizedRange<iota_view<int>>);
-		static_assert(Range<const decltype(rng)>);
+		auto rng = views::iota(0) | views::ext::take_exactly(10);
+		static_assert(view<decltype(rng)>);
+		static_assert(!sized_range<iota_view<int>>);
+		static_assert(range<const decltype(rng)>);
 		CHECK_EQUAL(rng, {0,1,2,3,4,5,6,7,8,9});
 	}
 
 	{
-		auto rng = view::iota(0, 100) | view::ext::take_exactly(10);
-		static_assert(View<decltype(rng)>);
-		static_assert(Range<const decltype(rng)>);
+		auto rng = views::iota(0, 100) | views::ext::take_exactly(10);
+		static_assert(view<decltype(rng)>);
+		static_assert(range<const decltype(rng)>);
 		CHECK_EQUAL(rng, {0,1,2,3,4,5,6,7,8,9});
 	}
 
 	{
-		auto rng = view::iota(0, 9) | view::ext::take_exactly(10);
-		static_assert(View<decltype(rng)>);
-		static_assert(Range<const decltype(rng)>);
+		auto rng = views::iota(0, 9) | views::ext::take_exactly(10);
+		static_assert(view<decltype(rng)>);
+		static_assert(range<const decltype(rng)>);
 		CHECK_EQUAL(rng, {0,1,2,3,4,5,6,7,8,9});
 	}
 
@@ -62,10 +62,10 @@ int main()
 		auto evens = [](int i){return i%2 == 0;};
 		std::stringstream sin{"0 1 2 3 4 5 6 7 8 9"};
 		my_subrange is{istream_iterator<int>{sin}, istream_iterator<int>{}};
-		static_assert(InputRange<decltype(is)>);
-		auto rng = is | view::filter(evens) | view::ext::take_exactly(3);
-		static_assert(View<decltype(rng)>);
-		static_assert(!Range<const decltype(rng)>);
+		static_assert(input_range<decltype(is)>);
+		auto rng = is | views::filter(evens) | views::ext::take_exactly(3);
+		static_assert(view<decltype(rng)>);
+		static_assert(!range<const decltype(rng)>);
 		CHECK_EQUAL(rng, {0,2,4});
 	}
 
@@ -73,10 +73,10 @@ int main()
 		auto odds = [](int i){return i%2 == 1;};
 		std::stringstream sin{"0 1 2 3 4 5 6 7 8 9"};
 		my_subrange is{istream_iterator<int>{sin}, istream_iterator<int>{}};
-		auto pipe = view::filter(odds) | view::ext::take_exactly(3);
+		auto pipe = views::filter(odds) | views::ext::take_exactly(3);
 		auto rng = is | pipe;
-		static_assert(View<decltype(rng)>);
-		static_assert(!Range<const decltype(rng)>);
+		static_assert(view<decltype(rng)>);
+		static_assert(!range<const decltype(rng)>);
 		CHECK_EQUAL(rng, {1,3,5});
 	}
 

--- a/test/view/take_view.cpp
+++ b/test/view/take_view.cpp
@@ -38,26 +38,26 @@ int main()
 	using namespace ranges;
 
 	{
-		auto rng = view::iota(0) | view::take(10);
+		auto rng = views::iota(0) | views::take(10);
 		using R = decltype(rng);
-		static_assert(View<R>);
-		static_assert(!SizedRange<R>);
-		static_assert(!CommonRange<R>);
-		static_assert(RandomAccessRange<R>);
-		static_assert(!ContiguousRange<R>);
-		static_assert(Range<const R>);
+		static_assert(view<R>);
+		static_assert(!sized_range<R>);
+		static_assert(!common_range<R>);
+		static_assert(random_access_range<R>);
+		static_assert(!contiguous_range<R>);
+		static_assert(range<const R>);
 		CHECK_EQUAL(rng, {0,1,2,3,4,5,6,7,8,9});
 	}
 
 	{
-		auto rng = view::iota(0, 100) | view::take(10);
+		auto rng = views::iota(0, 100) | views::take(10);
 		using R = decltype(rng);
-		static_assert(View<R>);
-		static_assert(SizedRange<R>);
-		static_assert(CommonRange<R>);
-		static_assert(RandomAccessRange<R>);
-		static_assert(!ContiguousRange<R>);
-		static_assert(Range<const R>);
+		static_assert(view<R>);
+		static_assert(sized_range<R>);
+		static_assert(common_range<R>);
+		static_assert(random_access_range<R>);
+		static_assert(!contiguous_range<R>);
+		static_assert(range<const R>);
 		CHECK_EQUAL(rng, {0,1,2,3,4,5,6,7,8,9});
 	}
 
@@ -65,16 +65,16 @@ int main()
 		auto evens = [](int i) { return i % 2 == 0; };
 		std::stringstream sin{"0 1 2 3 4 5 6 7 8 9"};
 		my_subrange is{istream_iterator<int>{sin}, istream_iterator<int>{}};
-		static_assert(InputRange<decltype(is)>);
-		auto rng = is | view::filter(evens) | view::take(3);
+		static_assert(input_range<decltype(is)>);
+		auto rng = is | views::filter(evens) | views::take(3);
 		using R = decltype(rng);
-		static_assert(View<R>);
-		static_assert(!SizedRange<decltype(rng.base())>);
-		static_assert(!SizedRange<R>);
-		static_assert(!CommonRange<R>);
-		static_assert(InputRange<R>);
-		static_assert(!ForwardRange<R>);
-		static_assert(!Range<const R>);
+		static_assert(view<R>);
+		static_assert(!sized_range<decltype(rng.base())>);
+		static_assert(!sized_range<R>);
+		static_assert(!common_range<R>);
+		static_assert(input_range<R>);
+		static_assert(!forward_range<R>);
+		static_assert(!range<const R>);
 		CHECK_EQUAL(rng, {0,2,4});
 	}
 
@@ -82,16 +82,16 @@ int main()
 		auto odds = [](int i) { return i % 2 == 1; };
 		std::stringstream sin{"0 1 2 3 4 5 6 7 8 9"};
 		my_subrange is{istream_iterator<int>{sin}, istream_iterator<int>{}};
-		auto pipe = view::filter(odds) | view::take(3);
+		auto pipe = views::filter(odds) | views::take(3);
 		auto rng = is | pipe;
 		using R = decltype(rng);
-		static_assert(View<R>);
-		static_assert(!SizedRange<decltype(rng.base())>);
-		static_assert(!SizedRange<R>);
-		static_assert(!CommonRange<R>);
-		static_assert(InputRange<R>);
-		static_assert(!ForwardRange<R>);
-		static_assert(!Range<const R>);
+		static_assert(view<R>);
+		static_assert(!sized_range<decltype(rng.base())>);
+		static_assert(!sized_range<R>);
+		static_assert(!common_range<R>);
+		static_assert(input_range<R>);
+		static_assert(!forward_range<R>);
+		static_assert(!range<const R>);
 		CHECK_EQUAL(rng, {1,3,5});
 	}
 
@@ -102,10 +102,10 @@ int main()
 
 	{
 		std::list<int> l{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-		auto rng = l | view::take(6);
-		static_assert(ranges::View<decltype(rng)>);
-		static_assert(ranges::SizedRange<decltype(rng)>);
-		static_assert(ranges::BidirectionalIterator<decltype(ranges::begin(rng))>);
+		auto rng = l | views::take(6);
+		static_assert(ranges::view<decltype(rng)>);
+		static_assert(ranges::sized_range<decltype(rng)>);
+		static_assert(ranges::bidirectional_iterator<decltype(ranges::begin(rng))>);
 		CHECK_EQUAL(rng, {0, 1, 2, 3, 4, 5});
 	}
 

--- a/test/view/take_while_view.cpp
+++ b/test/view/take_while_view.cpp
@@ -18,31 +18,31 @@
 
 namespace ranges = __stl2;
 
-namespace view {
-	using namespace ranges::view;
-	using view::ext::take_while;
-} // namespace view
+namespace views {
+	using namespace ranges::views;
+	using views::ext::take_while;
+} // namespace views
 
 int main()
 {
-	auto rng0 = view::iota(10) | view::take_while([](int i) { return i != 25; });
+	auto rng0 = views::iota(10) | views::take_while([](int i) { return i != 25; });
 	CHECK_EQUAL(rng0, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
-	static_assert(ranges::View<decltype(rng0)>);
-	static_assert(!ranges::CommonRange<decltype(rng0)>);
-	static_assert(ranges::RandomAccessIterator<decltype(rng0.begin())>);
+	static_assert(ranges::view<decltype(rng0)>);
+	static_assert(!ranges::common_range<decltype(rng0)>);
+	static_assert(ranges::random_access_iterator<decltype(rng0.begin())>);
 
 	std::vector<int> vi{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	auto rng1 = vi | view::take_while([](int i) { return i != 50; });
-	static_assert(ranges::RandomAccessRange<decltype(rng1)>);
+	auto rng1 = vi | views::take_while([](int i) { return i != 50; });
+	static_assert(ranges::random_access_range<decltype(rng1)>);
 	CHECK_EQUAL(rng1, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
 #if 0 // DISABLED until generate is migrated to cmcstl2.
 	{
-		auto ns = view::generate([]() mutable {
+		auto ns = views::generate([]() mutable {
 			static int N;
 			return ++N;
 		});
-		auto rng = ns | view::take_while([](int i) { return i < 5; });
+		auto rng = ns | views::take_while([](int i) { return i < 5; });
 		CHECK_EQUAL(rng, {1,2,3,4});
 	}
 #endif

--- a/test/view/transform_view.cpp
+++ b/test/view/transform_view.cpp
@@ -37,32 +37,32 @@ int main() {
 
 	int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-	auto rng = rgi | view::transform(is_odd());
+	auto rng = rgi | views::transform(is_odd());
 	static_assert(same_as<int &, decltype(*begin(rgi))>);
 	static_assert(same_as<bool, decltype(*begin(rng))>);
-	static_assert(View<decltype(rng)>);
-	static_assert(SizedRange<decltype(rng)>);
-	static_assert(RandomAccessRange<decltype(rng)>);
+	static_assert(view<decltype(rng)>);
+	static_assert(sized_range<decltype(rng)>);
+	static_assert(random_access_range<decltype(rng)>);
 	CHECK_EQUAL(rng, {true, false, true, false, true, false, true, false, true, false});
 
 	std::pair<int, int> rgp[] = {{1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}, {7,7}, {8,8}, {9,9}, {10,10}};
-	auto rng2 = rgp | view::transform(&std::pair<int,int>::first);
+	auto rng2 = rgp | views::transform(&std::pair<int,int>::first);
 	static_assert(same_as<int &, decltype(*begin(rng2))>);
 	static_assert(same_as<iter_value_t<iterator_t<decltype(rng2)>>, int>);
 	static_assert(same_as<decltype(iter_move(begin(rng2))), int &&>);
-	static_assert(View<decltype(rng2)>);
-	static_assert(CommonRange<decltype(rng2)>);
-	static_assert(SizedRange<decltype(rng2)>);
-	static_assert(RandomAccessRange<decltype(rng2)>);
+	static_assert(view<decltype(rng2)>);
+	static_assert(common_range<decltype(rng2)>);
+	static_assert(sized_range<decltype(rng2)>);
+	static_assert(random_access_range<decltype(rng2)>);
 	CHECK(&*begin(rng2) == &rgp[0].first);
 	CHECK(rng2.size() == 10u);
 	CHECK_EQUAL(rng2, {1,2,3,4,5,6,7,8,9,10});
-	CHECK_EQUAL(rng2 | view::reverse, {10,9,8,7,6,5,4,3,2,1});
+	CHECK_EQUAL(rng2 | views::reverse, {10,9,8,7,6,5,4,3,2,1});
 
 	// https://github.com/CaseyCarter/cmcstl2/issues/262
 	{
 		auto id = [](int x){ return x; };
-		view::iota(0) | view::filter(id) | view::transform(id);
+		views::iota(0) | views::filter(id) | views::transform(id);
 	}
 
 	return ::test_result();


### PR DESCRIPTION
P1754 renames the concepts from PascalCase to snake_case. This commit
completes what 8d54d1a started, by renaming everything in [readable,
uniform_random_bit_generator].

Same deal: used Code's find/replace all, but excluding `include/meta` this time!