### PR TITLE
Remove uses of TS abbreviated function templates

### DIFF
--- a/test/algorithm/next_permutation.cpp
+++ b/test/algorithm/next_permutation.cpp
@@ -33,7 +33,8 @@
 
 namespace ranges = __stl2;
 
-constexpr ranges::integral factorial(ranges::integral x)
+template<ranges::integral T>
+constexpr auto factorial(T x)
 {
 	decltype(x) r = 1;
 	for (; 1 < x; --x)

--- a/test/algorithm/prev_permutation.cpp
+++ b/test/algorithm/prev_permutation.cpp
@@ -32,7 +32,8 @@
 
 namespace ranges = __stl2;
 
-constexpr auto factorial(ranges::integral x)
+template<ranges::integral T>
+constexpr auto factorial(T x)
 {
 	decltype(x) r = 1;
 	for (; 1 < x; --x) {

--- a/test/view/move_view.cpp
+++ b/test/view/move_view.cpp
@@ -28,7 +28,8 @@ namespace {
 		return ranges::views::iota(from, to);
 	}
 
-	void test(ranges::range&& base) {
+	template<ranges::range R>
+	void test(R&& base) {
 		auto rng = base | ranges::views::move;
 		CHECK(static_cast<std::size_t>(ranges::size(rng)) == ranges::size(base));
 		CHECK(!ranges::empty(rng));


### PR DESCRIPTION
I'm notably not replacing these with C++20 abbreviated function templates since - to my knowledge - nobody implements them.