### PR TITLE
any_iterator cleanup:

### DIFF
--- a/test/iterator/any_iterator.cpp
+++ b/test/iterator/any_iterator.cpp
@@ -16,16 +16,16 @@
 #include <sstream>
 #include "../simple_test.hpp"
 
-namespace stl2 = __stl2;
+namespace ranges = __stl2;
 
 void test_small() {
 	int rg[]{0,1,2,3,4,5,6,7,8,9};
-	using AI = stl2::any_input_iterator<int&>;
+	using AI = ranges::ext::any_input_iterator<int&>;
 	AI first{rg};
 	AI const last{rg+10};
 	auto a1 = first, a2 = a1; (void)a2; // makin' copies
-	CHECK(&rg[5] == &*stl2::next(first, 5));
-	CHECK(&rg[5] == &(int const&)stl2::iter_move(stl2::next(first, 5)));
+	CHECK(&rg[5] == &*ranges::next(first, 5));
+	CHECK(&rg[5] == &(int const&)ranges::iter_move(ranges::next(first, 5)));
 	int i = 0;
 	for (; first != last; ++first, ++i) {
 		CHECK(!(first == last));
@@ -40,14 +40,14 @@ void test_small() {
 void test_big() {
 	std::stringstream sin{"now is the time for all good personages"};
 	using I = std::istream_iterator<std::string>;
-	using AI = stl2::any_input_iterator<std::string const &>;
+	using AI = ranges::ext::any_input_iterator<std::string const &>;
 	AI first{I{sin}};
 	AI const last{I{}};
 	auto a1 = first, a2 = a1; (void)a2; // makin' aliases
 	CHECK(first != last);
 	if (first != last) {
 		CHECK(*first == "now");
-		first = stl2::next(first, 7, last);
+		first = ranges::next(first, 7, last);
 		CHECK(first != last);
 		if (first != last) {
 			CHECK(*first == "personages");


### PR DESCRIPTION
* move into namespace `ext`
* avoid constraint recursion in converting constructors
* variable template instead of type template for `is_small`
* merge reference count into `shared_iterator`
* Use `if constexpr` instead of tag dispatch