### PR TITLE
ranges::swap should allow customization for unions

### DIFF
--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -36,6 +36,14 @@ STL2_OPEN_NAMESPACE {
 		return tmp;
 	}
 
+	namespace detail {
+		template<class T>
+		META_CONCEPT has_class_or_enum_type =
+			std::is_class_v<__uncvref<T>> ||
+			std::is_enum_v<__uncvref<T>> ||
+			std::is_union_v<__uncvref<T>>;
+	}
+
 	///////////////////////////////////////////////////////////////////////////
 	// swap [utility.swap]
 	//
@@ -51,14 +59,13 @@ STL2_OPEN_NAMESPACE {
 		// finding std::swap. (See the detailed discussion at
 		// https://github.com/ericniebler/stl2/issues/139)
 		template<class T> void swap(T&, T&) = delete;
-		template<class T, std::size_t N> void swap(T(&)[N], T(&)[N]) = delete;
 
 		template<class T, class U>
 		META_CONCEPT has_customization =
-			(std::is_class_v<__uncvref<T>> || std::is_class_v<__uncvref<U>>
-			 || std::is_enum_v<__uncvref<T>> || std::is_enum_v<__uncvref<U>>) &&
+			(detail::has_class_or_enum_type<T> ||
+			 detail::has_class_or_enum_type<U>) &&
 			requires(T&& t, U&& u) {
-				(void)swap(static_cast<T&&>(t), static_cast<U&&>(u));
+				swap(static_cast<T&&>(t), static_cast<U&&>(u));
 			};
 
 		template<class F, class T, class U>

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -39,9 +39,15 @@ STL2_OPEN_NAMESPACE {
 	namespace detail {
 		template<class T>
 		META_CONCEPT has_class_or_enum_type =
+#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
+			__is_class(__uncvref<T>) ||
+			__is_enum(__uncvref<T>) ||
+			__is_union(__uncvref<T>);
+#else // ^^^ Use intrinsics / use type traits vvv
 			std::is_class_v<__uncvref<T>> ||
 			std::is_enum_v<__uncvref<T>> ||
 			std::is_union_v<__uncvref<T>>;
+#endif // intrinsics vs. traits
 	}
 
 	///////////////////////////////////////////////////////////////////////////

--- a/test/concepts/swap.cpp
+++ b/test/concepts/swap.cpp
@@ -141,6 +141,29 @@ namespace example {
 	}
 }
 
+namespace union_customizable {
+	union U {
+		int i = 42;
+		double d;
+		U() = default;
+		U(U&&) = delete;
+	};
+
+	int count = 0;
+
+	void swap(U&, U&) {
+		++count;
+	}
+
+	void test() {
+		static_assert(swappable<U>);
+		U u0, u1;
+		CHECK(count == 0);
+		ranges::swap(u0, u1);
+		CHECK(count == 1);
+	}
+} // namespace union_customizable
+
 int main() {
 	{
 		int a[2][2] = {{0, 1}, {2, 3}};
@@ -162,6 +185,7 @@ int main() {
 	}
 
 	example::test();
+	union_customizable::test();
 
 	return ::test_result();
 }


### PR DESCRIPTION
.... which `is_class_v` rejects. Thanks to Jonathan Wakely for catching the bug.