### PR TITLE
silences GCC warning by deleting an unused declaration

### DIFF
--- a/include/stl2/view/view_interface.hpp
+++ b/include/stl2/view/view_interface.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 			ContainerConvertibleGCCBugs<C, R>;
 
 		template<range R>
-		constexpr bool is_in_range(R& r, iter_difference_t<iterator_t<R>> n) noexcept {
+		constexpr bool is_in_range(R&, iter_difference_t<iterator_t<R>> n) noexcept {
 			return 0 <= n;
 		}
 


### PR DESCRIPTION
GCC was giving me an unused variable warning when trying to compile `cycle_view` in cmcstl2.