### PR TITLE
P1452 fixes:

### DIFF
--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -295,7 +295,7 @@ namespace meta
         typename detail::require_constant<T{}()>;
         requires T{}() == T::value;
 
-        { T{} } -> typename T::value_type;
+        requires std::is_convertible_v<T, typename T::value_type>;
     };
     // clang-format on
 #endif // META_CONCEPT

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -212,7 +212,7 @@ STL2_OPEN_NAMESPACE {
 			Cursor<C> &&
 			semiregular<S> &&
 			requires(const C& c, const S& s) {
-				{ c.equal(s) } -> bool;
+				{ c.equal(s) } -> same_as<bool>;
 			};
 		template<class S, class C>
 		META_CONCEPT sized_sentinel_for =

--- a/include/stl2/detail/iterator/increment.hpp
+++ b/include/stl2/detail/iterator/increment.hpp
@@ -140,7 +140,7 @@ STL2_OPEN_NAMESPACE {
 				n + ci; requires same_as<decltype((n + ci)), I>;
 				ci - n; requires same_as<decltype((ci - n)), I>;
 #endif // META_HAS_P1084
-				{ ci - ci } -> iter_difference_t<I>;
+				{ ci - ci } -> convertible_to<iter_difference_t<I>>;
 			};
 			// FIXME: Axioms
 	}

--- a/include/stl2/detail/iterator/insert_iterators.hpp
+++ b/include/stl2/detail/iterator/insert_iterators.hpp
@@ -115,7 +115,7 @@ STL2_OPEN_NAMESPACE {
 		template<class T, class C>
 		META_CONCEPT InsertableInto =
 			requires(T&& t, C& c, iterator_t<C> i) {
-				{  c.insert(i, (T&&)t) } -> iterator_t<C>;
+				{  c.insert(i, (T&&)t) } -> same_as<iterator_t<C>>;
 			};
 	}
 

--- a/include/stl2/view/subrange.hpp
+++ b/include/stl2/view/subrange.hpp
@@ -37,8 +37,8 @@ STL2_OPEN_NAMESPACE {
 
 		template<class T>
 		META_CONCEPT PairLikeGCCBugs = requires(T t) {
-			{ std::get<0>(t) } -> const std::tuple_element_t<0, T>&;
-			{ std::get<1>(t) } -> const std::tuple_element_t<1, T>&;
+			{ std::get<0>(t) } -> convertible_to<const std::tuple_element_t<0, T>&>;
+			{ std::get<1>(t) } -> convertible_to<const std::tuple_element_t<1, T>&>;
 		};
 
 		template<class T>


### PR DESCRIPTION
P1452 removes the `-> type` syntax for return-type-requirements.

Fixes #342.