### PR TITLE
Disable workarounds for GCC 10

### DIFF
--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -27,7 +27,7 @@
 #endif // __clang__
 
 #ifndef STL2_WORKAROUND_GCC_69096
- #if defined(__GNUC__) && __GNUC__ >= 6
+ #if defined(__GNUC__) && __GNUC__ >= 6 && __GNUC__ < 10
   // Return type deduction performed *before* checking constraints.
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69096
   #define STL2_WORKAROUND_GCC_69096 1
@@ -37,7 +37,7 @@
 #endif
 
 #ifndef STL2_WORKAROUND_GCC_79591
- #if defined(__GNUC__) && __GNUC__ >= 6
+ #if defined(__GNUC__) && __GNUC__ >= 6 && __GNUC__ < 10
   // Overloading function template declarations that differ only in their
   // associated constraints does not work properly when at least one declaration
   // is imported with a using declaration.
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef STL2_WORKAROUND_GCC_UNKNOWN0
- #ifdef __GNUC__
+ #if defined(__GNUC__) && __GNUC__ < 10
   // Unfiled GCC bug triggered by the P/R for LWG 3149
   #define STL2_WORKAROUND_GCC_UNKNOWN0 1
  #else


### PR DESCRIPTION
GCC pre-10 doesn't need any of these workarounds.