### PR TITLE
Restore the "extraneous" initializers

### DIFF
--- a/include/stl2/detail/algorithm/adjacent_find.hpp
+++ b/include/stl2/detail/algorithm/adjacent_find.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __adjacent_find_fn adjacent_find;
+	inline constexpr __adjacent_find_fn adjacent_find{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/all_of.hpp
+++ b/include/stl2/detail/algorithm/all_of.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __all_of_fn all_of;
+	inline constexpr __all_of_fn all_of{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/any_of.hpp
+++ b/include/stl2/detail/algorithm/any_of.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __any_of_fn any_of;
+	inline constexpr __any_of_fn any_of{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/binary_search.hpp
+++ b/include/stl2/detail/algorithm/binary_search.hpp
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __binary_search_fn binary_search;
+	inline constexpr __binary_search_fn binary_search{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/copy.hpp
+++ b/include/stl2/detail/algorithm/copy.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __copy_fn copy;
+	inline constexpr __copy_fn copy{};
 
 	namespace ext {
 		struct __copy_fn : private __niebloid {
@@ -85,7 +85,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __copy_fn copy;
+		inline constexpr __copy_fn copy{};
 	} // namespace ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/copy_backward.hpp
+++ b/include/stl2/detail/algorithm/copy_backward.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __copy_backward_fn copy_backward;
+	inline constexpr __copy_backward_fn copy_backward{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/copy_if.hpp
+++ b/include/stl2/detail/algorithm/copy_if.hpp
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __copy_if_fn copy_if;
+	inline constexpr __copy_if_fn copy_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/copy_n.hpp
+++ b/include/stl2/detail/algorithm/copy_n.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __copy_n_fn copy_n;
+	inline constexpr __copy_n_fn copy_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/count.hpp
+++ b/include/stl2/detail/algorithm/count.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __count_fn count;
+	inline constexpr __count_fn count{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/count_if.hpp
+++ b/include/stl2/detail/algorithm/count_if.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __count_if_fn count_if;
+	inline constexpr __count_if_fn count_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/equal.hpp
+++ b/include/stl2/detail/algorithm/equal.hpp
@@ -95,7 +95,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __equal_fn equal;
+	inline constexpr __equal_fn equal{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/equal_range.hpp
+++ b/include/stl2/detail/algorithm/equal_range.hpp
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __equal_range_n_fn equal_range_n;
+		inline constexpr __equal_range_n_fn equal_range_n{};
 	} // namespace ext
 
 	struct __equal_range_fn : private __niebloid {
@@ -124,7 +124,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __equal_range_fn equal_range;
+	inline constexpr __equal_range_fn equal_range{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/fill.hpp
+++ b/include/stl2/detail/algorithm/fill.hpp
@@ -33,7 +33,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __fill_fn fill;
+	inline constexpr __fill_fn fill{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/fill_n.hpp
+++ b/include/stl2/detail/algorithm/fill_n.hpp
@@ -29,7 +29,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __fill_n_fn fill_n;
+	inline constexpr __fill_n_fn fill_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find.hpp
+++ b/include/stl2/detail/algorithm/find.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __find_fn find;
+	inline constexpr __find_fn find{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_end.hpp
+++ b/include/stl2/detail/algorithm/find_end.hpp
@@ -122,7 +122,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __find_end_fn find_end;
+	inline constexpr __find_end_fn find_end{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_first_of.hpp
+++ b/include/stl2/detail/algorithm/find_first_of.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __find_first_of_fn find_first_of;
+	inline constexpr __find_first_of_fn find_first_of{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_if.hpp
+++ b/include/stl2/detail/algorithm/find_if.hpp
@@ -41,7 +41,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __find_if_fn find_if;
+	inline constexpr __find_if_fn find_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/find_if_not.hpp
+++ b/include/stl2/detail/algorithm/find_if_not.hpp
@@ -38,7 +38,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __find_if_not_fn find_if_not;
+	inline constexpr __find_if_not_fn find_if_not{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/for_each.hpp
+++ b/include/stl2/detail/algorithm/for_each.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __for_each_fn for_each;
+	inline constexpr __for_each_fn for_each{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/generate.hpp
+++ b/include/stl2/detail/algorithm/generate.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __generate_fn generate;
+	inline constexpr __generate_fn generate{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/generate_n.hpp
+++ b/include/stl2/detail/algorithm/generate_n.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __generate_n_fn generate_n;
+	inline constexpr __generate_n_fn generate_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/heap_sift.hpp
+++ b/include/stl2/detail/algorithm/heap_sift.hpp
@@ -62,7 +62,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __sift_up_n_fn sift_up_n;
+		inline constexpr __sift_up_n_fn sift_up_n{};
 
 		struct __sift_down_n_fn {
 			template<random_access_iterator I, class Comp, class Proj>
@@ -122,7 +122,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __sift_down_n_fn sift_down_n;
+		inline constexpr __sift_down_n_fn sift_down_n{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/includes.hpp
+++ b/include/stl2/detail/algorithm/includes.hpp
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __includes_fn includes;
+	inline constexpr __includes_fn includes{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/inplace_merge.hpp
+++ b/include/stl2/detail/algorithm/inplace_merge.hpp
@@ -164,7 +164,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr merge_adaptive_fn merge_adaptive;
+		inline constexpr merge_adaptive_fn merge_adaptive{};
 
 		struct inplace_merge_no_buffer_fn
 		{
@@ -179,7 +179,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr inplace_merge_no_buffer_fn inplace_merge_no_buffer;
+		inline constexpr inplace_merge_no_buffer_fn inplace_merge_no_buffer{};
 	}
 
 	struct __inplace_merge_fn : private __niebloid {
@@ -208,7 +208,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __inplace_merge_fn inplace_merge;
+	inline constexpr __inplace_merge_fn inplace_merge{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_heap.hpp
+++ b/include/stl2/detail/algorithm/is_heap.hpp
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_heap_fn is_heap;
+	inline constexpr __is_heap_fn is_heap{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_heap_until.hpp
+++ b/include/stl2/detail/algorithm/is_heap_until.hpp
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __is_heap_until_n_fn is_heap_until_n;
+		inline constexpr __is_heap_until_n_fn is_heap_until_n{};
 	}
 
 	struct __is_heap_until_fn : private __niebloid {
@@ -83,7 +83,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_heap_until_fn is_heap_until;
+	inline constexpr __is_heap_until_fn is_heap_until{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_partitioned.hpp
+++ b/include/stl2/detail/algorithm/is_partitioned.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_partitioned_fn is_partitioned;
+	inline constexpr __is_partitioned_fn is_partitioned{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_permutation.hpp
+++ b/include/stl2/detail/algorithm/is_permutation.hpp
@@ -232,7 +232,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_permutation_fn is_permutation;
+	inline constexpr __is_permutation_fn is_permutation{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_sorted.hpp
+++ b/include/stl2/detail/algorithm/is_sorted.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_sorted_fn is_sorted;
+	inline constexpr __is_sorted_fn is_sorted{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/is_sorted_until.hpp
+++ b/include/stl2/detail/algorithm/is_sorted_until.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __is_sorted_until_fn is_sorted_until;
+	inline constexpr __is_sorted_until_fn is_sorted_until{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/lexicographical_compare.hpp
+++ b/include/stl2/detail/algorithm/lexicographical_compare.hpp
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __lexicographical_compare_fn lexicographical_compare;
+	inline constexpr __lexicographical_compare_fn lexicographical_compare{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/lower_bound.hpp
+++ b/include/stl2/detail/algorithm/lower_bound.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __lower_bound_n_fn lower_bound_n;
+		inline constexpr __lower_bound_n_fn lower_bound_n{};
 	}
 
 	struct __lower_bound_fn : private __niebloid {
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __lower_bound_fn lower_bound;
+	inline constexpr __lower_bound_fn lower_bound{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/make_heap.hpp
+++ b/include/stl2/detail/algorithm/make_heap.hpp
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __make_heap_fn make_heap;
+	inline constexpr __make_heap_fn make_heap{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/max.hpp
+++ b/include/stl2/detail/algorithm/max.hpp
@@ -70,7 +70,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __max_fn max;
+	inline constexpr __max_fn max{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/max_element.hpp
+++ b/include/stl2/detail/algorithm/max_element.hpp
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __max_element_fn max_element;
+	inline constexpr __max_element_fn max_element{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/merge.hpp
+++ b/include/stl2/detail/algorithm/merge.hpp
@@ -72,7 +72,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __merge_fn merge;
+	inline constexpr __merge_fn merge{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/min.hpp
+++ b/include/stl2/detail/algorithm/min.hpp
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __min_fn min;
+	inline constexpr __min_fn min{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/min_element.hpp
+++ b/include/stl2/detail/algorithm/min_element.hpp
@@ -45,7 +45,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __min_element_fn min_element;
+	inline constexpr __min_element_fn min_element{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/minmax.hpp
+++ b/include/stl2/detail/algorithm/minmax.hpp
@@ -106,7 +106,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __minmax_fn minmax;
+	inline constexpr __minmax_fn minmax{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/minmax_element.hpp
+++ b/include/stl2/detail/algorithm/minmax_element.hpp
@@ -69,7 +69,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __minmax_element_fn minmax_element;
+	inline constexpr __minmax_element_fn minmax_element{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/mismatch.hpp
+++ b/include/stl2/detail/algorithm/mismatch.hpp
@@ -59,7 +59,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __mismatch_fn mismatch;
+	inline constexpr __mismatch_fn mismatch{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/move.hpp
+++ b/include/stl2/detail/algorithm/move.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __move_fn move;
+	inline constexpr __move_fn move{};
 
 	namespace ext {
 		struct __move_fn : private __niebloid {
@@ -90,7 +90,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __move_fn move;
+		inline constexpr __move_fn move{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/move_backward.hpp
+++ b/include/stl2/detail/algorithm/move_backward.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __move_backward_fn move_backward;
+	inline constexpr __move_backward_fn move_backward{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/next_permutation.hpp
+++ b/include/stl2/detail/algorithm/next_permutation.hpp
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __next_permutation_fn next_permutation;
+	inline constexpr __next_permutation_fn next_permutation{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/none_of.hpp
+++ b/include/stl2/detail/algorithm/none_of.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __none_of_fn none_of;
+	inline constexpr __none_of_fn none_of{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/nth_element.hpp
+++ b/include/stl2/detail/algorithm/nth_element.hpp
@@ -272,7 +272,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __nth_element_fn nth_element;
+	inline constexpr __nth_element_fn nth_element{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/partial_sort.hpp
+++ b/include/stl2/detail/algorithm/partial_sort.hpp
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __partial_sort_fn partial_sort;
+	inline constexpr __partial_sort_fn partial_sort{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/partial_sort_copy.hpp
+++ b/include/stl2/detail/algorithm/partial_sort_copy.hpp
@@ -73,7 +73,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __partial_sort_copy_fn partial_sort_copy;
+	inline constexpr __partial_sort_copy_fn partial_sort_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/partition.hpp
+++ b/include/stl2/detail/algorithm/partition.hpp
@@ -75,7 +75,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __partition_fn partition;
+	inline constexpr __partition_fn partition{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/partition_copy.hpp
+++ b/include/stl2/detail/algorithm/partition_copy.hpp
@@ -60,7 +60,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __partition_copy_fn partition_copy;
+	inline constexpr __partition_copy_fn partition_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/partition_point.hpp
+++ b/include/stl2/detail/algorithm/partition_point.hpp
@@ -52,7 +52,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __partition_point_n_fn partition_point_n;
+		inline constexpr __partition_point_n_fn partition_point_n{};
 	}
 
 	struct __partition_point_fn : private __niebloid {
@@ -95,7 +95,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __partition_point_fn partition_point;
+	inline constexpr __partition_point_fn partition_point{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/pop_heap.hpp
+++ b/include/stl2/detail/algorithm/pop_heap.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __pop_heap_n_fn pop_heap_n;
+		inline constexpr __pop_heap_n_fn pop_heap_n{};
 	}
 
 	struct __pop_heap_fn : private __niebloid {
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __pop_heap_fn pop_heap;
+	inline constexpr __pop_heap_fn pop_heap{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/prev_permutation.hpp
+++ b/include/stl2/detail/algorithm/prev_permutation.hpp
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __prev_permutation_fn prev_permutation;
+	inline constexpr __prev_permutation_fn prev_permutation{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/push_heap.hpp
+++ b/include/stl2/detail/algorithm/push_heap.hpp
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __push_heap_fn push_heap;
+	inline constexpr __push_heap_fn push_heap{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/remove.hpp
+++ b/include/stl2/detail/algorithm/remove.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __remove_fn remove;
+	inline constexpr __remove_fn remove{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/remove_copy.hpp
+++ b/include/stl2/detail/algorithm/remove_copy.hpp
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __remove_copy_fn remove_copy;
+	inline constexpr __remove_copy_fn remove_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/remove_copy_if.hpp
+++ b/include/stl2/detail/algorithm/remove_copy_if.hpp
@@ -49,7 +49,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __remove_copy_if_fn remove_copy_if;
+	inline constexpr __remove_copy_if_fn remove_copy_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/remove_if.hpp
+++ b/include/stl2/detail/algorithm/remove_if.hpp
@@ -48,7 +48,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __remove_if_fn remove_if;
+	inline constexpr __remove_if_fn remove_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/replace.hpp
+++ b/include/stl2/detail/algorithm/replace.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __replace_fn replace;
+	inline constexpr __replace_fn replace{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/replace_copy.hpp
+++ b/include/stl2/detail/algorithm/replace_copy.hpp
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __replace_copy_fn replace_copy;
+	inline constexpr __replace_copy_fn replace_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/replace_copy_if.hpp
+++ b/include/stl2/detail/algorithm/replace_copy_if.hpp
@@ -56,7 +56,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __replace_copy_if_fn replace_copy_if;
+	inline constexpr __replace_copy_if_fn replace_copy_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/replace_if.hpp
+++ b/include/stl2/detail/algorithm/replace_if.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __replace_if_fn replace_if;
+	inline constexpr __replace_if_fn replace_if{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/reverse.hpp
+++ b/include/stl2/detail/algorithm/reverse.hpp
@@ -46,7 +46,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __reverse_fn reverse;
+	inline constexpr __reverse_fn reverse{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/reverse_copy.hpp
+++ b/include/stl2/detail/algorithm/reverse_copy.hpp
@@ -43,7 +43,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __reverse_copy_fn reverse_copy;
+	inline constexpr __reverse_copy_fn reverse_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/rotate.hpp
+++ b/include/stl2/detail/algorithm/rotate.hpp
@@ -166,7 +166,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __sean_parent_fn rotate;
+	inline constexpr __sean_parent_fn rotate{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/rotate_copy.hpp
+++ b/include/stl2/detail/algorithm/rotate_copy.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __rotate_copy_fn rotate_copy;
+	inline constexpr __rotate_copy_fn rotate_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/sample.hpp
+++ b/include/stl2/detail/algorithm/sample.hpp
@@ -149,7 +149,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __sample_fn sample;
+		inline constexpr __sample_fn sample{};
 	} // namespace ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/algorithm/search.hpp
+++ b/include/stl2/detail/algorithm/search.hpp
@@ -137,7 +137,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __search_fn search;
+	inline constexpr __search_fn search{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/search_n.hpp
+++ b/include/stl2/detail/algorithm/search_n.hpp
@@ -125,7 +125,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __search_n_fn search_n;
+	inline constexpr __search_n_fn search_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/set_difference.hpp
+++ b/include/stl2/detail/algorithm/set_difference.hpp
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __set_difference_fn set_difference;
+	inline constexpr __set_difference_fn set_difference{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/set_intersection.hpp
+++ b/include/stl2/detail/algorithm/set_intersection.hpp
@@ -65,7 +65,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __set_intersection_fn set_intersection;
+	inline constexpr __set_intersection_fn set_intersection{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/set_symmetric_difference.hpp
+++ b/include/stl2/detail/algorithm/set_symmetric_difference.hpp
@@ -85,7 +85,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __set_symmetric_difference_fn set_symmetric_difference;
+	inline constexpr __set_symmetric_difference_fn set_symmetric_difference{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/set_union.hpp
+++ b/include/stl2/detail/algorithm/set_union.hpp
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __set_union set_union;
+	inline constexpr __set_union set_union{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/shuffle.hpp
+++ b/include/stl2/detail/algorithm/shuffle.hpp
@@ -53,7 +53,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __shuffle_fn shuffle;
+	inline constexpr __shuffle_fn shuffle{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/sort.hpp
+++ b/include/stl2/detail/algorithm/sort.hpp
@@ -197,7 +197,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __sort_fn sort;
+	inline constexpr __sort_fn sort{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/sort_heap.hpp
+++ b/include/stl2/detail/algorithm/sort_heap.hpp
@@ -44,7 +44,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __sort_heap_n_fn sort_heap_n;
+		inline constexpr __sort_heap_n_fn sort_heap_n{};
 	} // namespace ext
 
 	struct __sort_heap_fn : private __niebloid {
@@ -68,7 +68,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __sort_heap_fn sort_heap;
+	inline constexpr __sort_heap_fn sort_heap{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/stable_partition.hpp
+++ b/include/stl2/detail/algorithm/stable_partition.hpp
@@ -271,7 +271,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __stable_partition_n_fn stable_partition_n;
+		inline constexpr __stable_partition_n_fn stable_partition_n{};
 	} // namespace ext
 
 	struct __stable_partition_fn : private __niebloid {
@@ -309,7 +309,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __stable_partition_fn stable_partition;
+	inline constexpr __stable_partition_fn stable_partition{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/stable_sort.hpp
+++ b/include/stl2/detail/algorithm/stable_sort.hpp
@@ -166,7 +166,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __stable_sort_fn stable_sort;
+	inline constexpr __stable_sort_fn stable_sort{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/swap_ranges.hpp
+++ b/include/stl2/detail/algorithm/swap_ranges.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __swap_ranges3_fn __swap_ranges3;
+	inline constexpr __swap_ranges3_fn __swap_ranges3{};
 
 	struct __swap_ranges_fn : private __niebloid {
 		template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
@@ -61,7 +61,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __swap_ranges_fn swap_ranges;
+	inline constexpr __swap_ranges_fn swap_ranges{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/transform.hpp
+++ b/include/stl2/detail/algorithm/transform.hpp
@@ -80,7 +80,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __transform_fn transform;
+	inline constexpr __transform_fn transform{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/unique.hpp
+++ b/include/stl2/detail/algorithm/unique.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __unique_fn unique;
+	inline constexpr __unique_fn unique{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/unique_copy.hpp
+++ b/include/stl2/detail/algorithm/unique_copy.hpp
@@ -93,7 +93,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __unique_copy_fn unique_copy;
+	inline constexpr __unique_copy_fn unique_copy{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/algorithm/upper_bound.hpp
+++ b/include/stl2/detail/algorithm/upper_bound.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __upper_bound_n_fn upper_bound_n;
+		inline constexpr __upper_bound_n_fn upper_bound_n{};
 	}
 
 	struct __upper_bound_fn : private __niebloid {
@@ -74,7 +74,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __upper_bound_fn upper_bound;
+	inline constexpr __upper_bound_fn upper_bound{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/construct_destruct.hpp
+++ b/include/stl2/detail/construct_destruct.hpp
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr destruct_fn destruct;
+		inline constexpr destruct_fn destruct{};
 
 		struct construct_fn {
 			template<class T, class... Args>
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr construct_fn construct;
+		inline constexpr construct_fn construct{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/fwd.hpp
+++ b/include/stl2/detail/fwd.hpp
@@ -279,7 +279,7 @@ STL2_OPEN_NAMESPACE {
 		struct priority_tag : priority_tag<N - 1> {};
 		template<>
 		struct priority_tag<0> {};
-		inline constexpr priority_tag<4> max_priority_tag;
+		inline constexpr priority_tag<4> max_priority_tag{};
 	}
 
 	struct __niebloid {

--- a/include/stl2/detail/iterator/basic_iterator.hpp
+++ b/include/stl2/detail/iterator/basic_iterator.hpp
@@ -616,7 +616,7 @@ STL2_OPEN_NAMESPACE {
 			static_cast<BI&&>(i).get()
 		)
 	};
-	inline constexpr __get_cursor_fn get_cursor;
+	inline constexpr __get_cursor_fn get_cursor{};
 
 	namespace basic_iterator_adl {
 		struct hook {};

--- a/include/stl2/detail/iterator/concepts.hpp
+++ b/include/stl2/detail/iterator/concepts.hpp
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __iter_move::fn iter_move;
+		inline constexpr __iter_move::fn iter_move{};
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -288,7 +288,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __iter_swap::fn iter_swap;
+		inline constexpr __iter_swap::fn iter_swap{};
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/include/stl2/detail/iterator/default_sentinel.hpp
+++ b/include/stl2/detail/iterator/default_sentinel.hpp
@@ -17,7 +17,7 @@
 STL2_OPEN_NAMESPACE {
 	struct default_sentinel_t {};
 
-	inline constexpr default_sentinel_t default_sentinel;
+	inline constexpr default_sentinel_t default_sentinel{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/iterator/operations.hpp
+++ b/include/stl2/detail/iterator/operations.hpp
@@ -103,7 +103,7 @@ STL2_OPEN_NAMESPACE {
 		operator()(counted_iterator<I>& i, iter_difference_t<I> n) const;
 	};
 
-	inline constexpr __advance_fn advance;
+	inline constexpr __advance_fn advance{};
 
 	// next
 	struct __next_fn : private __niebloid {
@@ -131,7 +131,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __next_fn next;
+	inline constexpr __next_fn next{};
 
 	// prev
 	struct __prev_fn : private __niebloid {
@@ -153,7 +153,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __prev_fn prev;
+	inline constexpr __prev_fn prev{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/iterator/unreachable.hpp
+++ b/include/stl2/detail/iterator/unreachable.hpp
@@ -40,7 +40,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr unreachable_sentinel_t unreachable_sentinel;
+	inline constexpr unreachable_sentinel_t unreachable_sentinel{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/memory/destroy.hpp
+++ b/include/stl2/detail/memory/destroy.hpp
@@ -31,7 +31,7 @@ STL2_OPEN_NAMESPACE {
 		void operator()(T* p) const noexcept;
 	};
 
-	inline constexpr __destroy_at_fn destroy_at;
+	inline constexpr __destroy_at_fn destroy_at{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// destroy [specialized.destroy]
@@ -63,7 +63,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __destroy_fn destroy;
+	inline constexpr __destroy_fn destroy{};
 
 	template<destructible T>
 	inline void __destroy_at_fn::operator()(T* p) const noexcept {
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __destroy_n_fn destroy_n;
+	inline constexpr __destroy_n_fn destroy_n{};
 
 	namespace detail {
 		template<_NoThrowForwardIterator I>

--- a/include/stl2/detail/memory/uninitialized_copy.hpp
+++ b/include/stl2/detail/memory/uninitialized_copy.hpp
@@ -47,7 +47,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_copy_fn uninitialized_copy;
+	inline constexpr __uninitialized_copy_fn uninitialized_copy{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// uninitialized_copy_n [uninitialized.copy]
@@ -67,7 +67,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_copy_n_fn uninitialized_copy_n;
+	inline constexpr __uninitialized_copy_n_fn uninitialized_copy_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_DETAIL_MEMORY_UNINITIALIZED_COPY_HPP

--- a/include/stl2/detail/memory/uninitialized_default_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_default_construct.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_default_construct_fn uninitialized_default_construct;
+	inline constexpr __uninitialized_default_construct_fn uninitialized_default_construct{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// uninitialized_default_construct_n [Extension]
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_default_construct_n_fn uninitialized_default_construct_n;
+	inline constexpr __uninitialized_default_construct_n_fn uninitialized_default_construct_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_DETAIL_MEMORY_UNINITIALIZED_DEFAULT_CONSTRUCT_HPP

--- a/include/stl2/detail/memory/uninitialized_fill.hpp
+++ b/include/stl2/detail/memory/uninitialized_fill.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_fill_fn uninitialized_fill;
+	inline constexpr __uninitialized_fill_fn uninitialized_fill{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// uninitialized_fill_n [uninitialized.fill]
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_fill_n_fn uninitialized_fill_n;
+	inline constexpr __uninitialized_fill_n_fn uninitialized_fill_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_DETAIL_MEMORY_UNINITIALIZED_FILL_HPP

--- a/include/stl2/detail/memory/uninitialized_move.hpp
+++ b/include/stl2/detail/memory/uninitialized_move.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_move_fn uninitialized_move;
+	inline constexpr __uninitialized_move_fn uninitialized_move{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// uninitialized_move_n [uninitialized.move]
@@ -69,7 +69,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_move_n_fn uninitialized_move_n;
+	inline constexpr __uninitialized_move_n_fn uninitialized_move_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_DETAIL_MEMORY_UNINITIALIZED_MOVE_HPP

--- a/include/stl2/detail/memory/uninitialized_value_construct.hpp
+++ b/include/stl2/detail/memory/uninitialized_value_construct.hpp
@@ -42,7 +42,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_value_construct_fn uninitialized_value_construct;
+	inline constexpr __uninitialized_value_construct_fn uninitialized_value_construct{};
 
 	///////////////////////////////////////////////////////////////////////////
 	// uninitialized_value_construct_n [uninitialized.construct.value]
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __uninitialized_value_construct_n_fn uninitialized_value_construct_n;
+	inline constexpr __uninitialized_value_construct_n_fn uninitialized_value_construct_n{};
 } STL2_CLOSE_NAMESPACE
 
 #endif // STL2_DETAIL_MEMORY_UNINITIALIZED_VALUE_CONSTRUCT_HPP

--- a/include/stl2/detail/range/access.hpp
+++ b/include/stl2/detail/range/access.hpp
@@ -35,7 +35,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr const T&& operator()(T&& t) const noexcept {
 			return (T&&)t;
 		}
-	} __as_const {};
+	} __as_const{};
 
 	// begin
 	namespace __begin {
@@ -96,7 +96,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __begin::__fn begin;
+		inline constexpr __begin::__fn begin{};
 	}
 
 	template<class R>
@@ -162,7 +162,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __end::__fn end;
+		inline constexpr __end::__fn end{};
 	}
 
 	template<class R>
@@ -177,7 +177,7 @@ STL2_OPEN_NAMESPACE {
 		)
 	};
 	inline namespace __cpos {
-		inline constexpr __cbegin_fn cbegin;
+		inline constexpr __cbegin_fn cbegin{};
 	}
 
 	// cend
@@ -189,7 +189,7 @@ STL2_OPEN_NAMESPACE {
 		)
 	};
 	inline namespace __cpos {
-		inline constexpr __cend_fn cend;
+		inline constexpr __cend_fn cend{};
 	}
 
 	// rbegin
@@ -250,7 +250,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __rbegin::__fn rbegin;
+		inline constexpr __rbegin::__fn rbegin{};
 	}
 
 	template<class T>
@@ -305,7 +305,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __rend::__fn rend;
+		inline constexpr __rend::__fn rend{};
 	}
 
 	template<class T>
@@ -320,7 +320,7 @@ STL2_OPEN_NAMESPACE {
 		)
 	};
 	inline namespace __cpos {
-		inline constexpr __crbegin_fn crbegin;
+		inline constexpr __crbegin_fn crbegin{};
 	}
 
 	// crend
@@ -332,7 +332,7 @@ STL2_OPEN_NAMESPACE {
 		)
 	};
 	inline namespace __cpos {
-		inline constexpr __crend_fn crend;
+		inline constexpr __crend_fn crend{};
 	}
 
 	// disable_sized_range [range.sized]
@@ -406,7 +406,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __size::__fn size;
+		inline constexpr __size::__fn size{};
 	}
 
 	// empty
@@ -458,7 +458,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __empty::__fn empty;
+		inline constexpr __empty::__fn empty{};
 	}
 
 	// data
@@ -526,7 +526,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __data::__fn data;
+		inline constexpr __data::__fn data{};
 	}
 
 	// cdata
@@ -538,7 +538,7 @@ STL2_OPEN_NAMESPACE {
 		)
 	};
 	inline namespace __cpos {
-		inline constexpr __cdata_fn cdata;
+		inline constexpr __cdata_fn cdata{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/range/nth_iterator.hpp
+++ b/include/stl2/detail/range/nth_iterator.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __nth_iterator nth_iterator;
+		inline constexpr __nth_iterator nth_iterator{};
 	} // namespace ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/detail/range/primitives.hpp
+++ b/include/stl2/detail/range/primitives.hpp
@@ -77,7 +77,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __enumerate_fn enumerate;
+		inline constexpr __enumerate_fn enumerate{};
 	}
 
 	struct __distance_fn : private __niebloid {
@@ -111,7 +111,7 @@ STL2_OPEN_NAMESPACE {
 		}
 	};
 
-	inline constexpr __distance_fn distance;
+	inline constexpr __distance_fn distance{};
 } STL2_CLOSE_NAMESPACE
 
 #endif

--- a/include/stl2/detail/swap.hpp
+++ b/include/stl2/detail/swap.hpp
@@ -108,7 +108,7 @@ STL2_OPEN_NAMESPACE {
 		};
 	}
 	inline namespace __cpos {
-		inline constexpr __swap::fn swap;
+		inline constexpr __swap::fn swap{};
 	}
 
 	///////////////////////////////////////////////////////////////////////////

--- a/include/stl2/view/all.hpp
+++ b/include/stl2/view/all.hpp
@@ -50,7 +50,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __all_fn all;
+		inline constexpr __all_fn all{};
 	} // namespace views
 
 	template<viewable_range R>

--- a/include/stl2/view/common.hpp
+++ b/include/stl2/view/common.hpp
@@ -86,7 +86,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __common_fn common;
+		inline constexpr __common_fn common{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/counted.hpp
+++ b/include/stl2/view/counted.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __counted_fn counted;
+		inline constexpr __counted_fn counted{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/drop.hpp
+++ b/include/stl2/view/drop.hpp
@@ -53,8 +53,8 @@ STL2_OPEN_NAMESPACE {
 		constexpr auto size() requires (!ext::simple_view<R> && sized_range<R>) { return size_impl(*this); }
 		constexpr auto size() const requires sized_range<const R> { return size_impl(*this); }
 	private:
-		R base_;
-		D count_;
+		R base_{};
+		D count_ = 0;
 
 		template<class X>
 		static constexpr auto begin_impl(X& x) {
@@ -102,7 +102,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __drop_fn drop;
+		inline constexpr __drop_fn drop{};
 	} // mamespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/drop_while.hpp
+++ b/include/stl2/view/drop_while.hpp
@@ -64,7 +64,7 @@ STL2_OPEN_NAMESPACE {
 
 			constexpr auto end() { return __stl2::end(base_); }
 		private:
-			R base_;
+			R base_{};
 		};
 
 		template<class R, class Pred>
@@ -84,7 +84,7 @@ STL2_OPEN_NAMESPACE {
 			{ return detail::view_closure{*this, std::move(pred)}; }
 		};
 
-		inline constexpr __drop_while_fn drop_while;
+		inline constexpr __drop_while_fn drop_while{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/empty.hpp
+++ b/include/stl2/view/empty.hpp
@@ -30,7 +30,7 @@ STL2_OPEN_NAMESPACE {
 
 	namespace views {
 		template<class T>
-		inline constexpr empty_view<T> empty;
+		inline constexpr empty_view<T> empty{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/filter.hpp
+++ b/include/stl2/view/filter.hpp
@@ -67,7 +67,7 @@ STL2_OPEN_NAMESPACE {
 	requires view<V>
 	class filter_view<V, Pred>::__iterator {
 	private:
-		iterator_t<V> current_ {};
+		iterator_t<V> current_{};
 		filter_view* parent_ = nullptr;
 		friend __sentinel;
 	public:
@@ -196,7 +196,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __filter_fn filter;
+		inline constexpr __filter_fn filter{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/generate.hpp
+++ b/include/stl2/view/generate.hpp
@@ -118,7 +118,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __generate_fn generate;
+		inline constexpr __generate_fn generate{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/indirect.hpp
+++ b/include/stl2/view/indirect.hpp
@@ -122,7 +122,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __indirect_fn indirect;
+		inline constexpr __indirect_fn indirect{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/iota.hpp
+++ b/include/stl2/view/iota.hpp
@@ -69,8 +69,8 @@ STL2_OPEN_NAMESPACE {
 		struct __iterator;
 		struct __sentinel;
 
-		I value_ {};
-		Bound bound_ {};
+		I value_{};
+		Bound bound_{};
 	public:
 		iota_view() = default;
 		/// \pre: `Bound{}` is reachable from `value`
@@ -193,7 +193,7 @@ STL2_OPEN_NAMESPACE {
 		{ return *x - *y; }
 
 	private:
-		I value_ {};
+		I value_{};
 	};
 
 	template<weakly_incrementable I, semiregular Bound>
@@ -236,7 +236,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __iota_fn iota;
+		inline constexpr __iota_fn iota{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/istream.hpp
+++ b/include/stl2/view/istream.hpp
@@ -97,7 +97,7 @@ STL2_OPEN_NAMESPACE {
 		};
 
 		template<class Val>
-		inline constexpr __istream_fn<Val> istream;
+		inline constexpr __istream_fn<Val> istream{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/join.hpp
+++ b/include/stl2/view/join.hpp
@@ -292,7 +292,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __join_fn join;
+		inline constexpr __join_fn join{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/move.hpp
+++ b/include/stl2/view/move.hpp
@@ -87,7 +87,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __move_fn move;
+		inline constexpr __move_fn move{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/ref.hpp
+++ b/include/stl2/view/ref.hpp
@@ -94,7 +94,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __ref_fn ref;
+		inline constexpr __ref_fn ref{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/repeat.hpp
+++ b/include/stl2/view/repeat.hpp
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __repeat_fn repeat;
+		inline constexpr __repeat_fn repeat{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/repeat_n.hpp
+++ b/include/stl2/view/repeat_n.hpp
@@ -37,7 +37,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __repeat_n_fn repeat_n;
+		inline constexpr __repeat_n_fn repeat_n{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/reverse.hpp
+++ b/include/stl2/view/reverse.hpp
@@ -105,7 +105,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __reverse_fn reverse;
+		inline constexpr __reverse_fn reverse{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/single.hpp
+++ b/include/stl2/view/single.hpp
@@ -57,7 +57,7 @@ STL2_OPEN_NAMESPACE {
 			)
 		};
 
-		inline constexpr __single_fn single;
+		inline constexpr __single_fn single{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/split.hpp
+++ b/include/stl2/view/split.hpp
@@ -34,7 +34,7 @@ STL2_OPEN_NAMESPACE {
 
 	template<input_range Rng>
 	struct __split_view_base {
-		iterator_t<Rng> current_ {};
+		iterator_t<Rng> current_{};
 	};
 	template<forward_range Rng>
 	struct __split_view_base<Rng> {};
@@ -48,8 +48,8 @@ STL2_OPEN_NAMESPACE {
 		template<bool Const> struct __outer_iterator;
 		template<bool Const> struct __inner_iterator;
 
-		Rng base_ {};
-		Pattern pattern_ {};
+		Rng base_{};
+		Pattern pattern_{};
 	public:
 		split_view() = default;
 		constexpr split_view(Rng base, Pattern pattern)
@@ -99,7 +99,7 @@ STL2_OPEN_NAMESPACE {
 	struct __split_view_outer_base {};
 	template<forward_range Rng, bool Const>
 	struct __split_view_outer_base<Rng, Const> {
-		iterator_t<__maybe_const<Const, Rng>> current_ {};
+		iterator_t<__maybe_const<Const, Rng>> current_{};
 	};
 
 	template<input_range Rng, forward_range Pattern>
@@ -213,7 +213,7 @@ STL2_OPEN_NAMESPACE {
 	template<bool Const>
 	struct split_view<Rng, Pattern>::__outer_iterator<Const>::value_type {
 	private:
-		__outer_iterator i_ {};
+		__outer_iterator i_{};
 	public:
 		value_type() = default;
 		constexpr explicit value_type(__outer_iterator i)
@@ -237,7 +237,7 @@ STL2_OPEN_NAMESPACE {
 
 		static_assert(forward_range<Rng> || !Const);
 
-		__outer_iterator<Const> i_ {};
+		__outer_iterator<Const> i_{};
 		bool zero_ = false;
 
 		constexpr bool at_end() const {
@@ -325,7 +325,7 @@ STL2_OPEN_NAMESPACE {
 			{ return detail::view_closure{*this, std::forward<T>(t)}; }
 		};
 
-		inline constexpr __split_fn split;
+		inline constexpr __split_fn split{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/take.hpp
+++ b/include/stl2/view/take.hpp
@@ -29,8 +29,8 @@ STL2_OPEN_NAMESPACE {
 		template<bool> struct __sentinel;
 		using D = iter_difference_t<iterator_t<R>>;
 
-		R base_ {};
-		D count_ {};
+		R base_{};
+		D count_{};
 
 		template<class Self>
 		static constexpr auto begin_(Self& self) {
@@ -92,7 +92,7 @@ STL2_OPEN_NAMESPACE {
 		using Base = __maybe_const<Const, R>;
 		using CI = counted_iterator<iterator_t<Base>>;
 
-		sentinel_t<Base> end_ {};
+		sentinel_t<Base> end_{};
 	public:
 		__sentinel() = default;
 
@@ -125,7 +125,7 @@ STL2_OPEN_NAMESPACE {
 			{ return detail::view_closure{*this, static_cast<D>(count)}; }
 		};
 
-		inline constexpr __take_fn take;
+		inline constexpr __take_fn take{};
 	}
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/take_exactly.hpp
+++ b/include/stl2/view/take_exactly.hpp
@@ -36,7 +36,7 @@ STL2_OPEN_NAMESPACE {
 			using base_t = detail::ebo_box<Base, take_exactly_view<Base>>;
 			using base_t::get;
 
-			iter_difference_t<iterator_t<Base>> n_;
+			iter_difference_t<iterator_t<Base>> n_ = 0;
 		public:
 			take_exactly_view() = default;
 
@@ -118,7 +118,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __take_exactly_fn take_exactly;
+		inline constexpr __take_exactly_fn take_exactly{};
 	} // namespace views::ext
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/take_while.hpp
+++ b/include/stl2/view/take_while.hpp
@@ -51,7 +51,7 @@ STL2_OPEN_NAMESPACE {
 		constexpr auto end() const requires range<const R>
 		{ return end_impl(*this); }
 	private:
-		R base_;
+		R base_{};
 
 		template<class Self>
 		static constexpr auto begin_impl(Self& self) { return __stl2::begin(self.base_); }
@@ -73,8 +73,8 @@ STL2_OPEN_NAMESPACE {
 	class take_while_view<R, Pred>::__sentinel {
 		friend __sentinel<false>;
 		using Base = __maybe_const<Const, R>;
-		sentinel_t<Base> end_ {};
-		const Pred* pred_;
+		sentinel_t<Base> end_{};
+		const Pred* pred_ = nullptr;
 	public:
 		__sentinel() = default;
 
@@ -107,7 +107,7 @@ STL2_OPEN_NAMESPACE {
 			{ return detail::view_closure{*this, std::move(pred)}; }
 		};
 
-		inline constexpr __take_while_fn take_while;
+		inline constexpr __take_while_fn take_while{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 

--- a/include/stl2/view/transform.hpp
+++ b/include/stl2/view/transform.hpp
@@ -93,7 +93,7 @@ STL2_OPEN_NAMESPACE {
 	private:
 		using Parent = __maybe_const<Const, transform_view>;
 		using Base = __maybe_const<Const, V>;
-		iterator_t<Base> current_ {};
+		iterator_t<Base> current_{};
 		Parent* parent_ = nullptr;
 		friend __iterator<!Const>;
 		friend __sentinel<Const>;
@@ -223,7 +223,7 @@ STL2_OPEN_NAMESPACE {
 	private:
 		using Parent = __maybe_const<Const, transform_view>;
 		using Base = __maybe_const<Const, V>;
-		sentinel_t<Base> end_ {};
+		sentinel_t<Base> end_{};
 		friend __sentinel<!Const>;
 
 		constexpr bool equal(const __iterator<Const>& i) const {
@@ -282,7 +282,7 @@ STL2_OPEN_NAMESPACE {
 			}
 		};
 
-		inline constexpr __transform_fn transform;
+		inline constexpr __transform_fn transform{};
 	} // namespace views
 } STL2_CLOSE_NAMESPACE
 


### PR DESCRIPTION
[dcl.constexpr]/10 suggests that even const-default-constructible constexpr objects must have an initializer.